### PR TITLE
return from Main loop on Ctrl-C/shutdown

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -434,6 +434,7 @@ impl Future for Main {
             }
 
             if let Async::Ready(Some(())) = self.signal.poll().unwrap() {
+                trace!("Ctrl-C received");
                 if !self.shutdown {
                     if let Some(ref spirc) = self.spirc {
                         spirc.shutdown();
@@ -466,6 +467,10 @@ impl Future for Main {
 
             if !progress {
                 return Ok(Async::NotReady);
+            }
+
+            if self.shutdown {
+                return Ok(Async::Ready(()));
             }
         }
     }


### PR DESCRIPTION
When we receive Ctrl-C we set shutdown to true, but we do not return from the Main Future with Ready without triggering Ctrl-C handler again.