### PR TITLE
Bump up vergen (and switch to rustc-env flags)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -835,7 +835,6 @@ dependencies = [
  "tokio-process 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-signal 0.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -917,7 +916,7 @@ dependencies = [
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "url 1.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2327,15 +2326,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "vergen"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "vergen"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -2723,7 +2713,6 @@ dependencies = [
 "checksum utf8-ranges 1.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "9d50aa7650df78abf942826607c62468ce18d9019673d4a2ebe1865dbb96ffde"
 "checksum uuid 0.7.4 (registry+https://github.com/rust-lang/crates.io-index)" = "90dbc611eb48397705a6b0f6e917da23ae517e4d127123d2cf7674206627d32a"
 "checksum vec_map 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "05c78687fb1a80548ae3250346c3db86a80a7cdd77bda190189f2d0a0987c81a"
-"checksum vergen 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "8c3365f36c57e5df714a34be40902b27a992eeddb9996eca52d0584611cf885d"
 "checksum vergen 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "6aba5e34f93dc7051dfad05b98a18e9156f27e7b431fe1d2398cb6061c0a1dba"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,6 @@ url = "1.7"
 sha-1 = "0.8"
 hex = "0.3"
 
-[build-dependencies]
-rand            = "0.7"
-vergen          = "3.0"
-
 [features]
 alsa-backend = ["librespot-playback/alsa-backend"]
 portaudio-backend = ["librespot-playback/portaudio-backend"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -40,4 +40,4 @@ aes = "0.3"
 
 [build-dependencies]
 rand = "0.7"
-vergen = "0.1.0"
+vergen = "3.0.4"

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,38 +1,19 @@
 extern crate rand;
 extern crate vergen;
 
-use rand::Rng;
 use rand::distributions::Alphanumeric;
-use std::env;
-use std::fs::OpenOptions;
-use std::io::Write;
-use std::path::PathBuf;
+use rand::Rng;
+use vergen::{generate_cargo_keys, ConstantsFlags};
 
 fn main() {
-    let out = PathBuf::from(env::var("OUT_DIR").unwrap());
-
-    vergen::vergen(vergen::OutputFns::all()).unwrap();
+    let mut flags = ConstantsFlags::all();
+    flags.toggle(ConstantsFlags::REBUILD_ON_HEAD_CHANGE);
+    generate_cargo_keys(ConstantsFlags::all()).expect("Unable to generate the cargo keys!");
 
     let mut rng = rand::thread_rng();
-    let build_id: String = ::std::iter::repeat(()).map(|()| rng.sample(Alphanumeric)).take(8).collect();
-
-    let mut version_file = OpenOptions::new()
-        .write(true)
-        .append(true)
-        .open(&out.join("version.rs"))
-        .unwrap();
-
-    let build_id_fn = format!(
-        "
-/// Generate a random build id.
-pub fn build_id() -> &'static str {{
-    \"{}\"
-}}
-",
-        build_id
-    );
-
-    if let Err(e) = version_file.write_all(build_id_fn.as_bytes()) {
-        println!("{}", e);
-    }
+    let build_id: String = ::std::iter::repeat(())
+        .map(|()| rng.sample(Alphanumeric))
+        .take(8)
+        .collect();
+    println!("cargo:rustc-env=VERGEN_BUILD_ID={}", build_id);
 }

--- a/core/src/version.rs
+++ b/core/src/version.rs
@@ -1,5 +1,44 @@
-include!(concat!(env!("OUT_DIR"), "/version.rs"));
-
 pub fn version_string() -> String {
     format!("librespot-{}", short_sha())
+}
+
+// Generate a timestamp representing now (UTC) in RFC3339 format.
+pub fn now() -> &'static str {
+    env!("VERGEN_BUILD_TIMESTAMP")
+}
+
+// Generate a timstamp string representing now (UTC).
+pub fn short_now() -> &'static str {
+    env!("VERGEN_BUILD_DATE")
+}
+
+// Generate a SHA string
+pub fn sha() -> &'static str {
+    env!("VERGEN_SHA")
+}
+
+// Generate a short SHA string
+pub fn short_sha() -> &'static str {
+    env!("VERGEN_SHA_SHORT")
+}
+
+// Generate the commit date string
+pub fn commit_date() -> &'static str {
+    env!("VERGEN_COMMIT_DATE")
+}
+
+// Generate the target triple string
+pub fn target() -> &'static str {
+    env!("VERGEN_TARGET_TRIPLE")
+}
+
+// Generate a semver string
+pub fn semver() -> &'static str {
+    // env!("VERGEN_SEMVER")
+    env!("CARGO_PKG_VERSION")
+}
+
+// Generate a random build id.
+pub fn build_id() -> &'static str {
+    env!("VERGEN_BUILD_ID")
 }


### PR DESCRIPTION
Since we are doing some general housekeeping anyway!

Not quite sure what `vergen` was doing as a build dependency for the binary though.  Looks to be a straggler from when the `librespot-core` was split out in https://github.com/librespot-org/librespot/issues/130?