### PR TITLE
Fix error handling for closed channel.

### DIFF
--- a/core/src/channel.rs
+++ b/core/src/channel.rs
@@ -92,7 +92,8 @@ impl ChannelManager {
 impl Channel {
     fn recv_packet(&mut self) -> Poll<Bytes, ChannelError> {
         let (cmd, packet) = match self.receiver.poll() {
-            Ok(Async::Ready(t)) => t.expect("channel closed"),
+            Ok(Async::Ready(Some(t))) => t,
+            Ok(Async::Ready(None)) => return Err(ChannelError), // The channel has been closed.
             Ok(Async::NotReady) => return Ok(Async::NotReady),
             Err(()) => unreachable!(),
         };


### PR DESCRIPTION
I improved the error handling of the channel receiver to avoid crashing if the channel has been closed.

This (hopefully) fixes #417 (crash when changing accounts). Unfortunately I can't test this myself at the moment because I don't have two accounts at hand.

fixes #417