### PR TITLE
WIP: Gapless playback

### DIFF
--- a/audio/src/lewton_decoder.rs
+++ b/audio/src/lewton_decoder.rs
@@ -24,7 +24,7 @@ where
         Ok(())
     }
 
-    pub fn postion(&self) -> Result<i64, VorbisError> {
+    pub fn position(&self) -> Result<i64, VorbisError> {
         match self.0.get_last_absgp() {
             Some(absgp) => Ok((absgp * 1000 / 44100) as i64), // in ms
             None => Ok(0),

--- a/audio/src/lewton_decoder.rs
+++ b/audio/src/lewton_decoder.rs
@@ -24,6 +24,13 @@ where
         Ok(())
     }
 
+    pub fn postion(&self) -> Result<i64, VorbisError> {
+        match self.0.get_last_absgp() {
+            Some(absgp) => Ok((absgp * 1000 / 44100) as i64), // in ms
+            None => Ok(0),
+        }
+    }
+
     pub fn next_packet(&mut self) -> Result<Option<VorbisPacket>, VorbisError> {
         use self::lewton::audio::AudioReadError::AudioIsHeader;
         use self::lewton::OggReadError::NoCapturePatternFound;

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -386,7 +386,7 @@ impl PlayerInternal {
                 } = self.state
                 {
                     current_normalisation_factor = normalisation_factor;
-                    if i64::from(duration) - decoder.postion().unwrap() <= 2000 {
+                    if i64::from(duration) - decoder.position().unwrap() <= 30000 {
                         signal_prefetch = true;
                     }
                     Some(decoder.next_packet().expect("Vorbis error"))


### PR DESCRIPTION
Work in progress PR with the final goal of providing gapless playback.

### Todo
- [x] Implement a channel b/w `player` and `spirc` thread for prefetch 
- [ ] Prefetch next track when current one is fully downloaded (instead of time based approach now)
- [ ] Implement `duration` with other decoders as well if we are moving away from the time approach 
- [ ] Gapless playback 

### Discussions

#### Distinguish b/w playback state and loading state:
 Currently when the decoder is done with the current file, the player thread fires off an `EndOfTrack` to `spirc` - signalling the loading of the next track. For gapless, we thus need to implement a buffer (or is it a queue), and distinguish b/w fetching/decrypting/decoding states and actual playback state. 
Thoughts/ideas for this?

 