### PR TITLE
Cache volume across restarts

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -233,11 +233,11 @@ impl Spirc {
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded();
 
-        let volume = config.volume as u16;
+        let volume = config.volume;
         let linear_volume = config.linear_volume;
 
         let device = initial_device_state(config, volume);
-        mixer.set_volume(volume_to_mixer(volume as u16, linear_volume));
+        mixer.set_volume(volume_to_mixer(volume, linear_volume));
 
         let mut task = SpircTask {
             player: player,

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -3,6 +3,8 @@ use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Poll, Sink, Stream};
 use protobuf::{self, Message};
 
+use core::cache::Cache;
+use core::volume::Volume;
 use core::config::ConnectConfig;
 use core::mercury::MercuryError;
 use core::session::Session;
@@ -193,7 +195,13 @@ fn calc_logarithmic_volume(volume: u16) -> u16 {
     val
 }
 
-fn volume_to_mixer(volume: u16, linear_volume: bool) -> u16 {
+fn volume_to_mixer(volume: u16, linear_volume: bool, cache: Option<Cache>) -> u16 {
+    let vol = Volume {
+        volume: volume as i32
+    };
+    if cache.is_some() {
+        cache.as_ref().unwrap().save_volume(&vol);
+    }
     if linear_volume {
         debug!("linear volume: {}", volume);
         volume

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -4,13 +4,13 @@ use futures::{Async, Future, Poll, Sink, Stream};
 use protobuf::{self, Message};
 
 use core::cache::Cache;
-use core::volume::Volume;
 use core::config::ConnectConfig;
 use core::mercury::MercuryError;
 use core::session::Session;
 use core::spotify_id::SpotifyId;
 use core::util::SeqGenerator;
 use core::version;
+use core::volume::Volume;
 
 use protocol;
 use protocol::spirc::{DeviceState, Frame, MessageType, PlayStatus, State};
@@ -198,7 +198,7 @@ fn calc_logarithmic_volume(volume: u16) -> u16 {
 
 fn volume_to_mixer(volume: u16, linear_volume: bool, cache: Option<Cache>) -> u16 {
     let vol = Volume {
-        volume: volume as i32
+        volume: volume as i32,
     };
     if cache.is_some() {
         cache.as_ref().unwrap().save_volume(&vol);
@@ -544,8 +544,11 @@ impl SpircTask {
 
             MessageType::kMessageTypeVolume => {
                 self.device.set_volume(frame.get_volume());
-                self.mixer
-                    .set_volume(volume_to_mixer(frame.get_volume() as u16, self.linear_volume, self.cache.clone()));
+                self.mixer.set_volume(volume_to_mixer(
+                    frame.get_volume() as u16,
+                    self.linear_volume,
+                    self.cache.clone(),
+                ));
                 self.notify(None);
             }
 
@@ -669,8 +672,11 @@ impl SpircTask {
             volume = 0xFFFF;
         }
         self.device.set_volume(volume);
-        self.mixer
-            .set_volume(volume_to_mixer(volume as u16, self.linear_volume, self.cache.clone()));
+        self.mixer.set_volume(volume_to_mixer(
+            volume as u16,
+            self.linear_volume,
+            self.cache.clone(),
+        ));
     }
 
     fn handle_volume_down(&mut self) {
@@ -679,8 +685,11 @@ impl SpircTask {
             volume = 0;
         }
         self.device.set_volume(volume as u32);
-        self.mixer
-            .set_volume(volume_to_mixer(volume as u16, self.linear_volume, self.cache.clone()));
+        self.mixer.set_volume(volume_to_mixer(
+            volume as u16,
+            self.linear_volume,
+            self.cache.clone(),
+        ));
     }
 
     fn handle_end_of_track(&mut self) {

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -64,7 +64,7 @@ impl Cache {
         Volume::from_file(path)
     }
 
-    pub fn save_volume(&self, volume: &Volume) {
+    pub fn save_volume(&self, volume: Volume) {
         let path = self.volume_path();
         volume.save_to_file(&path);
     }

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 
 use authentication::Credentials;
 use spotify_id::FileId;
+use volume::Volume;
 
 #[derive(Clone)]
 pub struct Cache {
@@ -49,6 +50,23 @@ impl Cache {
     pub fn save_credentials(&self, cred: &Credentials) {
         let path = self.credentials_path();
         cred.save_to_file(&path);
+    }
+}
+
+// cache volume to root/volume
+impl Cache {
+    fn volume_path(&self) -> PathBuf {
+        self.root.join("volume")
+    }
+
+    pub fn volume(&self) -> Option<Volume> {
+        let path = self.volume_path();
+        Volume::from_file(path)
+    }
+
+    pub fn save_volume(&self, volume: &Volume) {
+        let path = self.volume_path();
+        volume.save_to_file(&path);
     }
 }
 

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -59,7 +59,7 @@ impl Cache {
         self.root.join("volume")
     }
 
-    pub fn volume(&self) -> Option<Volume> {
+    pub fn volume(&self) -> Option<u16> {
         let path = self.volume_path();
         Volume::from_file(path)
     }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -81,6 +81,6 @@ impl Default for DeviceType {
 pub struct ConnectConfig {
     pub name: String,
     pub device_type: DeviceType,
-    pub volume: i32,
+    pub volume: u16,
     pub linear_volume: bool,
 }

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -52,3 +52,4 @@ pub mod session;
 pub mod spotify_id;
 pub mod util;
 pub mod version;
+pub mod volume;

--- a/core/src/volume.rs
+++ b/core/src/volume.rs
@@ -14,8 +14,8 @@ impl Volume {
         let mut contents = String::new();
         reader.read_to_string(&mut contents).unwrap();
         let volume = contents.trim().parse::<i32>().unwrap();
-        if volume < 0 || volume > 100 {
-            panic!("Cached volume must be in the range 0-100");
+        if volume > 100 {
+            volume = 100;
         }
         Volume {
             volume: volume * 0xFFFF / 100,

--- a/core/src/volume.rs
+++ b/core/src/volume.rs
@@ -2,6 +2,7 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
 
+#[derive(Clone, Copy, Debug)]
 pub struct Volume {
     pub volume: i32,
 }

--- a/core/src/volume.rs
+++ b/core/src/volume.rs
@@ -2,7 +2,6 @@ use std::fs::File;
 use std::io::{Read, Write};
 use std::path::Path;
 
-
 pub struct Volume {
     pub volume: i32,
 }
@@ -18,7 +17,7 @@ impl Volume {
             panic!("Cached volume must be in the range 0-100");
         }
         Volume {
-            volume: volume * 0xFFFF / 100
+            volume: volume * 0xFFFF / 100,
         }
     }
 

--- a/core/src/volume.rs
+++ b/core/src/volume.rs
@@ -9,15 +9,13 @@ pub struct Volume {
 
 impl Volume {
     // read volume from file
-    fn from_reader<R: Read>(mut reader: R) -> Volume {
+    fn from_reader<R: Read>(mut reader: R) -> u16 {
         let mut contents = String::new();
         reader.read_to_string(&mut contents).unwrap();
-        Volume {
-            volume: contents.trim().parse::<u16>().unwrap(),
-        }
+        contents.trim().parse::<u16>().unwrap()
     }
 
-    pub(crate) fn from_file<P: AsRef<Path>>(path: P) -> Option<Volume> {
+    pub(crate) fn from_file<P: AsRef<Path>>(path: P) -> Option<u16> {
         File::open(path).ok().map(Volume::from_reader)
     }
 

--- a/core/src/volume.rs
+++ b/core/src/volume.rs
@@ -1,0 +1,40 @@
+use std::fs::File;
+use std::io::{Read, Write};
+use std::path::Path;
+
+
+pub struct Volume {
+    pub volume: i32,
+}
+
+impl Volume {
+    // read volume from file, enforce upper/lower bounds
+    // convert volume from 0..100 to 0..0xFFFF
+    fn from_reader<R: Read>(mut reader: R) -> Volume {
+        let mut contents = String::new();
+        reader.read_to_string(&mut contents).unwrap();
+        let volume = contents.trim().parse::<i32>().unwrap();
+        if volume < 0 || volume > 100 {
+            panic!("Cached volume must be in the range 0-100");
+        }
+        Volume {
+            volume: volume * 0xFFFF / 100
+        }
+    }
+
+    pub(crate) fn from_file<P: AsRef<Path>>(path: P) -> Option<Volume> {
+        File::open(path).ok().map(Volume::from_reader)
+    }
+
+    // convert volume from 0..0xFFFF to 0..100
+    // write to plaintext file
+    fn save_to_writer<W: Write>(&self, writer: &mut W) {
+        let volume = self.volume * 100 / 0xFFFF;
+        writer.write_all(volume.to_string().as_bytes()).unwrap();
+    }
+
+    pub(crate) fn save_to_file<P: AsRef<Path>>(&self, path: P) {
+        let mut file = File::create(path).unwrap();
+        self.save_to_writer(&mut file)
+    }
+}

--- a/core/src/volume.rs
+++ b/core/src/volume.rs
@@ -8,17 +8,12 @@ pub struct Volume {
 }
 
 impl Volume {
-    // read volume from file, enforce upper/lower bounds
-    // convert volume from 0..100 to 0..0xFFFF
+    // read volume from file
     fn from_reader<R: Read>(mut reader: R) -> Volume {
         let mut contents = String::new();
         reader.read_to_string(&mut contents).unwrap();
-        let mut volume = contents.trim().parse::<u16>().unwrap();
-        if volume > 100 {
-            volume = 100;
-        }
         Volume {
-            volume: (volume as i32 * 0xFFFF / 100) as u16,
+            volume: contents.trim().parse::<u16>().unwrap(),
         }
     }
 
@@ -26,11 +21,9 @@ impl Volume {
         File::open(path).ok().map(Volume::from_reader)
     }
 
-    // convert volume from 0..0xFFFF to 0..100
-    // write to plaintext file
+    // write volume to file
     fn save_to_writer<W: Write>(&self, writer: &mut W) {
-        let volume = (self.volume as f32 * 100.0 / 0xFFFF as f32).round() as u16;
-        writer.write_all(volume.to_string().as_bytes()).unwrap();
+        writer.write_all(self.volume.to_string().as_bytes()).unwrap();
     }
 
     pub(crate) fn save_to_file<P: AsRef<Path>>(&self, path: P) {

--- a/core/src/volume.rs
+++ b/core/src/volume.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 #[derive(Clone, Copy, Debug)]
 pub struct Volume {
-    pub volume: i32,
+    pub volume: u16,
 }
 
 impl Volume {
@@ -13,12 +13,12 @@ impl Volume {
     fn from_reader<R: Read>(mut reader: R) -> Volume {
         let mut contents = String::new();
         reader.read_to_string(&mut contents).unwrap();
-        let volume = contents.trim().parse::<i32>().unwrap();
+        let mut volume = contents.trim().parse::<u16>().unwrap();
         if volume > 100 {
             volume = 100;
         }
         Volume {
-            volume: volume * 0xFFFF / 100,
+            volume: (volume as i32 * 0xFFFF / 100) as u16,
         }
     }
 
@@ -29,7 +29,7 @@ impl Volume {
     // convert volume from 0..0xFFFF to 0..100
     // write to plaintext file
     fn save_to_writer<W: Write>(&self, writer: &mut W) {
-        let volume = self.volume * 100 / 0xFFFF;
+        let volume = (self.volume as f32 * 100.0 / 0xFFFF as f32).round() as u16;
         writer.write_all(volume.to_string().as_bytes()).unwrap();
     }
 

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -36,7 +36,7 @@ fn main() {
     let session = core.run(Session::connect(session_config, credentials, None, handle))
         .unwrap();
 
-    let (player, _)= Player::new(player_config, session.clone(), None, move || (backend)(None));
+    let (player, _) = Player::new(player_config, session.clone(), None, move || (backend)(None));
 
     println!("Playing...");
     core.run(player.load(track, true, 0)).unwrap();

--- a/playback/src/audio_backend/jackaudio.rs
+++ b/playback/src/audio_backend/jackaudio.rs
@@ -1,6 +1,8 @@
 use super::{Open, Sink};
-use jack::prelude::{client_options, AsyncClient, AudioOutPort, AudioOutSpec, Client, JackControl, Port,
-                    ProcessHandler, ProcessScope};
+use jack::prelude::{
+    client_options, AsyncClient, AudioOutPort, AudioOutSpec, Client, JackControl, Port, ProcessHandler,
+    ProcessScope,
+};
 use std::io;
 use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -215,7 +215,7 @@ fn setup(args: &[String]) -> Setup {
 
     // override default volume with cached volume if found
     if cached_volume.is_some() {
-        default_volume = cached_volume.unwrap().volume;
+        default_volume = cached_volume.unwrap().volume as i32;
     }
 
     // override default/cached volume with initial volume if found

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,7 +427,6 @@ impl Future for Main {
                 let mixer = (self.mixer)();
                 let player_config = self.player_config.clone();
                 let connect_config = self.connect_config.clone();
-                let cache = self.cache.clone();
 
                 let audio_filter = mixer.get_audio_filter();
                 let backend = self.backend;
@@ -436,7 +435,7 @@ impl Future for Main {
                         (backend)(device)
                     });
 
-                let (spirc, spirc_task) = Spirc::new(connect_config, session, player, mixer, cache);
+                let (spirc, spirc_task) = Spirc::new(connect_config, session, player, mixer);
                 self.spirc = Some(spirc);
                 self.spirc_task = Some(spirc_task);
                 self.player_event_channel = Some(event_channel);

--- a/src/main.rs
+++ b/src/main.rs
@@ -427,6 +427,7 @@ impl Future for Main {
                 let mixer = (self.mixer)();
                 let player_config = self.player_config.clone();
                 let connect_config = self.connect_config.clone();
+                let cache = self.cache.clone();
 
                 let audio_filter = mixer.get_audio_filter();
                 let backend = self.backend;
@@ -435,7 +436,7 @@ impl Future for Main {
                         (backend)(device)
                     });
 
-                let (spirc, spirc_task) = Spirc::new(connect_config, session, player, mixer);
+                let (spirc, spirc_task) = Spirc::new(connect_config, session, player, mixer, cache);
                 self.spirc = Some(spirc);
                 self.spirc_task = Some(spirc_task);
                 self.player_event_channel = Some(event_channel);

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,23 +210,23 @@ fn setup(args: &[String]) -> Setup {
         .opt_str("c")
         .map(|cache_location| Cache::new(PathBuf::from(cache_location), use_audio_cache));
 
-    let mut default_volume = 0x8000;
+    let mut default_volume: u16 = 0x8000;
     let cached_volume = cache.as_ref().and_then(Cache::volume);
 
     // override default volume with cached volume if found
     if cached_volume.is_some() {
-        default_volume = cached_volume.unwrap().volume as i32;
+        default_volume = cached_volume.unwrap().volume;
     }
 
     // override default/cached volume with initial volume if found
     let initial_volume = matches
         .opt_str("initial-volume")
         .map(|volume| {
-            let volume = volume.parse::<i32>().unwrap();
-            if volume < 0 || volume > 100 {
+            let volume = volume.parse::<u16>().unwrap();
+            if volume > 100 {
                 panic!("Initial volume must be in the range 0-100");
             }
-            volume * 0xFFFF / 100
+            (volume as i32 * 0xFFFF / 100) as u16
         })
         .unwrap_or(default_volume);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,15 +210,6 @@ fn setup(args: &[String]) -> Setup {
         .opt_str("c")
         .map(|cache_location| Cache::new(PathBuf::from(cache_location), use_audio_cache));
 
-    let mut default_volume: u16 = 0x8000;
-    let cached_volume = cache.as_ref().and_then(Cache::volume);
-
-    // override default volume with cached volume if found
-    if cached_volume.is_some() {
-        default_volume = cached_volume.unwrap().volume;
-    }
-
-    // override default/cached volume with initial volume if found
     let initial_volume = matches
         .opt_str("initial-volume")
         .map(|volume| {
@@ -228,7 +219,8 @@ fn setup(args: &[String]) -> Setup {
             }
             (volume as i32 * 0xFFFF / 100) as u16
         })
-        .unwrap_or(default_volume);
+        .or_else(|| cache.as_ref().and_then(Cache::volume))
+        .unwrap_or(0x8000);
 
     let zeroconf_port = matches
         .opt_str("zeroconf-port")


### PR DESCRIPTION
This is a continuation of [https://github.com/librespot-org/librespot/pull/218](https://github.com/librespot-org/librespot/pull/218). Now, volume is cached when the user supplies the `--cache` directory. `--initial-volume` overrides cached volume, which in turn overrides the default hard-coded volume.

Currently, the volume is stored in a plaintext file containing only the (percentage) volume. In the future, it could be expanded into a config.json with other parameters as well, since I've largely copied the way that the credentials are stored in credentials.json.

I don't know if the final commit (passing to `Spirc` and `SpircTask`) is the most elegant way to access the cache from `volume_to_mixer`, so I'm open to any improvements to that aspect.