### PR TITLE
travis: Use `cargo --locked` everywhere

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,13 +26,13 @@ before_script:
       fi
 
 script:
-    - cargo build --no-default-features
-    - cargo build --no-default-features --features "with-tremor"
-    - cargo build --no-default-features --features "with-vorbis"
-    - cargo build --no-default-features --features "portaudio-backend"
-    - cargo build --no-default-features --features "pulseaudio-backend"
-    - cargo build --no-default-features --features "alsa-backend"
-    - cargo build --no-default-features --target armv7-unknown-linux-gnueabihf
+    - cargo build --locked --no-default-features
+    - cargo build --locked --no-default-features --features "with-tremor"
+    - cargo build --locked --no-default-features --features "with-vorbis"
+    - cargo build --locked --no-default-features --features "portaudio-backend"
+    - cargo build --locked --no-default-features --features "pulseaudio-backend"
+    - cargo build --locked --no-default-features --features "alsa-backend"
+    - cargo build --locked --no-default-features --target armv7-unknown-linux-gnueabihf
 
 notifications:
   email: false


### PR DESCRIPTION
This will prevent `Cargo.lock` from getting out of sync