### PR TITLE
Rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,10 @@ before_script:
     - echo '[target.armv7-unknown-linux-gnueabihf]' > ~/.cargo/config
     - echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
     - rustup target add armv7-unknown-linux-gnueabihf
+    - rustup component add rustfmt
 
 script:
+    - cargo fmt --all -- --check
     - cargo build --locked --no-default-features
     - cargo build --locked --no-default-features --features "with-tremor"
     - cargo build --locked --no-default-features --features "with-vorbis"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,38 +2,30 @@
 
 ## Setup
 
-In order to contribute to librespot, you will first need to set up a suitable rust build environment, with the necessary dependenices installed. These instructions will walk you through setting up a simple build environment.
+In order to contribute to librespot, you will first need to set up a suitable Rust build environment, with the necessary dependencies installed. These instructions will walk you through setting up a simple build environment.
 
-You will need to have C compiler, rust, and portaudio installed.
+You will need to have C compiler, Rust, and alsa/portaudio libraries installed.
 
 ### Install Rust
 
-The easiest, and recommended way to get rust setu is to use [rustup](https://rustup.rs). You can install rustup with this command:
+The easiest, and recommended way to get Rust is to use [rustup](https://rustup.rs). You can install `rustup` with this command:
 
 ```bash
 curl https://sh.rustup.rs -sSf | sh
 ```
 
-Follow any prompts it gives you to install rust. Once that’s done, rust is ready to use.
- 
+Follow any prompts it gives you to install Rust. Once that’s done, Rust's standard tools should be setup and ready to use.
+
+#### Additional Rust tools - `rustfmt`
+To ensure a consistent codebase, install [`rustfmt`](https://github.com/rust-lang/rustfmt) via `rustup`.
+This is not optional, as Travis CI is set up to check that code is compliant with this repos style guides.
+```bash
+rustup component add rustfmt
+```
+
 ### Install Other Dependencies
-On debian / ubuntu, the following command will install these dependencies :
 
-```bash
-sudo apt-get install build-essential portaudio19-dev
-```
-
-On Fedora systems, the following command will install these dependencies :
-
-```bash
-sudo dnf install portaudio-devel make gcc
-```
-
-On macOS, using homebrew :
-
-```bash
-brew install portaudio
-```
+Install the required dependencies as described in the [Readme](https://github.com/librespot-org/librespot#building)
 
 ### Getting the Source
 
@@ -47,22 +39,6 @@ CD to the newly cloned repo...
 
 ```bash
 cd librespot
-```
-
-### Development Extra Steps
-
-If you are looking to carry out development on librespot:
-
-```bash
-rustup override set nightly
-```
-
-The command above overrides the default rust in the directory housing librespot to use the ```nightly``` version, as opposed to the ```stable``` version.
-
-Then, run the command below to install [rustfmt](https://github.com/rust-lang-nursery/rustfmt) for the ```nightly``` toolchain. This is not optional, as Travis CI is set up to check that code is compliant with rustfmt.
-
-```bash
-rustup component add rustfmt-preview
 ```
 
 ## Compiling & Running
@@ -87,7 +63,7 @@ You will most likely want to build debug builds when developing, as they are fas
 
 There are also a number of compiler feature flags that you can add, in the event that you want to have certain additional features also compiled. The list of these is available on the [wiki](https://github.com/librespot-org/librespot/wiki/Compiling#addition-features).
 
-By default, librespot compiles with the ```portaudio-backend``` feature. To compile without default features, you can run with:
+By default, librespot compiles with the ```rodio-backend``` feature. To compile without default features, you can run with:
 
 ```bash
 cargo build --no-default-features
@@ -112,7 +88,7 @@ If you have encountered a bug, please report it, as we rely on user reports to f
 Please also make sure that your issues are helpful. To ensure that your issue is helpful, please read over this brief checklist to avoid the more common pitfalls:
 
 	- Please take a moment to search/read previous similar issues to ensure you aren’t posting a duplicate. Duplicates will be closed immediately.
-	- Please include a clear description of what the issue is. Issues with descriptions such as ‘It hangs after 40 minutes’ will be closed immediately. 
+	- Please include a clear description of what the issue is. Issues with descriptions such as ‘It hangs after 40 minutes’ will be closed immediately.
 	- Please include, where possible, steps to reproduce the bug, along with any other material that is related to the bug. For example, if librespot consistently crashes when you try to play a song, please include the Spotify URI of that song. This can be immensely helpful in quickly pinpointing and resolving issues.
 	- Lastly, and perhaps most importantly, please include a backtrace where possible. Recent versions of librespot should produce these automatically when it crashes, and print them to the console, but in some cases, you may need to run ‘export RUST_BACKTRACE=full’ before running librespot to enable backtraces.
 
@@ -126,14 +102,13 @@ Fork -> Fix -> PR -> Review -> Merge
 
 This is how all code is added to the repository, even by those with write access.
 
-#### Steps before Commiting
+#### Steps before Committing
 
 In order to prepare for a PR, you will need to do a couple of things first:
 
 Make any changes that you are going to make to the code, but do not commit yet.
 
-Make sure you are using rust ```nightly``` to build librespot. Once this is confirmed, you will need to run the following command:
-
+Make sure that the code is formatted by running:
 ```bash
 cargo fmt --all
 ```

--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@
 # librespot
 *librespot* is an open source client library for Spotify. It enables
 applications to use Spotify's service, without using the official but
-closed-source libspotify. Additionally, it will provide extra features
+closed-source `libspotify`. Additionally, it will provide extra features
 which are not available in the official library.
 
-_Note: librespot only works with Spotify Premium. This will remain the case for the forseeable future, as we are unlikely to work on implementing the features such as limited skips and adverts that would be required to make librespot compliant with free accounts._
+_Note: librespot only works with Spotify Premium. This will remain the case for the foreseeable future, as we are unlikely to work on implementing the features such as limited skips and adverts that would be required to make librespot compliant with free accounts._
 
 ## This fork
 As the origin by [plietar](https://github.com/plietar/) is no longer actively maintained, this organisation and repository have been set up so that the project may be maintained and upgraded in the future.
@@ -28,9 +28,11 @@ If you run into a bug when using librespot, please search the existing issues be
 # Building
 Rust 1.30.0 or later is required to build librespot.
 
-We recently switched to using [Rodio](https://github.com/tomaka/rodio) for audio playback by default, hene for macOS and Windows, you should just be able to clone and build librespot (with the command below). For linux, you will need to run the additional commands below, depending on your distro.
+## Additional Dependencies
+We recently switched to using [Rodio](https://github.com/tomaka/rodio) for audio playback by default, hence for macOS and Windows, you should just be able to clone and build librespot (with the command below).
+For Linux, you will need to run the additional commands below, depending on your distro.
 
-On debian / ubuntu, the following command will install these dependencies :
+On Debian/Ubuntu, the following command will install these dependencies :
 ```shell
 sudo apt-get install build-essential libasound2-dev
 ```
@@ -40,7 +42,19 @@ On Fedora systems, the following command will install these dependencies :
 sudo dnf install alsa-lib-devel make gcc
 ```
 
-Once you've cloned this repository you can build *librespot* using `cargo`.
+librespot currently offers the a selection of [audio backends](https://github.com/librespot-org/librespot/wiki/Audio-Backends).
+```
+Rodio (default)
+ALSA
+PortAudio
+PulseAudio
+JACK
+SDL
+Pipe
+```
+Please check the corresponding [compiling wiki entry](https://github.com/librespot-org/librespot/wiki/Compiling#dependencies) for backend specific dependencies.
+
+Once you've installed the dependencies and cloned this repository you can build *librespot* with the default backend using Cargo.
 ```shell
 cargo build --release
 ```

--- a/audio/src/decrypt.rs
+++ b/audio/src/decrypt.rs
@@ -1,16 +1,13 @@
 use std::io;
 
-use aes_ctr::Aes128Ctr;
-use aes_ctr::stream_cipher::{
-    NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek
-};
 use aes_ctr::stream_cipher::generic_array::GenericArray;
+use aes_ctr::stream_cipher::{NewStreamCipher, SyncStreamCipher, SyncStreamCipherSeek};
+use aes_ctr::Aes128Ctr;
 
 use core::audio_key::AudioKey;
 
 const AUDIO_AESIV: [u8; 16] = [
-    0x72, 0xe0, 0x67, 0xfb, 0xdd, 0xcb, 0xcf, 0x77,
-    0xeb, 0xe8, 0xbc, 0x64, 0x3f, 0x63, 0x0d, 0x93,
+    0x72, 0xe0, 0x67, 0xfb, 0xdd, 0xcb, 0xcf, 0x77, 0xeb, 0xe8, 0xbc, 0x64, 0x3f, 0x63, 0x0d, 0x93,
 ];
 
 pub struct AudioDecrypt<T: io::Read> {

--- a/audio/src/fetch.rs
+++ b/audio/src/fetch.rs
@@ -349,7 +349,7 @@ impl Seek for AudioFileStreaming {
     fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
         self.position = try!(self.read_file.seek(pos));
         // Do not seek past EOF
-        if (self.position as usize % CHUNK_SIZE) != 0  {
+        if (self.position as usize % CHUNK_SIZE) != 0 {
             // Notify the fetch thread to get the correct block
             // This can fail if fetch thread has completed, in which case the
             // block is ready. Just ignore the error.

--- a/audio/src/lib.rs
+++ b/audio/src/lib.rs
@@ -3,12 +3,12 @@ extern crate futures;
 #[macro_use]
 extern crate log;
 
+extern crate aes_ctr;
 extern crate bit_set;
 extern crate byteorder;
 extern crate num_bigint;
 extern crate num_traits;
 extern crate tempfile;
-extern crate aes_ctr;
 
 extern crate librespot_core as core;
 

--- a/connect/src/discovery.rs
+++ b/connect/src/discovery.rs
@@ -1,13 +1,13 @@
-use base64;
-use sha1::{Sha1, Digest};
-use hmac::{Hmac, Mac};
-use aes_ctr::Aes128Ctr;
-use aes_ctr::stream_cipher::{NewStreamCipher, SyncStreamCipher};
 use aes_ctr::stream_cipher::generic_array::GenericArray;
+use aes_ctr::stream_cipher::{NewStreamCipher, SyncStreamCipher};
+use aes_ctr::Aes128Ctr;
+use base64;
 use futures::sync::mpsc;
 use futures::{Future, Poll, Stream};
+use hmac::{Hmac, Mac};
 use hyper::server::{Http, Request, Response, Service};
 use hyper::{self, Get, Post, StatusCode};
+use sha1::{Digest, Sha1};
 
 #[cfg(feature = "with-dns-sd")]
 use dns_sd::DNSService;
@@ -114,21 +114,18 @@ impl Discovery {
         let base_key = &base_key[..16];
 
         let checksum_key = {
-            let mut h = HmacSha1::new_varkey(base_key)
-                .expect("HMAC can take key of any size");
+            let mut h = HmacSha1::new_varkey(base_key).expect("HMAC can take key of any size");
             h.input(b"checksum");
             h.result().code()
         };
 
         let encryption_key = {
-            let mut h = HmacSha1::new_varkey(&base_key)
-                .expect("HMAC can take key of any size");
+            let mut h = HmacSha1::new_varkey(&base_key).expect("HMAC can take key of any size");
             h.input(b"encryption");
             h.result().code()
         };
 
-        let mut h = HmacSha1::new_varkey(&checksum_key)
-            .expect("HMAC can take key of any size");
+        let mut h = HmacSha1::new_varkey(&checksum_key).expect("HMAC can take key of any size");
         h.input(encrypted);
         if let Err(_) = h.verify(cksum) {
             warn!("Login error for user {:?}: MAC mismatch", username);
@@ -139,7 +136,7 @@ impl Discovery {
             });
 
             let body = result.to_string();
-            return ::futures::finished(Response::new().with_body(body))
+            return ::futures::finished(Response::new().with_body(body));
         }
 
         let decrypted = {
@@ -194,17 +191,18 @@ impl Service for Discovery {
             body.fold(Vec::new(), |mut acc, chunk| {
                 acc.extend_from_slice(chunk.as_ref());
                 Ok::<_, hyper::Error>(acc)
-            }).map(move |body| {
-                    params.extend(url::form_urlencoded::parse(&body).into_owned());
-                    params
-                })
-                .and_then(
-                    move |params| match (method, params.get("action").map(AsRef::as_ref)) {
-                        (Get, Some("getInfo")) => this.handle_get_info(&params),
-                        (Post, Some("addUser")) => this.handle_add_user(&params),
-                        _ => this.not_found(),
-                    },
-                ),
+            })
+            .map(move |body| {
+                params.extend(url::form_urlencoded::parse(&body).into_owned());
+                params
+            })
+            .and_then(move |params| {
+                match (method, params.get("action").map(AsRef::as_ref)) {
+                    (Get, Some("getInfo")) => this.handle_get_info(&params),
+                    (Post, Some("addUser")) => this.handle_add_user(&params),
+                    _ => this.not_found(),
+                }
+            }),
         )
     }
 }
@@ -235,7 +233,8 @@ pub fn discovery(
             &format!("0.0.0.0:{}", port).parse().unwrap(),
             &handle,
             move || Ok(discovery.clone()),
-        ).unwrap()
+        )
+        .unwrap()
     };
 
     let s_port = serve.incoming_ref().local_addr().port();
@@ -260,7 +259,8 @@ pub fn discovery(
         None,
         s_port,
         &["VERSION=1.0", "CPath=/"],
-    ).unwrap();
+    )
+    .unwrap();
 
     #[cfg(not(feature = "with-dns-sd"))]
     let responder = mdns::Responder::spawn(&handle)?;

--- a/connect/src/lib.rs
+++ b/connect/src/lib.rs
@@ -15,10 +15,10 @@ extern crate rand;
 extern crate tokio_core;
 extern crate url;
 
-extern crate sha1;
-extern crate hmac;
 extern crate aes_ctr;
 extern crate block_modes;
+extern crate hmac;
+extern crate sha1;
 
 #[cfg(feature = "with-dns-sd")]
 extern crate dns_sd;

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,8 +1,8 @@
 extern crate rand;
 extern crate vergen;
 
-use rand::Rng;
 use rand::distributions::Alphanumeric;
+use rand::Rng;
 use std::env;
 use std::fs::OpenOptions;
 use std::io::Write;
@@ -14,7 +14,10 @@ fn main() {
     vergen::vergen(vergen::OutputFns::all()).unwrap();
 
     let mut rng = rand::thread_rng();
-    let build_id: String = ::std::iter::repeat(()).map(|()| rng.sample(Alphanumeric)).take(8).collect();
+    let build_id: String = ::std::iter::repeat(())
+        .map(|()| rng.sample(Alphanumeric))
+        .take(8)
+        .collect();
 
     let mut version_file = OpenOptions::new()
         .write(true)

--- a/core/src/apresolve.rs
+++ b/core/src/apresolve.rs
@@ -10,7 +10,7 @@ use std::str::FromStr;
 use tokio_core::reactor::Handle;
 use url::Url;
 
-error_chain!{}
+error_chain! {}
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct APResolveData {

--- a/core/src/authentication.rs
+++ b/core/src/authentication.rs
@@ -1,12 +1,12 @@
+use aes::Aes192;
 use base64;
 use byteorder::{BigEndian, ByteOrder};
-use aes::Aes192;
 use hmac::Hmac;
-use sha1::{Sha1, Digest};
 use pbkdf2::pbkdf2;
 use protobuf::ProtobufEnum;
 use serde;
 use serde_json;
+use sha1::{Digest, Sha1};
 use std::fs::File;
 use std::io::{self, Read, Write};
 use std::ops::FnOnce;
@@ -76,9 +76,9 @@ impl Credentials {
 
         // decrypt data using ECB mode without padding
         let blob = {
-            use aes::block_cipher_trait::BlockCipher;
-            use aes::block_cipher_trait::generic_array::GenericArray;
             use aes::block_cipher_trait::generic_array::typenum::Unsigned;
+            use aes::block_cipher_trait::generic_array::GenericArray;
+            use aes::block_cipher_trait::BlockCipher;
 
             let mut data = base64::decode(encrypted_blob).unwrap();
             let cipher = Aes192::new(GenericArray::from_slice(&key));

--- a/core/src/connection/handshake.rs
+++ b/core/src/connection/handshake.rs
@@ -1,9 +1,9 @@
 use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
-use hmac::{Hmac, Mac};
-use sha1::Sha1;
 use futures::{Async, Future, Poll};
+use hmac::{Hmac, Mac};
 use protobuf::{self, Message};
 use rand::thread_rng;
+use sha1::Sha1;
 use std::io::{self, Read};
 use std::marker::PhantomData;
 use tokio_codec::{Decoder, Framed};
@@ -190,15 +190,13 @@ fn compute_keys(shared_secret: &[u8], packets: &[u8]) -> (Vec<u8>, Vec<u8>, Vec<
 
     let mut data = Vec::with_capacity(0x64);
     for i in 1..6 {
-        let mut mac = HmacSha1::new_varkey(&shared_secret)
-            .expect("HMAC can take key of any size");
+        let mut mac = HmacSha1::new_varkey(&shared_secret).expect("HMAC can take key of any size");
         mac.input(packets);
         mac.input(&[i]);
         data.extend_from_slice(&mac.result().code());
     }
 
-    let mut mac = HmacSha1::new_varkey(&data[..0x14])
-        .expect("HMAC can take key of any size");;
+    let mut mac = HmacSha1::new_varkey(&data[..0x14]).expect("HMAC can take key of any size");;
     mac.input(packets);
 
     (

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -8,9 +8,9 @@ use futures::{Future, Sink, Stream};
 use protobuf::{self, Message};
 use std::io;
 use std::net::ToSocketAddrs;
+use tokio_codec::Framed;
 use tokio_core::net::TcpStream;
 use tokio_core::reactor::Handle;
-use tokio_codec::Framed;
 use url::Url;
 
 use authentication::Credentials;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,30 +11,30 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 
+extern crate aes;
 extern crate base64;
 extern crate byteorder;
 extern crate bytes;
 extern crate extprim;
+extern crate hmac;
 extern crate httparse;
 extern crate hyper;
 extern crate hyper_proxy;
 extern crate num_bigint;
 extern crate num_integer;
 extern crate num_traits;
+extern crate pbkdf2;
 extern crate protobuf;
 extern crate rand;
 extern crate serde;
 extern crate serde_json;
+extern crate sha1;
 extern crate shannon;
 extern crate tokio_codec;
 extern crate tokio_core;
 extern crate tokio_io;
 extern crate url;
 extern crate uuid;
-extern crate sha1;
-extern crate hmac;
-extern crate pbkdf2;
-extern crate aes;
 
 extern crate librespot_protocol as protocol;
 

--- a/core/src/mercury/types.rs
+++ b/core/src/mercury/types.rs
@@ -37,7 +37,8 @@ impl ToString for MercuryMethod {
             MercuryMethod::SUB => "SUB",
             MercuryMethod::UNSUB => "UNSUB",
             MercuryMethod::SEND => "SEND",
-        }.to_owned()
+        }
+        .to_owned()
     }
 }
 

--- a/core/src/proxytunnel.rs
+++ b/core/src/proxytunnel.rs
@@ -102,7 +102,8 @@ fn proxy_connect<T: AsyncWrite>(connection: T, connect_url: &str) -> WriteAll<T,
          \r\n",
         uri.host().expect(&format!("No host in {}", uri)),
         uri.port().expect(&format!("No port in {}", uri))
-    ).into_bytes();
+    )
+    .into_bytes();
 
     write_all(connection, buffer)
 }

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -1,12 +1,12 @@
 use std::io;
+use std::sync::atomic::{AtomicUsize, Ordering, ATOMIC_USIZE_INIT};
 use std::sync::{Arc, RwLock, Weak};
-use std::sync::atomic::{ATOMIC_USIZE_INIT, AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
-use futures::{Async, Future, IntoFuture, Poll, Stream};
 use futures::sync::mpsc;
+use futures::{Async, Future, IntoFuture, Poll, Stream};
 use tokio_core::reactor::{Handle, Remote};
 
 use apresolve::apresolve_or_fallback;
@@ -289,7 +289,8 @@ where
                     session.shutdown();
                     return Err(From::from(e));
                 }
-            }.expect("connection closed");
+            }
+            .expect("connection closed");
 
             session.dispatch(cmd, data);
         }

--- a/playback/src/audio_backend/alsa.rs
+++ b/playback/src/audio_backend/alsa.rs
@@ -64,7 +64,8 @@ impl Open for AlsaSink {
             }
             Some(device) => device,
             None => "default",
-        }.to_string();
+        }
+        .to_string();
 
         AlsaSink(None, name)
     }

