### PR TITLE
Add a armv6hf crossbuild target

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -2,7 +2,7 @@
 # Build the docker image from the root of the project with the following command :
 # $ docker build -t librespot-cross -f contrib/Dockerfile .
 #
-# The resulting image can be used to build librespot for linux x86_64, armhf and armel.
+# The resulting image can be used to build librespot for linux x86_64, armhf(with support for armv6hf), armel, mipsel, aarch64
 # $ docker run -v /tmp/librespot-build:/build librespot-cross
 #
 # The compiled binaries will be located in /tmp/librespot-build
@@ -11,7 +11,7 @@
 # $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features "alsa-backend"
 # $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend"
 # $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend"
-#
+# $ docker run -v /tmp/librespot-build:/build librespot-cross contrib/docker-build-pi-armv6hf.sh
 
 FROM debian:stretch
 
@@ -37,7 +37,10 @@ RUN mkdir /.cargo && \
     echo '[target.arm-unknown-linux-gnueabi]\nlinker = "arm-linux-gnueabi-gcc"' >> /.cargo/config && \
     echo '[target.mipsel-unknown-linux-gnu]\nlinker = "mipsel-linux-gnu-gcc"' >> /.cargo/config
 
-RUN mkdir /build
+RUN mkdir /build && \
+    mkdir /pi-tools && \
+    curl -L https://github.com/raspberrypi/tools/archive/648a6eeb1e3c2b40af4eb34d88941ee0edeb3e9a.tar.gz | tar xz --strip-components 1 -C /pi-tools
+
 ENV CARGO_TARGET_DIR /build
 ENV CARGO_HOME /build/cache
 

--- a/contrib/docker-build-pi-armv6hf.sh
+++ b/contrib/docker-build-pi-armv6hf.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+# Snipped and tucked from https://github.com/plietar/librespot/pull/202/commits/21549641d39399cbaec0bc92b36c9951d1b87b90
+# and further inputs from https://github.com/kingosticks/librespot/commit/c55dd20bd6c7e44dd75ff33185cf50b2d3bd79c3
+
+set -eux
+# Get alsa lib and headers
+ALSA_VER="1.0.25-4"
+DEPS=( \
+  "http://mirrordirector.raspbian.org/raspbian/pool/main/a/alsa-lib/libasound2_${ALSA_VER}_armhf.deb" \
+  "http://mirrordirector.raspbian.org/raspbian/pool/main/a/alsa-lib/libasound2-dev_${ALSA_VER}_armhf.deb" \
+)
+
+# Collect Paths
+SYSROOT="/pi-tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot"
+GCC="/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin"
+GCC_SYSROOT="$GCC/gcc-sysroot"
+
+
+export PATH=/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/:$PATH
+
+# Link the compiler
+export TARGET_CC="$GCC/arm-linux-gnueabihf-gcc"
+
+# Create wrapper around gcc to point to rpi sysroot
+echo -e '#!/bin/bash' "\n$TARGET_CC --sysroot $SYSROOT \"\$@\"" > $GCC_SYSROOT
+chmod +x $GCC_SYSROOT
+
+# Add extra target dependencies to our rpi sysroot
+for path in "${DEPS[@]}"; do
+  curl -OL $path
+  dpkg -x $(basename $path) $SYSROOT
+done
+
+# i don't why this is neccessary
+# ln -s ld-linux.so.3 $SYSROOT/lib/ld-linux-armhf.so.3
+
+# point cargo to use gcc wrapper as linker
+echo -e '[target.arm-unknown-linux-gnueabihf]\nlinker = "gcc-sysroot"' > /.cargo/config
+
+# Build
+cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend"


### PR DESCRIPTION
This is mainly from https://github.com/plietar/librespot/pull/202/ with a few changes.
mainly, moved the raspberrypi-tools/ download into the Dockerfile so that it can be cached.

