### PR TITLE
Add CLIENT_ID env var for compiling with a client id

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,6 @@
 
 #[macro_use] extern crate log;
 #[macro_use] extern crate serde_json;
-#[macro_use] extern crate serde_derive;
 
 extern crate base64;
 extern crate crypto;


### PR DESCRIPTION
Add CLIENT_ID env var for compiling with a client id, remove unnecessary serde_derive. If you can think of a better way than a double match statement, happy to improve this...