--- a/playback/src/audio_backend/portaudio.rs
+++ b/playback/src/audio_backend/portaudio.rs
@@ -51,7 +51,8 @@ impl<'a> Open for PortAudioSink<'a> {
             }
             Some(device) => find_output(device),
             None => get_default_output_index(),
-        }.expect("Could not find device");
+        }
+        .expect("Could not find device");
 
         let info = portaudio_rs::device::get_info(device_idx);
         let latency = match info {
@@ -81,7 +82,8 @@ impl<'a> Sink for PortAudioSink<'a> {
                     FRAMES_PER_BUFFER_UNSPECIFIED,
                     StreamFlags::empty(),
                     None,
-                ).unwrap(),
+                )
+                .unwrap(),
             );;
         }
 

--- a/playback/src/audio_backend/rodio.rs
+++ b/playback/src/audio_backend/rodio.rs
@@ -1,8 +1,8 @@
 use super::{Open, Sink};
-extern crate rodio;
 extern crate cpal;
-use std::{io, thread, time};
+extern crate rodio;
 use std::process::exit;
+use std::{io, thread, time};
 
 pub struct RodioSink {
     rodio_sink: rodio::Sink,
@@ -14,7 +14,7 @@ fn list_formats(ref device: &rodio::Device) {
         Err(e) => {
             warn!("Error getting default rodio::Sink format: {:?}", e);
             return;
-        },
+        }
     };
 
     let mut output_formats = match device.supported_output_formats() {
@@ -22,13 +22,16 @@ fn list_formats(ref device: &rodio::Device) {
         Err(e) => {
             warn!("Error getting supported rodio::Sink formats: {:?}", e);
             return;
-        },
+        }
     };
 
     if output_formats.peek().is_some() {
         debug!("  Available formats:");
         for format in output_formats {
-            let s = format!("{}ch, {:?}, min {:?}, max {:?}", format.channels, format.data_type, format.min_sample_rate, format.max_sample_rate);
+            let s = format!(
+                "{}ch, {:?}, min {:?}, max {:?}",
+                format.channels, format.data_type, format.min_sample_rate, format.max_sample_rate
+            );
             if format == default_fmt {
                 debug!("    (default) {}", s);
             } else {
@@ -79,9 +82,7 @@ impl Open for RodioSink {
         }
         let sink = rodio::Sink::new(&rodio_device);
 
-        RodioSink {
-            rodio_sink: sink,
-        }
+        RodioSink { rodio_sink: sink }
     }
 }
 

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -28,10 +28,11 @@ pub struct MixerConfig {
 }
 
 impl Default for MixerConfig {
-    fn default() -> MixerConfig { MixerConfig {
-        card: String::from("default"),
-        mixer: String::from("PCM"),
-        index: 0,
+    fn default() -> MixerConfig {
+        MixerConfig {
+            card: String::from("default"),
+            mixer: String::from("PCM"),
+            index: 0,
         }
     }
 }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -557,12 +557,8 @@ impl PlayerInternal {
             }
         };
 
-        let key = self
-            .session
-            .audio_key()
-            .request(track.id, file_id);
+        let key = self.session.audio_key().request(track.id, file_id);
         let encrypted_file = AudioFile::open(&self.session, file_id);
-
 
         let encrypted_file = encrypted_file.wait().unwrap();
         let key = key.wait().unwrap();

--- a/protocol/build.rs
+++ b/protocol/build.rs
@@ -19,7 +19,8 @@ fn main() {
                 input: &[path],
                 includes: &["proto"],
                 customize: Customize { ..Default::default() },
-            }).expect("protoc");
+            })
+            .expect("protoc");
             let new_checksum = cksum_file(path).unwrap();
             f_str = f_str.replace(&expected_checksum.to_string(), &new_checksum.to_string());
             changed = true;

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,3 @@
 max_width = 105
 reorder_imports = true
