### PR TITLE
Implement [Replace] for rust-crypto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ num-bigint = "0.1.35"
 protobuf = "1.1"
 rand = "0.3.13"
 rpassword = "0.3.0"
-rust-crypto = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
+rust-crypto = "0.2.36"
 serde = "0.9.6"
 serde_derive = "0.9.6"
 serde_json = "0.9.5"
@@ -56,6 +56,9 @@ url = "1.3"
 rand            = "0.3.13"
 vergen          = "0.1.0"
 protobuf_macros = { git = "https://github.com/plietar/rust-protobuf-macros", features = ["with-syntex"] }
+
+[replace]
+"rust-crypto:0.2.36" = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
 
 [features]
 alsa-backend = ["librespot-playback/alsa-backend"]

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -14,7 +14,7 @@ lewton = "0.8.0"
 log = "0.3.5"
 num-bigint = "0.1.35"
 num-traits = "0.1.36"
-rust-crypto = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
+rust-crypto = "0.2.36"
 tempfile = "2.1"
 
 tremor = { git = "https://github.com/plietar/rust-tremor", optional = true }

--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -19,7 +19,7 @@ log = "0.3.5"
 num-bigint = "0.1.35"
 protobuf = "1.1"
 rand = "0.3.13"
-rust-crypto = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
+rust-crypto = "0.2.36"
 serde = "0.9.6"
 serde_derive = "0.9.6"
 serde_json = "0.9.5"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -22,7 +22,7 @@ num-traits = "0.1.36"
 protobuf = "1.1"
 rand = "0.3.13"
 rpassword = "0.3.0"
-rust-crypto = { git = "https://github.com/awmath/rust-crypto.git", branch = "avx2" }
+rust-crypto = "0.2.36"
 serde = "0.9.6"
 serde_derive = "0.9.6"
 serde_json = "0.9.5"


### PR DESCRIPTION
Option 5 from #128, usea  replace tag to switch to avx2 branch from [awmath/rust-crypto](https://github.com/awmath/rust-crypto/tree/avx2)