### PR TITLE
[Rodio] Re-acquire audio sink when (re)starting playback.

### DIFF
--- a/playback/src/audio_backend/rodio.rs
+++ b/playback/src/audio_backend/rodio.rs
@@ -5,7 +5,8 @@ use std::{io, thread, time};
 use std::process::exit;
 
 pub struct RodioSink {
-    rodio_sink: rodio::Sink,
+    rodio_sink: Option<rodio::Sink>,
+    device_name: Option<String>,
 }
 
 fn list_formats(ref device: &rodio::Device) {
@@ -52,61 +53,68 @@ fn list_outputs() {
     }
 }
 
-impl Open for RodioSink {
-    fn open(device: Option<String>) -> RodioSink {
-        debug!("Using rodio sink");
-
-        let mut rodio_device = rodio::default_output_device().expect("no output device available");
-        if device.is_some() {
-            let device_name = device.unwrap();
-
-            if device_name == "?".to_string() {
-                list_outputs();
-                exit(0)
-            }
-            let mut found = false;
-            for d in rodio::output_devices() {
-                if d.name() == device_name {
-                    rodio_device = d;
-                    found = true;
+fn match_output(device_name: Option<String>) -> cpal::Device {
+    match device_name {
+        Some(dn) => {
+            let mut rodio_device = None;
+            for device in cpal::output_devices() {
+                if device.name() == dn {
+                    rodio_device = Some(device);
                     break;
                 }
             }
-            if !found {
-                println!("No output sink matching '{}' found.", device_name);
-                exit(0)
+            match rodio_device {
+                Some(cd) => cd,
+                None => {
+                    println!("No output sink matching '{}' found.", dn);
+                    exit(0)
+                }
             }
+        },
+        None => rodio::default_output_device().expect("no output device available")
+    }
+}
+
+impl Open for RodioSink {
+    fn open(device_name: Option<String>) -> RodioSink {
+        debug!("Using rodio sink");
+
+        if device_name == Some("?".to_string()) {
+            list_outputs();
+            exit(0)
         }
-        let sink = rodio::Sink::new(&rodio_device);
 
         RodioSink {
-            rodio_sink: sink,
+            device_name,
+            rodio_sink: None,
         }
     }
 }
 
 impl Sink for RodioSink {
     fn start(&mut self) -> io::Result<()> {
-        // More similar to an "unpause" than "play". Doesn't undo "stop".
-        // self.rodio_sink.play();
+        let rodio_device = match_output(self.device_name.clone());
+        let sink = rodio::Sink::new(&rodio_device);
+        self.rodio_sink = Some(sink);
         Ok(())
     }
 
     fn stop(&mut self) -> io::Result<()> {
-        // This will immediately stop playback, but the sink is then unusable.
-        // We just have to let the current buffer play till the end.
-        // self.rodio_sink.stop();
+        let sink = self.rodio_sink.as_mut().expect("stop called before start");
+        sink.stop();
         Ok(())
     }
 
     fn write(&mut self, data: &[i16]) -> io::Result<()> {
+        let sink = self.rodio_sink.as_mut().expect("write called before start");
+
         let source = rodio::buffer::SamplesBuffer::new(2, 44100, data);
-        self.rodio_sink.append(source);
+        sink.append(source);
 
         // Chunk sizes seem to be about 256 to 3000 ish items long.
         // Assuming they're on average 1628 then a half second buffer is:
         // 44100 elements --> about 27 chunks
-        while self.rodio_sink.len() > 26 {
+        while sink.len() > 26 {
             // sleep and wait for rodio to drain a bit
             thread::sleep(time::Duration::from_millis(10));
         }

--- a/playback/src/audio_backend/rodio.rs
+++ b/playback/src/audio_backend/rodio.rs
@@ -100,8 +100,7 @@ impl Sink for RodioSink {
     }
 
     fn stop(&mut self) -> io::Result<()> {
-        let sink = self.rodio_sink.as_mut().expect("stop called before start");
-        sink.stop();
+        self.rodio_sink = None;
         Ok(())
     }
 


### PR DESCRIPTION
This releases the audio sink and re-acquires it when skipping/pausing a song.

This is useful for switching playback device on desktop machines.

In an ideal world Rodio would check to see if the default sink has changed and switch automatically. But for the moment I find this behaviour acceptable, as I have a couple of playback devices I use.

This has a nice side effect of clearing the sink when stopping playback, which can make librespot feel more responsive.

I expect the performance issues seen previously by @chrisbp in https://github.com/librespot-org/librespot/pull/277 will only be fixed by not using rodio::Sink and rodio's mixer. Meaning this whole backend will need re-writing at some point to support an as-yet-non-existent very simple Rodio API for efficient playback of a single Source. So this PR may prove pointless.

N.B. Currently this causes a fuzz noise because it plays the first 5ms of every queued audio chunk when stopping. Waiting on https://github.com/tomaka/rodio/pull/221 to fix that.

I have excluded Cargo.lock cause I'm using a local Rodio and CPAL so it's pretty meaningless.