### PR TITLE
Fix pulseaudio playback with Lewton

### DIFF
--- a/playback/src/audio_backend/pulseaudio.rs
+++ b/playback/src/audio_backend/pulseaudio.rs
@@ -112,6 +112,7 @@ impl Sink for PulseAudioSink {
         } else {
             let ptr = data.as_ptr() as *const libc::c_void;
             let len = data.len() as usize * mem::size_of::<i16>();
+            assert!(len > 0);
             call_pulseaudio(
                 |err| unsafe { pa_simple_write(self.s, ptr, len, err) },
                 |ret| ret < 0,

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -372,19 +372,21 @@ impl PlayerInternal {
     fn handle_packet(&mut self, packet: Option<VorbisPacket>, normalisation_factor: f32) {
         match packet {
             Some(mut packet) => {
-                if let Some(ref editor) = self.audio_filter {
-                    editor.modify_stream(&mut packet.data_mut())
-                };
+                if packet.data().len() > 0 {
+                    if let Some(ref editor) = self.audio_filter {
+                        editor.modify_stream(&mut packet.data_mut())
+                    };
 
-                if self.config.normalisation && normalisation_factor != 1.0 {
-                    for x in packet.data_mut().iter_mut() {
-                        *x = (*x as f32 * normalisation_factor) as i16;
+                    if self.config.normalisation && normalisation_factor != 1.0 {
+                        for x in packet.data_mut().iter_mut() {
+                            *x = (*x as f32 * normalisation_factor) as i16;
+                        }
                     }
-                }
 
-                if let Err(err) = self.sink.write(&packet.data()) {
-                    error!("Could not write audio: {}", err);
-                    self.stop_sink();
+                    if let Err(err) = self.sink.write(&packet.data()) {
+                        error!("Could not write audio: {}", err);
+                        self.stop_sink();
+                    }
                 }
             }
 


### PR DESCRIPTION
Lewton returns empty packets from next_packet(). This caused problems with the pulseaudio backend.