### PR TITLE
add pkg-config and some configuration to Dockerfile.Rpi to allow cross-compilation

### DIFF
--- a/contrib/Dockerfile.Rpi
+++ b/contrib/Dockerfile.Rpi
@@ -24,6 +24,7 @@ RUN apt-get update
 
 RUN apt-get install -y curl git build-essential crossbuild-essential-armhf
 RUN apt-get install -y libasound2-dev libasound2-dev:armhf
+RUN apt-get install -y pkg-config
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin/:${PATH}"
@@ -35,9 +36,12 @@ RUN mkdir /.cargo && \
 RUN mkdir /build
 ENV CARGO_TARGET_DIR /build
 ENV CARGO_HOME /build/cache
+ENV PKG_CONFIG_PATH /usr/lib/arm-linux-gnueabihf/pkgconfig/
+ENV PKG_CONFIG_ALLOW_CROSS 1
 
 ADD . /src
 WORKDIR /src
+
 RUN cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend"
 
 


### PR DESCRIPTION
When cross-compiling using Dockerfile.Rpi I came across the following errors

```
...
Compiling c2-chacha v0.2.2
   Compiling thread_local v0.3.6
   Compiling lock_api v0.1.5

   Compiling rustc_version v0.2.3
error: failed to run custom build command for `alsa-sys v0.1.2`

Caused by:
  process didn't exit successfully: `/build/release/build/alsa-sys-9e3efef5874a428f/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "Cross compilation detected. Use PKG_CONFIG_ALLOW_CROSS=1 to override"', src/libcore/result.rs:999:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

warning: build failed, waiting for other jobs to finish...
```

and 

```
....
Compiling crossbeam-utils v0.6.6
   Compiling c2-chacha v0.2.2
   Compiling thread_local v0.3.6
   Compiling lock_api v0.1.5
   Compiling rustc_version v0.2.3
error: failed to run custom build command for `alsa-sys v0.1.2`

Caused by:
  process didn't exit successfully: `/build/release/build/alsa-sys-9e3efef5874a428f/build-script-build` (exit code: 101)
--- stderr
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: "Failed to run `\"pkg-config\" \"--libs\" \"--cflags\" \"alsa\"`: No such file or directory (os error 2)"', src/libcore/result.rs:999:5
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace.

warning: build failed, waiting for other jobs to finish...
error: build failed
```

and 

```
....

