### PR TITLE
Add credentials field alias

### DIFF
--- a/core/src/authentication.rs
+++ b/core/src/authentication.rs
@@ -22,6 +22,7 @@ pub struct Credentials {
     #[serde(deserialize_with = "deserialize_protobuf_enum")]
     pub auth_type: AuthenticationType,
 
+    #[serde(alias = "encoded_auth_blob")]
     #[serde(serialize_with = "serialize_base64")]
     #[serde(deserialize_with = "deserialize_base64")]
     pub auth_data: Vec<u8>,


### PR DESCRIPTION
`encoded_auth_blob` is used in the credentials response of the Facebook auth flow