### PR TITLE
Lock Rodio to v0.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -946,7 +946,7 @@ dependencies = [
  "librespot-metadata 0.1.0",
  "log 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "portaudio-rs 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "rodio 0.9.0 (git+https://github.com/tomaka/rodio)",
+ "rodio 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "sdl2 0.32.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1649,7 +1649,7 @@ dependencies = [
 [[package]]
 name = "rodio"
 version = "0.9.0"
-source = "git+https://github.com/tomaka/rodio#655d05100f1ba695bcc93b8733216de37d0c5432"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "cpal 0.8.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2621,7 +2621,7 @@ dependencies = [
 "checksum regex-syntax 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "cd5485bf1523a9ed51c4964273f22f63f24e31632adb5dad134f488f86a3875c"
 "checksum relay 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "1576e382688d7e9deecea24417e350d3062d97e32e45d70b1cde65994ff1489a"
 "checksum remove_dir_all 0.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "4a83fa3702a688b9359eccba92d153ac33fd2e8462f9e0e3fdf155239ea7792e"
-"checksum rodio 0.9.0 (git+https://github.com/tomaka/rodio)" = "<none>"
+"checksum rodio 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d0f961b254e66d147a7b550c78b01308934c97d807a34b417fd0f5a0a0f3a2d"
 "checksum rpassword 3.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c34fa7bcae7fca3c8471e8417088bbc3ad9af8066b0ecf4f3c0d98a0d772716e"
 "checksum rustc-demangle 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "a7f4dccf6f4891ebcc0c39f9b6eb1a83b9bf5d747cb439ec6fba4f3b977038af"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -20,7 +20,7 @@ portaudio-rs    = { version = "0.3.0", optional = true }
 libpulse-sys    = { version = "0.0.0", optional = true }
 jack            = { version = "0.5.3", optional = true }
 libc            = { version = "0.2", optional = true }
-rodio           = { git = "https://github.com/tomaka/rodio", optional = true, default-features = false }
+rodio           = { version = "0.9", optional = true, default-features = false }
 cpal            = { version = "0.8", optional = true }
 sdl2            = { version = "0.32", optional = true }
 


### PR DESCRIPTION
`rodio` pushed a change (https://github.com/RustAudio/rodio/commit/0151398043a07e0b44583f03e77ad8ab935c3dbc) to, updating the dependency `cpal` to `v0.10`, which is incompatible with the current `librespot` implementation.

This wouldn't be noticeable when working with `librespot` directly based on how Cargo resolves dependencies (I think, still figuring this whole Rust thing out), but if `librespot` is being used as a dependency in another project, then the newer `cpal` crate also gets pulled in, and `librespot` won't compile.

The change in `rodio` has only occurred in the repository, there hasn't been a new version published, so I figured it would be better to pin the dependency version for the time being.