-reorder_imports_in_group = true
 reorder_modules = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,18 +4,18 @@ extern crate getopts;
 extern crate librespot;
 #[macro_use]
 extern crate log;
+extern crate hex;
 extern crate rpassword;
+extern crate sha1;
 extern crate tokio_core;
 extern crate tokio_io;
 extern crate tokio_process;
 extern crate tokio_signal;
 extern crate url;
-extern crate sha1;
-extern crate hex;
 
-use sha1::{Sha1, Digest};
 use futures::sync::mpsc::UnboundedReceiver;
 use futures::{Async, Future, Poll, Stream};
+use sha1::{Digest, Sha1};
 use std::env;
 use std::io::{self, stderr, Write};
 use std::mem;
@@ -249,7 +249,8 @@ fn setup(args: &[String]) -> Setup {
                 panic!("Initial volume must be in the range 0-100");
             }
             (volume as i32 * 0xFFFF / 100) as u16
-        }).or_else(|| cache.as_ref().and_then(Cache::volume))
+        })
+        .or_else(|| cache.as_ref().and_then(Cache::volume))
         .unwrap_or(0x8000);
 
     let zeroconf_port = matches
@@ -503,13 +504,14 @@ impl Future for Main {
                     if let Some(ref program) = self.player_event_program {
                         let child = run_program_on_events(event, program)
                             .expect("program failed to start")
-                            .map(|status| if !status.success() {
-                                error!("child exited with status {:?}", status.code());
+                            .map(|status| {
+                                if !status.success() {
+                                    error!("child exited with status {:?}", status.code());
+                                }
                             })
                             .map_err(|e| error!("failed to wait on child process: {}", e));
 
                         self.handle.spawn(child);
-
                     }
                 }
             }

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -1,8 +1,8 @@
 use librespot::playback::player::PlayerEvent;
-use tokio_process::{Child, CommandExt};
 use std::collections::HashMap;
 use std::io;
 use std::process::Command;
+use tokio_process::{Child, CommandExt};
 
 fn run_program(program: &str, env_vars: HashMap<&str, String>) -> io::Result<Child> {
     let mut v: Vec<&str> = program.split_whitespace().collect();


### PR DESCRIPTION
`rustfmt` ~is~ *seems to be*  much more stable than when it was removed back in https://github.com/librespot-org/librespot/issues/208

This PR:
1. Removes deprecated `reorder_imports_in_group` as it's now combined with `reorder_imports`
2. Add `rustfmt` checks to Travis (only for stable)
3. Format the entire codebase (with `rustfmt 1.2.2-stable`)
4. Update `Contributing.md` (and `Readme.md` while I was at it)
   - I also removed removed `nightly` requirement for development - as `rustfmt` is available on the stable channel.  Or was there other reasons for the `nightly` requirement?


