### PR TITLE
readme related project rpi-audio-receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ This is a non exhaustive list of projects that either use or have modified libre
 - [plugin.audio.spotify](https://github.com/marcelveldt/plugin.audio.spotify) - A Kodi plugin for Spotify.
 - [raspotify](https://github.com/dtcooper/raspotify) - Spotify Connect client for the Raspberry Pi that Just Works™
 - [Spotifyd](https://github.com/Spotifyd/spotifyd) - A stripped down librespot UNIX daemon.
+- [rpi-audio-receiver](https://github.com/nicokaiser/rpi-audio-receiver) - easy Raspbian install scripts for Spotifyd, Bluetooth, Shairport and other audio receivers
 - [Spotcontrol](https://github.com/badfortrains/spotcontrol) - A golang implementation of a Spotify Connect controller. No playback
 functionality.
 - [librespot-java](https://github.com/devgianlu/librespot-java) - A Java port of librespot.


### PR DESCRIPTION
Hi this PR is a documentation-only change to mention the related rpi-audio-receiver project by @nicokaiser that makes it easy to install Spotifyd and other audio reveiver protocols onto Raspbian. Thanks for all your great work on librespot. ArtMG