### PR TITLE
Prevent spirc from crashing when the queue is empty.

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -534,6 +534,8 @@ impl SpircTask {
                 } else {
                     info!("No more tracks left in queue");
                     self.state.set_status(PlayStatus::kPlayStatusStop);
+                    self.player.stop();
+                    self.mixer.stop();
                 }
 
                 self.notify(None);
@@ -670,11 +672,12 @@ impl SpircTask {
         // Removes current track if it is queued
         // Returns the index of the next track
         let current_index = self.state.get_playing_track_index() as usize;
-        if self.state.get_track()[current_index].get_queued() {
+        if (current_index < self.state.get_track().len()) && self.state.get_track()[current_index].get_queued() {
             self.state.mut_track().remove(current_index);
-            return current_index;
+            current_index
+        } else {
+            current_index + 1
         }
-        current_index + 1
     }
 
     fn handle_next(&mut self) {
@@ -706,12 +709,23 @@ impl SpircTask {
             new_index = 0; // Loop around back to start
             continue_playing = self.state.get_repeat();
         }
-        self.state.set_playing_track_index(new_index);
-        self.state.set_position_ms(0);
-        let now = self.now_ms();
-        self.state.set_position_measured_at(now as u64);
 
-        self.load_track(continue_playing);
+        if tracks_len > 0 {
+            self.state.set_playing_track_index(new_index);
+            self.state.set_position_ms(0);
+            let now = self.now_ms();
+            self.state.set_position_measured_at(now as u64);
+
+            self.load_track(continue_playing);
+
+         } else {
+            info!("Not playing next track because there are no more tracks left in queue.");
+            self.state.set_playing_track_index(0);
+            self.state.set_status(PlayStatus::kPlayStatusStop);
+            self.player.stop();
+            self.mixer.stop();
+        }
+
     }
 
     fn handle_prev(&mut self) {


### PR DESCRIPTION
I investigated a panic I observed. spirc's handle_next was called on an empty queue resulting in an index violation on the queue. I modified the code to catch this kind of situation.

Unfortunately I don't know how to reproduce this situation - I only saw it in the logs and we were mucking around with spotify quite a bit at the time so I don't know which of our actions caused it. Nevertheless I think it's worth fixing.