### PR TITLE
Prevent crash in audio_backend/alsa.rs when switching from Kodi audio…

### DIFF
--- a/src/audio_backend/alsa.rs
+++ b/src/audio_backend/alsa.rs
@@ -18,10 +18,17 @@ impl Sink for AlsaSink {
     fn start(&mut self) -> io::Result<()> {
         if self.0.is_some() {
         } else {
-            self.0 = Some(PCM::open(&*self.1,
+            match PCM::open(&*self.1,
                                     Stream::Playback, Mode::Blocking,
                                     Format::Signed16, Access::Interleaved,
-                                    2, 44100).ok().unwrap());
+                                    2, 44100) {
+                Ok(f) => self.0 = Some(f),
+                Err(e) => {
+                    self.0 = None; 
+                    error!("Alsa error PCM open {}", e); 
+                    return Err(io::Error::new(io::ErrorKind::Other, "Alsa error: PCM open failed"));
+                }
+            }
         }
         Ok(())
     }

--- a/src/audio_backend/alsa.rs
+++ b/src/audio_backend/alsa.rs
@@ -16,15 +16,13 @@ impl Open for AlsaSink {
 
 impl Sink for AlsaSink {
     fn start(&mut self) -> io::Result<()> {
-        if self.0.is_some() {
-        } else {
+        if self.0.is_none() {
             match PCM::open(&*self.1,
                                     Stream::Playback, Mode::Blocking,
                                     Format::Signed16, Access::Interleaved,
                                     2, 44100) {
                 Ok(f) => self.0 = Some(f),
                 Err(e) => {
-                    self.0 = None; 
                     error!("Alsa error PCM open {}", e); 
                     return Err(io::Error::new(io::ErrorKind::Other, "Alsa error: PCM open failed"));
                 }


### PR DESCRIPTION
… to librespot
This is just to prevent the crash. Causes start play to keep silent. After another pause and play of the user, the music starts..