error: linking with `arm-linux-gnueabihf-gcc` failed: exit code: 1
  |
  = note: "arm-linux-gnueabihf-gcc" "-Wl,--as-needed" "-Wl,-z,noexecstack" "-L" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.0.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.1.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.10.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.11.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.12.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.13.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.14.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.15.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.2.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.3.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.4.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.5.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.6.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.7.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.8.rcgu.o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.librespot.acrvotec-cgu.9.rcgu.o" "-o" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909" "/build/arm-unknown-linux-gnueabihf/release/deps/librespot-825a7b55b9315909.3f7ctbpc3dbyu3ys.rcgu.o" "-Wl,--gc-sections" "-pie" "-Wl,-zrelro" "-Wl,-znow" "-Wl,-O1" "-nodefaultlibs" "-L" "/build/arm-unknown-linux-gnueabihf/release/deps" "-L" "/build/release/deps" "-L" "/usr/lib/x86_64-linux-gnu" "-L" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib" "-Wl,-Bstatic" "/build/arm-unknown-linux-gnueabihf/release/deps/libhex-371adc3991b523dc.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_process-520b5238dc16094c.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_signal-4ca81d2961a08579.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libsignal_hook-6819d4af74065fce.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libsignal_hook_registry-0e7b472cb5e92d1a.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libarc_swap-189903b703ca1802.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librpassword-e2f317294d3f0742.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblibrespot-7b8cad692dd63b0e.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblibrespot_connect-d180bc069b88d006.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblibrespot_playback-005e111436f0c003.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblibrespot_metadata-1a4e7f450e9b4a58.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblinear_map-4d88a7618cdd8897.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libalsa-f86a29741b64705e.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libnix-3b948bf850aa9c8c.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbitflags-13b95fe401271d6f.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libalsa_sys-22c756ff7baecd75.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libmdns-c2764205c6ab0c6a.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libnix-4ec818c6a6763737.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libvoid-6b7886eb558c7a79.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbitflags-73b62c80a6f7438e.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libmultimap-64e97b7546dd881d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libget_if_addrs-a4328f55383e4643.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libc_linked_list-1ab619a0e3cd9a8e.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libdns_parser-90f968795bce1d15.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbyteorder-5f9a74b1680f03ad.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libblock_modes-8d178f0e22e01198.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblibrespot_audio-8e1cdd3dfadf611a.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblewton-31c9fc5a2d6062f8.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libogg-e2946941110f7d80.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblibrespot_core-72360dbc69325412.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblibrespot_protocol-8995db0d799b05ff.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libaes-a8f5f00b6737bdc9.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libpbkdf2-2dcf561e72e8a137.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libsha2-47648d844b006405.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand-c090e307aff08545.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libhmac-d79d6a5c60e436ec.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libcrypto_mac-fcdbc2c2bd476a7f.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libsubtle-3d95d3c0ffca37dd.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libsha1-8f2b744a25ba5803.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libfake_simd-0651912609bf5b31.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libdigest-76af9542f015a261.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libblock_buffer-3d23b7cf58c17b69.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libblock_padding-245c7d2c030bd2a5.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbyte_tools-121398a8fbc72c78.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libuuid-f464bb17240cc1c7.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libshannon-d948fc09f9f97041.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libserde_json-200d1076cacf2976.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libryu-cbb71d345a23fee2.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libitoa-9cf4c68384cc0351.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libhyper_proxy-7c9cc7e417bbecb6.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libextprim-205023890a3385de.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libserde-ec883b5286cc850d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liberror_chain-ef81db7ff94905b8.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libaes_ctr-6e278cb24790bc95.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libaes_soft-009c63923d6c81be.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libopaque_debug-bf4a004be2d1c9c0.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libctr-708d5e591a93a674.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libblock_cipher_trait-d15a33646b19a9fd.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libstream_cipher-37de7547d2aaf1a1.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libgeneric_array-e8dfb981d5324a74.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtypenum-941fd0118e467f59.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtempfile-d5547349b4443224.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libremove_dir_all-b89c9dca6e499d47.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbit_set-11f4ed265b9289eb.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbit_vec-df4059652f4c0e4f.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liburl-294016ac4014a08b.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libidna-cfdc77bc701da003.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libunicode_normalization-9846f6b700cb10ef.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libunicode_bidi-ab6ec0a123191e92.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libmatches-fe3d2f610c8de81b.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand-b3a104889609114d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_chacha-882bc1c24ffabb15.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libc2_chacha-c202bb1041fa7d25.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libppv_lite86-94a66ca1150ce73d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_core-db96f3fc3259bc67.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libgetrandom-c47027cbc5565ad4.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libprotobuf-212c19829c033538.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libnum_bigint-332ccbdabbf31dea.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libnum_integer-1128c49779767dd5.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libnum_traits-9b79349a12fb682b.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libhyper-157e70f0e012aa74.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libwant-b2e83d59d1850eff.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtry_lock-4092b7396befdbec.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_proto-62152c92a6d86eb6.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblog-d8ee517866546cb7.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_service-0d00c38b22a0efa8.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtake-f16ae2e46ef79a36.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libsmallvec-5abbd0937f5ee44d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libslab-44e2d37f010e252b.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand-c1f7fe78e61a5ecb.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand-78b226f8ad39f4fe.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_core-e45e6a852a3be88e.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libscoped_tls-7a78ab294b102b40.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio-b05e60bc66b57896.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_uds-22d8d91061999915.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libmio_uds-24baa2bddbd251f0.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_udp-49700384cdfe76a0.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_timer-7657f29dd1fe6359.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_tcp-16ee5379dc4bdb5d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_reactor-fa2021cf64f53c9d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_sync-55ed9df38c94e166.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libfnv-ad8d1f973689d544.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libparking_lot-280bb0849c71b8a5.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libparking_lot_core-6f220f4f92ed7413.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libsmallvec-1e9367dc86d4326d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblock_api-f85651c4d754fde6.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libowning_ref-4fa19cae77ccc9a5.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libstable_deref_trait-57b8abb90dfc1c52.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libscopeguard-57343b9350b3a3ed.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_fs-3c9187639f054a04.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_threadpool-94c467a84c5801e9.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand-b51a44f7d18fa5d8.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_xorshift-9580dedb269161ff.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_pcg-77cc182d9596698a.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_hc-a95f9af4157536e1.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_chacha-392123b5daf45257.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_isaac-a89525b0dadbf9fa.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_core-09f12d39aedd9216.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_os-df6aadd1b1a10955.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_jitter-dd25a1df9a18c83a.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librand_core-fbb623ced0a9281a.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libcrossbeam_queue-43775bcd7d3311da.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libcrossbeam_deque-75e24bdf11767a89.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libcrossbeam_epoch-a06bba01a9ac2d61.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libscopeguard-8d67412825b169b9.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libmemoffset-f51c5982b098fa2c.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libarrayvec-2e3efc60332bb968.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libnodrop-ca1d2d29e597e618.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_current_thread-dbfdd064cdf95784.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_executor-c10e2d785602362f.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libcrossbeam_utils-abd0ed4be4a448b1.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_codec-2baf01e0440f0577.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtokio_io-6c77fe6d67124e87.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libmio-5186a87d19f79167.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libslab-5032c140528b38c5.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtime-c7020c9755682a18.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/librelay-f12f7f11684ff6f5.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libpercent_encoding-6102bec6ec0af2df.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libnet2-91e75faa05a20277.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libmime-84d389623177dfe6.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libunicase-c41a449ebad55eeb.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblanguage_tags-e4ed8fdd1e57a553.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libhttparse-2d06c063665b2ebf.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libfutures_cpupool-a6c7fe4268aabf59.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libnum_cpus-ca4cf3e8e562413d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbytes-297b4fd9bbd9e767.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libiovec-f0fc27abb5f7a30c.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbase64-0c1cc3a0d26c3e25.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libsafemem-589607c96509ed44.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbase64-9fe2c9785c8226ee.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libbyteorder-10525dbecf066c58.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libgetopts-2a5fd15186ac3fb2.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libunicode_width-6e1427a36427fd6c.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libfutures-7da1d24fe286826d.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libenv_logger-10112ab162d0c331.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libregex-a59b78ff230213f6.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libutf8_ranges-24f0c248b6893abd.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libregex_syntax-2980fb73b94a9a90.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libucd_util-82204ed4abc975b5.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libthread_local-3ee085e9d13ac16f.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblazy_static-ad0512659ac2620a.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libspin-397eb7dde063b1c7.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libaho_corasick-7496125c80c17198.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libmemchr-f38b6492419e2d89.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libatty-e7652113508a084a.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblibc-640e5d7f44794ba7.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libhumantime-384a6681576e0315.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libquick_error-6469266eeadc7beb.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libtermcolor-e2d8d8eb9ba33820.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/liblog-1eed4c322b02b1d9.rlib" "/build/arm-unknown-linux-gnueabihf/release/deps/libcfg_if-789e1aa6dbe085d4.rlib" "-Wl,--start-group" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libstd-83a4f058944e6814.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libpanic_unwind-e11c7b3b3225afe2.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libbacktrace-13217ede3d276f16.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libbacktrace_sys-621a9ee22da6caa1.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/librustc_demangle-546c844e8071bbeb.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libhashbrown-be9569e4d599746f.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/librustc_std_workspace_alloc-47d8845cef2a3bc5.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libunwind-017511bce73a530c.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libcfg_if-be7979c57a08057b.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/liblibc-d6459c4f0817c67c.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/liballoc-580035dd98451925.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/librustc_std_workspace_core-aee5c24fff305dea.rlib" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libcore-8a55a4098920125a.rlib" "-Wl,--end-group" "/root/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/arm-unknown-linux-gnueabihf/lib/libcompiler_builtins-9fc4b5be2ba5cc19.rlib" "-Wl,-Bdynamic" "-lasound" "-lutil" "-lutil" "-ldl" "-lrt" "-lpthread" "-lgcc_s" "-lc" "-lm" "-lrt" "-lpthread" "-lutil" "-lutil"
  = note: /usr/lib/x86_64-linux-gnu/libasound.so: file not recognized: File format not recognized
          collect2: error: ld returned 1 exit status


error: aborting due to previous error

error: Could not compile `librespot`.

To learn more, run the command again with --verbose.

```

this commit fixes all three errors. With it I could successfully compile the binary for Rpi4