### PR TITLE
Rewrite and simplify Player

### DIFF
--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -30,6 +30,7 @@ pub struct PlayerConfig {
     pub bitrate: Bitrate,
     pub normalisation: bool,
     pub normalisation_pregain: f32,
+    pub volume: Option<f32>,
 }
 
 impl Default for PlayerConfig {
@@ -38,6 +39,7 @@ impl Default for PlayerConfig {
             bitrate: Bitrate::default(),
             normalisation: false,
             normalisation_pregain: 0.0,
+            volume: None,
         }
     }
 }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -335,7 +335,10 @@ impl PlayerInternal {
             PlayerCommand::Load(track_id, play, position, end_of_track) => {
                 let (decoder, normalisation_factor) = match self.load_track(track_id, position as i64) {
                     Some(result) => result,
-                    None => return Err(Error::new(ErrorKind::Other, "failed to load track")),
+                    None => {
+                        let _ = end_of_track.send(());
+                        return Ok(());
+                    },
                 };
 
                 // NB: we always swap out the loaded track.

--- a/src/main.rs
+++ b/src/main.rs
@@ -291,6 +291,7 @@ fn setup(args: &[String]) -> Setup {
                 .opt_str("normalisation-pregain")
                 .map(|pregain| pregain.parse::<f32>().expect("Invalid pregain float value"))
                 .unwrap_or(PlayerConfig::default().normalisation_pregain),
+            volume: None,
         }
     };
 


### PR DESCRIPTION
Hey,

This is a mostly complete rewrite of how logic is handled in the Player.

* There are no dead code paths causing the player thread to exit sporadically. The only way that a player thread currently can shut down is either for the commands channel to disconnect or for it to panic.
* The various player states have been simplified and documented. In particular the code has been rewritten to not make use of an `Invalid` state any longer. The `EndOfTrack` state has been removed.
* The loaded track is no longer stored in the player state. Instead it is stored in an `loaded_track: Option<LoadedTrack>`. This makes it clearer what the lifetime of a `loaded_track` is and affords us to implement some things decoupled from the state.
* The player has no interim panics. Instead all errors are propagated as errors. If an error reaches the thread it will panic.
* The `end_of_track` oneshot is called in the `Drop` implementation of `LoadedTrack` to make sure we don't forget about it. Hopefully this means we can write clients without having to match against `Err(Cancelled)` in the receiving end.

This was also built on top of a previous patch which incorporated linear volume control:

This adds linear volume control at the same stage as normalization happens and adds player events to control the volume directly.

I'm pretty sure this can be implemented somewhere in the audio backend, as an audio filter, or as part of the mixer. But this avoids iterating over the samples twice if normalization happens anyways by multiplying it with the normalization factor.