### PR TITLE
[Travis] Reduce cache bloat - don't save build artefacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,17 @@ rust:
   - nightly
 
 cache: cargo
-
+# Reduce cache bloat 
+before_cache:
+  - rm -rfv "$TRAVIS_HOME/.cargo/registry/src"
+  - rm -rfv target/debug/incremental/{librespot,build_script_build}-*
+  - rm -rfv target/debug/.fingerprint/librespot-*
+  - rm -rfv target/debug/build/librespot-*
+  - rm -rfv target/debug/deps/liblibrespot-*
+  - rm -rfv target/debug/deps/librespot-*
+  - rm -rfv target/debug/{librespot,liblibrespot}.d
+  - cargo clean -p librespot librespot-core librespot-connect librespot-audio librespot-metadata  librespot-playback
+  
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ before_script:
 
 script:
     - cargo build --locked --no-default-features
+    - cargo build --locked --examples
     - cargo build --locked --no-default-features --features "with-tremor"
     - cargo build --locked --no-default-features --features "with-vorbis"
     - cargo build --locked --no-default-features --features "alsa-backend"


### PR DESCRIPTION
[Travis adds all build](https://docs.travis-ci.com/user/languages/rust/#dependency-management) artefacts to the cache, which gets quite big quite soon. 
Some googlefoo suggests that we can remove some of these to reduce the bloat. 

I also bumped up the number of concurrent builds, so each Rust version job should now run in parallel. 