### PR TITLE
Ignore false shuffle/repeat when changing contexts to match Android behaviour (fixes: #266)

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -807,8 +807,16 @@ impl SpircTask {
         self.state.set_playing_track_index(index);
         self.state.set_track(tracks.into_iter().cloned().collect());
         self.state.set_context_uri(context_uri);
-        self.state.set_repeat(frame.get_state().get_repeat());
-        self.state.set_shuffle(frame.get_state().get_shuffle());
+        // has_shuffle/repeat seem to always be true in these replace msgs,
+        // but to replicate the behaviour of the Android client we have to
+        // ignore false values.
+        let state = frame.get_state();
+        if state.get_repeat() {
+            self.state.set_repeat(true);
+        }
+        if state.get_shuffle() {
+            self.state.set_shuffle(true);
+        }
     }
 
     fn load_track(&mut self, play: bool) {


### PR DESCRIPTION
Seems strange that these fields return true in the has_ methods when as far as I can tell it's impossible to remove the shuffle/repeat state in the client without explicitly toggling them with their dedicated buttons.

@devgianlu You mention in #266 that that librespot-java might handle this better, (I couldn't get it to work with Zeroconf on my windows laptop, I'll try again later), but [browsing the code](https://github.com/librespot-org/librespot-java/blob/0a08ba32eb8036f96a65f1cc57e1ea155da52ff1/core/src/main/java/xyz/gianlu/librespot/player/StateWrapper.java#L251) I couldn't see anything like this so I'm curious if the shuffle state does actually work better over there? Perhaps you've found a better solution.

EDIT: It would be great if a few people could try this out and see if they can get inconsistent behaviour between an official client and Librespot with these changes.