### PR TITLE
Add metadata pipe support which is compatible with forked-daapd.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -487,6 +487,7 @@ name = "librespot-playback"
 version = "0.1.0"
 dependencies = [
  "alsa 0.0.1 (git+https://github.com/plietar/rust-alsa)",
+ "base64 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "byteorder 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.21 (registry+https://github.com/rust-lang/crates.io-index)",
  "jack 0.5.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -11,6 +11,7 @@ path = "../core"
 path = "../metadata"
 
 [dependencies]
+base64 = "0.5.0"
 futures = "0.1.8"
 log = "0.3.5"
 byteorder = "1.2.1"

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -1,6 +1,6 @@
 #[macro_use]
 extern crate log;
-
+extern crate base64;
 extern crate byteorder;
 extern crate futures;
 

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -9,6 +9,7 @@ pub trait Mixer: Send {
     fn get_audio_filter(&self) -> Option<Box<AudioFilter + Send>> {
         None
     }
+    fn set_metadata_pipe(&mut self, _metadata_pipe: Option<String>) {}
 }
 
 pub trait AudioFilter {
@@ -18,6 +19,9 @@ pub trait AudioFilter {
 pub mod softmixer;
 use self::softmixer::SoftMixer;
 
+pub mod pipemixer;
+use self::pipemixer::PipeMixer;
+
 fn mk_sink<M: Mixer + 'static>() -> Box<Mixer> {
     Box::new(M::open())
 }
@@ -25,6 +29,7 @@ fn mk_sink<M: Mixer + 'static>() -> Box<Mixer> {
 pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn() -> Box<Mixer>> {
     match name.as_ref().map(AsRef::as_ref) {
         None | Some("softvol") => Some(mk_sink::<SoftMixer>),
+        Some("pipe") => Some(mk_sink::<PipeMixer>),
         _ => None,
     }
 }

--- a/playback/src/mixer/pipemixer.rs
+++ b/playback/src/mixer/pipemixer.rs
@@ -1,0 +1,56 @@
+use base64;
+use std::f32;
+use std::fs::File;
+use std::io::Write;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use super::Mixer;
+
+#[derive(Clone)]
+pub struct PipeMixer {
+    volume: Arc<AtomicUsize>,
+    pipe: Option<String>,
+}
+
+impl Mixer for PipeMixer {
+    fn open() -> PipeMixer {
+        PipeMixer {
+            volume: Arc::new(AtomicUsize::new(0xFFFF)),
+            pipe: None,
+        }
+    }
+    fn start(&self) {}
+    fn stop(&self) {}
+    fn volume(&self) -> u16 {
+        self.volume.load(Ordering::Relaxed) as u16
+    }
+    fn set_volume(&self, volume: u16) {
+        self.volume.store(volume as usize, Ordering::Relaxed);
+
+        if let Some(path) = self.pipe.as_ref() {
+            let vol = volume;
+            let metadata_vol = if vol == 0 {
+                -144.0f32
+            } else if vol == 1 {
+                -30.0f32
+            } else if vol == 0xFFFF {
+                0.0f32
+            } else {
+                ((vol as f32) - (0xFFFF as f32)) * 30.0f32 / (0xFFFE as f32)
+            };
+
+            let vol_string = format!("{:.*},0.00,0.00,0.00", 2, metadata_vol);
+            let vol_string_len = vol_string.chars().count();
+            let metadata_vol_string = base64::encode(&vol_string);
+            let metadata_xml = format!("<item><type>73736e63</type><code>70766f6c</code><length>{}</length>\n<data encoding=\"base64\">\n{}</data></item>", vol_string_len, metadata_vol_string);
+
+            let mut f = File::create(path).expect("Unable to open pipe");
+            f.write_all(metadata_xml.as_bytes())
+                .expect("Unable to write data");
+        }
+    }
+    fn set_metadata_pipe(&mut self, metadata_pipe: Option<String>) {
+        self.pipe = metadata_pipe;
+    }
+}


### PR DESCRIPTION
Use argument --metadata-pipe [/srv/music/librespot.metadata] to enable metadata pipe. 
Recommend to use arguments --linear-volume --mixer pipe to properly send the volume.