### PR TITLE
use dns-sd instead of mdns for discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "dns-sd"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "dtoa"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -283,7 +292,7 @@ dependencies = [
  "librespot-metadata 0.1.0",
  "librespot-protocol 0.1.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "mdns 0.2.0 (git+https://github.com/plietar/rust-mdns)",
+ "dns-sd 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "num-bigint 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "portaudio-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 1.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -394,23 +403,6 @@ dependencies = [
 name = "matches"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "mdns"
-version = "0.2.0"
-source = "git+https://github.com/plietar/rust-mdns#c0fc73502d7d752a4ffeb5268a017561405e218c"
-dependencies = [
- "byteorder 1.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "dns-parser 0.3.2 (git+https://github.com/plietar/dns-parser)",
- "futures 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
- "multimap 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "net2 0.2.31 (registry+https://github.com/rust-lang/crates.io-index)",
- "nix 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rand 0.3.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-core 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "memchr"
@@ -1134,7 +1126,6 @@ dependencies = [
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 "checksum log 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)" = "89f010e843f2b1a31dbd316b3b8d443758bc634bed37aabade59c686d644e0a2"
 "checksum matches 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "100aabe6b8ff4e4a7e32c1c13523379802df0772b82466207ac25b013f193376"
-"checksum mdns 0.2.0 (git+https://github.com/plietar/rust-mdns)" = "<none>"
 "checksum memchr 2.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "796fba70e76612589ed2ce7f45282f5af869e0fdd7cc6199fa1aa1f1d591ba9d"
 "checksum mime 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e2e00e17be181010a91dbfefb01660b17311059dc8c7f48b9017677721e732bd"
 "checksum mio 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "75f72a93f046f1517e3cfddc0a096eb756a2ba727d36edc8227dee769a50a9b0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ futures = "0.1.8"
 getopts = "0.2.14"
 hyper = "0.11.2"
 log = "0.3.5"
-mdns = { git = "https://github.com/plietar/rust-mdns" }
+dns-sd = "0.1.3"
 num-bigint = "0.1.35"
 protobuf = "1.1"
 rand = "0.3.13"

--- a/src/discovery.rs
+++ b/src/discovery.rs
@@ -6,7 +6,7 @@ use futures::sync::mpsc;
 use futures::{Future, Stream, Poll};
 use hyper::server::{Service, Request, Response, Http};
 use hyper::{self, Get, Post, StatusCode};
-use mdns;
+use dns_sd::DNSService;
 use num_bigint::BigUint;
 use rand;
 use std::collections::BTreeMap;
@@ -191,7 +191,7 @@ impl Service for Discovery {
 
 pub struct DiscoveryStream {
     credentials: mpsc::UnboundedReceiver<Credentials>,
-    _svc: mdns::Service,
+    _svc: DNSService,
 }
 
 pub fn discovery(handle: &Handle, config: ConnectConfig, device_id: String)
@@ -203,7 +203,7 @@ pub fn discovery(handle: &Handle, config: ConnectConfig, device_id: String)
         let http = Http::new();
         http.serve_addr_handle(&"0.0.0.0:0".parse().unwrap(), &handle, move || Ok(discovery.clone())).unwrap()
     };
-    let addr = serve.incoming_ref().local_addr();
+    let port = serve.incoming_ref().local_addr().port();
     let server_future = {
         let handle = handle.clone();
         serve.for_each(move |connection| {
@@ -214,12 +214,13 @@ pub fn discovery(handle: &Handle, config: ConnectConfig, device_id: String)
     };
     handle.spawn(server_future);
 
-    let responder = mdns::Responder::spawn(&handle)?;
-    let svc = responder.register(
-        "_spotify-connect._tcp".to_owned(),
-        config.name,
-        addr.port(),
-        &["VERSION=1.0", "CPath=/"]);
+    let svc = DNSService::register(Some(&*config.name),
+                                   "_spotify-connect._tcp",
+                                   None,
+                                   None,
+                                   port,
+                                   &["VERSION=1.0", "CPath=/"])
+                      .unwrap();
 
     Ok(DiscoveryStream {
         credentials: creds_rx,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ extern crate base64;
 extern crate crypto;
 extern crate futures;
 extern crate hyper;
-extern crate mdns;
+extern crate dns_sd;
 extern crate num_bigint;
 extern crate protobuf;
 extern crate rand;


### PR DESCRIPTION
Congratulations for this repository and for the improvements it brings to Librespot.

I maintain the Librespot addon for LibreELEC. Librespot requires some modifications to adapt to LibreELEC. At the moment I use patches to modify Librespot, but patches are tedious to maintain. I would therefore be happy if these patches could be merged upstream. My pacthes are however too brutal to be merged as such. But my control of Rust is not good enough to propose something else.

I therefore need your help to adapt my patches.
Thank you in advance for your help.

This is the first of my three patches: use dns-sd instead of mdns.