### PR TITLE
Add 5xx error panic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,10 +1,3 @@
-[root]
-name = "librespot-protocol"
-version = "0.1.0"
-dependencies = [
- "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
 [[package]]
 name = "aho-corasick"
 version = "0.6.4"
@@ -504,6 +497,13 @@ dependencies = [
  "librespot-metadata 0.1.0",
  "log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "portaudio-rs 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "librespot-protocol"
+version = "0.1.0"
+dependencies = [
+ "protobuf 1.4.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]

--- a/core/src/mercury/mod.rs
+++ b/core/src/mercury/mod.rs
@@ -189,7 +189,9 @@ impl MercuryManager {
             payload: pending.parts,
         };
 
-        if response.status_code >= 400 {
+        if response.status_code >= 500 {
+            panic!("Spotify servers returned an error. Restart librespot.");
+        } else if response.status_code >= 400 {
             warn!("error {} for uri {}", response.status_code, &response.uri);
             if let Some(cb) = pending.callback {
                 let _ = cb.send(Err(MercuryError));


### PR DESCRIPTION
This is a lazy bandaid for the hanging issue when ```5xx``` errors occur. Librespot now panics when it encounters them, so at least supervisors can now relaunch it automatically.