### PR TITLE
Null mixer to skip volume control

### DIFF
--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -39,12 +39,16 @@ impl Default for MixerConfig {
 pub mod softmixer;
 use self::softmixer::SoftMixer;
 
+pub mod nullmixer;
+use self::nullmixer::NullMixer;
+
 fn mk_sink<M: Mixer + 'static>(device: Option<MixerConfig>) -> Box<Mixer> {
     Box::new(M::open(device))
 }
 
 pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn(Option<MixerConfig>) -> Box<Mixer>> {
     match name.as_ref().map(AsRef::as_ref) {
+        Some("null") => Some(mk_sink::<NullMixer>),
         None | Some("softvol") => Some(mk_sink::<SoftMixer>),
         #[cfg(feature = "alsa-backend")]
         Some("alsa") => Some(mk_sink::<AlsaMixer>),

--- a/playback/src/mixer/nullmixer.rs
+++ b/playback/src/mixer/nullmixer.rs
@@ -1,0 +1,29 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+use super::AudioFilter;
+use super::{Mixer, MixerConfig};
+
+#[derive(Clone)]
+pub struct NullMixer {
+    volume: Arc<AtomicUsize>,
+}
+
+impl Mixer for NullMixer {
+    fn open(_: Option<MixerConfig>) -> NullMixer {
+        NullMixer {
+            volume: Arc::new(AtomicUsize::new(0xFFFF)),
+        }
+    }
+    fn start(&self) {}
+    fn stop(&self) {}
+    fn volume(&self) -> u16 {
+        self.volume.load(Ordering::Relaxed) as u16
+    }
+    fn set_volume(&self, volume: u16) {
+        self.volume.store(volume as usize, Ordering::Relaxed);
+    }
+    fn get_audio_filter(&self) -> Option<Box<AudioFilter + Send>> {
+        None
+    }
+}


### PR DESCRIPTION
Implement a null mixer that does not control volume with software. Having such mechanism is useful if you want to use some external method for volume control, but it isn't available in Librespot.

To support the null mixer, we'd most likely want to also expose volume changes as events that trigger external script.