### PR TITLE
Add librespot-java to related projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,5 +87,7 @@ This is a non exhaustive list of projects that either use or have modified libre
 - [plugin.audio.spotify](https://github.com/marcelveldt/plugin.audio.spotify) - A Kodi plugin for Spotify.
 - [raspotify](https://github.com/dtcooper/raspotify) - Spotify Connect client for the Raspberry Pi that Just Works™
 - [Spotifyd](https://github.com/Spotifyd/spotifyd) - A stripped down librespot UNIX daemon.
-- [Spotcontrol](https://github.com/badfortrains/spotcontrol) - A golang implementation of a Spotify Connect controller. No playback functionality.
+- [Spotcontrol](https://github.com/badfortrains/spotcontrol) - A golang implementation of a Spotify Connect controller. No playback
+functionality.
+- [librespot-java](https://github.com/devgianlu/librespot-java) - A Java port of librespot.
 


### PR DESCRIPTION
I've written a Java port of this library [here](https://github.com/devgianlu/librespot-java). What I've done so far:
- Authentication w/ password
- Authentication w/ Zeroconf
- Mercury request system
- Playlists and tracks querying