### PR TITLE
Include updating context_uri along with tracks and current index

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -633,6 +633,8 @@ impl SpircTask {
         self.state.set_playing_track_index(index);
         self.state.set_track(tracks.into_iter().cloned().collect());
         self.state.set_context_uri(context_uri);
+        self.state.set_repeat(frame.get_state().get_repeat());
+        self.state.set_shuffle(frame.get_state().get_shuffle());
     }
 
     fn load_track(&mut self, play: bool) {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -628,9 +628,11 @@ impl SpircTask {
     fn update_tracks(&mut self, frame: &protocol::spirc::Frame) {
         let index = frame.get_state().get_playing_track_index();
         let tracks = frame.get_state().get_track();
+        let context_uri = frame.get_state().get_context_uri().to_owned();
 
         self.state.set_playing_track_index(index);
         self.state.set_track(tracks.into_iter().cloned().collect());
+        self.state.set_context_uri(context_uri);
     }
 
     fn load_track(&mut self, play: bool) {


### PR DESCRIPTION
Some more low-hanging fruit but useful for other things. It also allows remote clients to show the green now-playing indication (#57).