### PR TITLE
Added rudimentary support for podcasts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -820,6 +820,7 @@ dependencies = [
  "error-chain 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "extprim 1.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.26 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hex 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "hmac 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.11.27 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -804,6 +804,11 @@ impl SpircTask {
         if context_uri.starts_with("spotify:station:") || context_uri.starts_with("spotify:dailymix:") {
             self.context_fut = self.resolve_station(&context_uri);
         }
+        // for episode support:
+        // set the episode bool to true
+        if context_uri.starts_with("spotify:show:"){
+            self.session.setEpisode(true);
+        }
 
         self.state.set_playing_track_index(index);
         self.state.set_track(tracks.into_iter().cloned().collect());
@@ -818,6 +823,17 @@ impl SpircTask {
             // Check for malformed gid
             let tracks_len = self.state.get_track().len() as u32;
             let mut track_ref = &self.state.get_track()[index as usize];
+            if track_ref.get_gid().len() != 0
+            {
+                SpotifyId::from_raw(track_ref.get_gid()).unwrap()
+            }
+            else
+            {
+                SpotifyId::from_rawURI(track_ref.get_uri()).unwrap()
+            }
+            // commented out for episode support
+            // don't know how to handle thisAsMut
+            /*
             while track_ref.get_gid().len() != 16 {
                 warn!(
                     "Skipping track {:?} at position [{}] of {}",
@@ -828,7 +844,8 @@ impl SpircTask {
                 index = if index + 1 < tracks_len { index + 1 } else { 0 };
                 track_ref = &self.state.get_track()[index as usize];
             }
-            SpotifyId::from_raw(track_ref.get_gid()).unwrap()
+            */
+            //SpotifyId::from_raw(track_ref.get_gid()).unwrap()
         };
 
         let position = self.state.get_position_ms();

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -809,6 +809,10 @@ impl SpircTask {
         if context_uri.starts_with("spotify:show:"){
             self.session.setEpisode(true);
         }
+        else
+        {
+            self.session.setEpisode(false);
+        }
 
         self.state.set_playing_track_index(index);
         self.state.set_track(tracks.into_iter().cloned().collect());

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -168,6 +168,7 @@ fn initial_device_state(config: ConnectConfig) -> DeviceState {
                     let repeated = msg.mut_stringValue();
                     repeated.push(::std::convert::Into::into("audio/local"));
                     repeated.push(::std::convert::Into::into("audio/track"));
+                    repeated.push(::std::convert::Into::into("audio/episode"));
                     repeated.push(::std::convert::Into::into("local"));
                     repeated.push(::std::convert::Into::into("track"))
                 };

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -37,6 +37,7 @@ sha-1 = "0.8.0"
 hmac = "0.7.0"
 pbkdf2 = "0.3.0"
 aes = "0.3.0"
+hex = "0.3.2"
 
 [build-dependencies]
 rand = "0.6"

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -24,6 +24,7 @@ struct SessionData {
     time_delta: i64,
     canonical_username: String,
     invalid: bool,
+    isEpisode: bool,
 }
 
 struct SessionInternal {
@@ -112,6 +113,7 @@ impl Session {
                 canonical_username: username,
                 invalid: false,
                 time_delta: 0,
+                isEpisode: false,
             }),
 
             tx_connection: sender_tx,
@@ -242,6 +244,16 @@ impl Session {
     pub fn is_invalid(&self) -> bool {
         self.0.data.read().unwrap().invalid
     }
+
+    // get and set methods for isEpisode
+    pub fn isEpisode(&self) -> bool {
+        self.0.data.read().unwrap().isEpisode
+    }
+
+    pub fn setEpisode(&self, value:bool) {
+        self.0.data.write().unwrap().isEpisode = value;
+    }
+
 }
 
 #[derive(Clone)]

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -56,6 +56,17 @@ impl SpotifyId {
         Ok(SpotifyId(u128::from_parts(high, low)))
     }
 
+    // for episode support
+    // extract the spotify id from the uri
+    pub fn from_rawURI(data: &str) -> Result<SpotifyId, SpotifyIdError> {
+        let parts = data.split(":");
+        let vec = parts.collect::<Vec<&str>>();
+        let uri = vec.last().unwrap();
+        let decoded = u128::from_str_radix(uri, 16);
+        let value = decoded.unwrap();
+        Ok(SpotifyId(value))
+    }
+
     pub fn to_base16(&self) -> String {
         let &SpotifyId(ref n) = self;
 

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -62,9 +62,7 @@ impl SpotifyId {
         let parts = data.split(":");
         let vec = parts.collect::<Vec<&str>>();
         let uri = vec.last().unwrap();
-        let decoded = u128::from_str_radix(uri, 16);
-        let value = decoded.unwrap();
-        Ok(SpotifyId(value))
+        SpotifyId::from_base62(uri)
     }
 
     pub fn to_base16(&self) -> String {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -17,7 +17,7 @@ use core::spotify_id::SpotifyId;
 use audio::{AudioDecrypt, AudioFile};
 use audio::{VorbisDecoder, VorbisPacket};
 use audio_backend::Sink;
-use metadata::{FileFormat, Metadata, Track};
+use metadata::{FileFormat, Metadata, Track, Episode};
 use mixer::AudioFilter;
 
 pub struct Player {


### PR DESCRIPTION
Hi,
I've been trying to get podcast support. I have no experience with rust and it will show. Hopefully, someone more experienced can review what I have done and rework it.
Basically, I added a bool switch in the session. 
If a new track is added without gid but just with an uri (this is what is happening for me when i try to play a podcast, this bool is switched and the spotifyid is extracted from the uri).

I also added a new struct called episode with its own metadata and parsing. The base_url is the main thing that is changed. Podcasts also don't have album information, so this is not parsed. 

In the player, it is really ugly. 

In load_track, I differentiate between episode and track. But as a result of my lack of rust knowledge the only way to get it to compile was to copy the track code and make small adjustments. 
This part will have to be reworked. In there, I also set the bitrate to 96 kbits as podcasts don't have higher quality. 

So again. This is not suppost to be merged directly, but is intended as a "this might work maybe like this". 
However, playback is working for me. 

Cheers,
Jan