### PR TITLE
Proposed update to Readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,9 @@ If there is a feature request that is being considered, or has been widely reque
 
 [ ] Document the Spotify Protocol and provide reference example.
 [ ] Implement API to allow wrappers to be written for librespot.
-[ ] Logarithmic volume scaling
+[ ] Logarithmic volume scaling (#10)
 [ ] Provide automatic release binaries for download
+[ ] Provide an adequate method for exporting metadata (#7)
 
 ## Disclaimer
 Using this code to connect to Spotify's API is probably forbidden by them.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ which are not available in the official library.
 Note: librespot only works with Spotify Premium
 
 ## This fork
-As the origin by [plietar](https://github.com/plietar/) is no longer actively maintained I wanted to have a place for a version of librespot with other peoples forks and features merged.
+As the origin by [plietar](https://github.com/plietar/) is no longer actively maintained, this organisation and repository have been set up so that the project may be maintained and upgraded in the future.
 
 # Wiki
 More information can be found in the [wiki](https://github.com/librespot-org/librespot/wiki)
@@ -17,7 +17,7 @@ More information can be found in the [wiki](https://github.com/librespot-org/lib
 # Building
 Rust 1.18.0 or later is required to build librespot.
 
-**If you are building librespot on macOS, the homebrew provided rust may fail due to the way in which homebrew installs rust. In this case, uninstall the homebrew version of rust and use [rustup](https://www.rustup.rs/), and librespot should then build.**
+**If you are building librespot on macOS, the homebrew provided rust may fail due to the way in which homebrew installs rust. In this case, uninstall the homebrew version of rust and use [rustup](https://www.rustup.rs/), and librespot should then build. This should have been fixed in more recent versions of Homebrew, but we're leaving this notice here as a warning.**
 
 It also requires a C, with portaudio.
 
@@ -48,13 +48,21 @@ Once you've built *librespot*, run it using :
 target/release/librespot --name DEVICENAME 
 ```
 
-## Disclaimer
-Using this code to connect to Spotify's API is probably forbidden by them.
-Use at your own risk.
-
 ## Contact
 Come and hang out on gitter if you need help or want to offer some.
 https://gitter.im/sashahilton00/spotify-connect-resources
+
+## To-Do/Feature Requests
+If there is a feature request that is being considered, or has been widely requested, it should be listed below. Please do not use this for bug reports or special use case feature requests.
+
+[ ] Document the Spotify Protocol and provide reference example.
+[ ] Implement API to allow wrappers to be written for librespot.
+[ ] Logarithmic volume scaling
+[ ] Provide automatic release binaries for download
+
+## Disclaimer
+Using this code to connect to Spotify's API is probably forbidden by them.
+Use at your own risk.
 
 ## License
 Everything in this repository is licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ https://gitter.im/sashahilton00/spotify-connect-resources
 ## To-Do/Feature Requests
 If there is a feature request that is being considered, or has been widely requested, it should be listed below. Please do not use this for bug reports or special use case feature requests.
 
-[ ] Document the Spotify Protocol and provide reference example.
-[ ] Implement API to allow wrappers to be written for librespot.
-[ ] Logarithmic volume scaling (#10)
-[ ] Provide automatic release binaries for download
-[ ] Provide an adequate method for exporting metadata (#7)
+- [ ] Document the Spotify Protocol and provide reference example.
+- [ ] Implement API to allow wrappers to be written for librespot.
+- [ ] Logarithmic volume scaling (#10)
+- [ ] Provide automatic release binaries for download
+- [ ] Provide an adequate method for exporting metadata (#7)
+  - [ ] Provide API Documentation
+  - [ ] Provide Schema/Versioning
 
 ## Disclaimer
 Using this code to connect to Spotify's API is probably forbidden by them.


### PR DESCRIPTION
This is just a simple update to the readme to reflect this repo's intention as the replacement repo for plietar/librespot, and adds a to-do list for feature requests/problems that need resolving.