### PR TITLE
Gapless play and improved notifications

### DIFF
--- a/audio/src/fetch.rs
+++ b/audio/src/fetch.rs
@@ -144,6 +144,15 @@ impl StreamLoaderController {
         }
     }
 
+    pub fn range_to_end_available(&self) -> bool {
+        if let Some(ref shared) = self.stream_shared {
+            let read_position = shared.read_position.load(atomic::Ordering::Relaxed);
+            self.range_available(Range::new(read_position, self.len() - read_position))
+        } else {
+            true
+        }
+    }
+
     pub fn ping_time_ms(&self) -> usize {
         if let Some(ref shared) = self.stream_shared {
             return shared.ping_time_ms.load(atomic::Ordering::Relaxed);

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1197,54 +1197,6 @@ impl SpircTask {
         }
     }
 
-    //    fn load_track(&mut self, start_playing: bool, position_ms: u32) {
-    //        let context_uri = self.state.get_context_uri().to_owned();
-    //        let mut index = self.state.get_playing_track_index();
-    //        let start_index = index;
-    //        let tracks_len = self.state.get_track().len() as u32;
-    //        debug!(
-    //            "Loading context: <{}> index: [{}] of {}",
-    //            context_uri, index, tracks_len
-    //        );
-    //        // Cycle through all tracks, break if we don't find any playable tracks
-    //        // TODO: This will panic if no playable tracks are found!
-    //        // tracks in each frame either have a gid or uri (that may or may not be a valid track)
-    //        // E.g - context based frames sometimes contain tracks with <spotify:meta:page:>
-    //        let track = {
-    //            let mut track_ref = self.state.get_track()[index as usize].clone();
-    //            let mut track_id = self.get_spotify_id_for_track(&track_ref);
-    //            while track_id.is_err() || track_id.unwrap().audio_type == SpotifyAudioType::NonPlayable
-    //            {
-    //                warn!(
-    //                    "Skipping track <{:?}> at position [{}] of {}",
-    //                    track_ref.get_uri(),
-    //                    index,
-    //                    tracks_len
-    //                );
-    //                index = if index + 1 < tracks_len { index + 1 } else { 0 };
-    //                self.state.set_playing_track_index(index);
-    //                if index == start_index {
-    //                    warn!("No playable track found in state: {:?}", self.state);
-    //                    break;
-    //                }
-    //                track_ref = self.state.get_track()[index as usize].clone();
-    //                track_id = self.get_spotify_id_for_track(&track_ref);
-    //            }
-    //            track_id
-    //        }
-    //            .expect("Invalid SpotifyId");
-    //
-    //        self.play_request_id = Some(self.player.load(track, start_playing, position_ms));
-    //
-    //        self.update_state_position(position_ms);
-    //        self.state.set_status(PlayStatus::kPlayStatusLoading);
-    //        if start_playing {
-    //            self.play_status = SpircPlayStatus::LoadingPlay { position_ms };
-    //        } else {
-    //            self.play_status = SpircPlayStatus::LoadingPause { position_ms };
-    //        }
-    //    }
-
     fn hello(&mut self) {
         CommandSender::new(self, MessageType::kMessageTypeHello).send();
     }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1142,7 +1142,7 @@ impl SpircTask {
         // tracks in each frame either have a gid or uri (that may or may not be a valid track)
         // E.g - context based frames sometimes contain tracks with <spotify:meta:page:>
 
-        let mut track_ref = self.state.get_track()[index as usize].clone();
+        let mut track_ref = self.state.get_track()[new_playlist_index as usize].clone();
         let mut track_id = self.get_spotify_id_for_track(&track_ref);
         while track_id.is_err() || track_id.unwrap().audio_type == SpotifyAudioType::NonPlayable {
             warn!(

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -614,7 +614,7 @@ impl SpircTask {
                     PlayerEvent::Stopped { .. } => match self.play_status {
                         SpircPlayStatus::Stopped => (),
                         _ => {
-                            warn!("The player has stopped unexpentedly.");
+                            warn!("The player has stopped unexpectedly.");
                             self.state.set_status(PlayStatus::kPlayStatusStop);
                             self.ensure_mixer_stopped();
                             self.notify(None, true);

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -546,14 +546,10 @@ impl SpircTask {
                     PlayerEvent::EndOfTrack { .. } => self.handle_end_of_track(),
                     PlayerEvent::Loading { .. } => (),
                     PlayerEvent::Playing { position_ms, .. } => {
-                        let new_nominal_start_time =
-                            self.now_ms() - position_ms as i64;
+                        let new_nominal_start_time = self.now_ms() - position_ms as i64;
                         match self.play_status {
                             SpircPlayStatus::Playing { nominal_start_time } => {
-                                if (nominal_start_time - new_nominal_start_time)
-                                    .abs()
-                                    > 100
-                                {
+                                if (nominal_start_time - new_nominal_start_time).abs() > 100 {
                                     self.update_state_position(position_ms);
                                     self.notify(None);
                                     self.play_status = SpircPlayStatus::Playing {
@@ -611,14 +607,17 @@ impl SpircTask {
                             self.play_status = SpircPlayStatus::Stopped;
                         }
                     },
-                    PlayerEvent::TimeToPreloadNextTrack {..} => match self.play_status {
-                        SpircPlayStatus::Paused {..}|SpircPlayStatus::Playing {..}| SpircPlayStatus::LoadingPause{..}|SpircPlayStatus::LoadingPlay {..} => {
+                    PlayerEvent::TimeToPreloadNextTrack { .. } => match self.play_status {
+                        SpircPlayStatus::Paused { .. }
+                        | SpircPlayStatus::Playing { .. }
+                        | SpircPlayStatus::LoadingPause { .. }
+                        | SpircPlayStatus::LoadingPlay { .. } => {
                             if let Some(track_id) = self.preview_next_track() {
                                 self.player.preload(track_id);
                             }
                         }
                         SpircPlayStatus::Stopped => (),
-                    }
+                    },
                     _ => (),
                 }
             }

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -63,6 +63,7 @@ pub struct AudioItem {
     pub uri: String,
     pub files: LinearMap<FileFormat, FileId>,
     pub name: String,
+    pub duration: i32,
     pub available: bool,
     pub alternatives: Option<Vec<SpotifyId>>,
 }
@@ -100,6 +101,7 @@ impl AudioFiles for Track {
                 uri: format!("spotify:track:{}", id.to_base62()),
                 files: item.files,
                 name: item.name,
+                duration: item.duration,
                 available: item.available,
                 alternatives: Some(item.alternatives),
             })
@@ -118,6 +120,7 @@ impl AudioFiles for Episode {
                 uri: format!("spotify:episode:{}", id.to_base62()),
                 files: item.files,
                 name: item.name,
+                duration: item.duration,
                 available: item.available,
                 alternatives: None,
             })

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1270,6 +1270,7 @@ impl PlayerInternal {
             }
 
             PlayerCommand::Preload { track_id } => {
+                debug!("Preloading track");
                 let mut preload_track = true;
 
                 if let PlayerPreload::Loading {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -668,7 +668,6 @@ impl Future for PlayerInternal {
     type Error = ();
 
     fn poll(&mut self) -> Poll<(), ()> {
-        let mut last_printed_stream_position_for_debug = 0;
         loop {
             let mut all_futures_completed_or_not_ready = true;
 
@@ -760,15 +759,6 @@ impl Future for PlayerInternal {
                         *stream_position_pcm =
                             *stream_position_pcm + (packet.data().len() / 2) as u64;
                         let stream_position_millis = Self::position_pcm_to_ms(*stream_position_pcm);
-
-                        if stream_position_millis / 1000 != last_printed_stream_position_for_debug {
-                            trace!(
-                                "Stream position: {} ({} seconds)",
-                                *stream_position_pcm,
-                                stream_position_millis / 1000
-                            );
-                            last_printed_stream_position_for_debug = stream_position_millis / 1000;
-                        }
 
                         let notify_about_position = match *reported_nominal_start_time {
                             None => true,

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1119,6 +1119,7 @@ impl PlayerInternal {
                         loaded_track.stream_loader_controller.set_stream_mode();
                         loaded_track.stream_position_pcm = Self::position_ms_to_pcm(position_ms);
                     }
+                    self.preload = PlayerPreload::None;
                     self.start_playback(track_id, play_request_id, loaded_track, play);
                     return;
                 }
@@ -1182,6 +1183,7 @@ impl PlayerInternal {
                         stream_position_pcm,
                     };
 
+                    self.preload = PlayerPreload::None;
                     self.start_playback(track_id, play_request_id, loaded_track, play);
 
                     if let PlayerState::Invalid = self.state {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1,19 +1,19 @@
 use byteorder::{LittleEndian, ReadBytesExt};
 use futures;
-use futures::sync::oneshot;
-use futures::{future, Future};
+use futures::{future, Async, Future, Poll, Stream};
 use std;
 use std::borrow::Cow;
 use std::cmp::max;
 use std::io::{Read, Result, Seek, SeekFrom};
 use std::mem;
-use std::sync::mpsc::{RecvError, RecvTimeoutError, TryRecvError};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::config::{Bitrate, PlayerConfig};
 use librespot_core::session::Session;
 use librespot_core::spotify_id::SpotifyId;
+
+use librespot_core::util::SeqGenerator;
 
 use crate::audio::{AudioDecrypt, AudioFile, StreamLoaderController};
 use crate::audio::{VorbisDecoder, VorbisPacket};
@@ -25,48 +25,121 @@ use crate::audio_backend::Sink;
 use crate::metadata::{AudioItem, FileFormat};
 use crate::mixer::AudioFilter;
 
+const PRELOAD_NEXT_TRACK_BEFORE_END_DURATION_MS: u32 = 30000;
+
 pub struct Player {
-    commands: Option<std::sync::mpsc::Sender<PlayerCommand>>,
+    commands: Option<futures::sync::mpsc::UnboundedSender<PlayerCommand>>,
     thread_handle: Option<thread::JoinHandle<()>>,
+    play_request_id_generator: SeqGenerator<u64>,
 }
 
 struct PlayerInternal {
     session: Session,
     config: PlayerConfig,
-    commands: std::sync::mpsc::Receiver<PlayerCommand>,
+    commands: futures::sync::mpsc::UnboundedReceiver<PlayerCommand>,
 
     state: PlayerState,
+    preload: PlayerPreload,
     sink: Box<dyn Sink>,
     sink_running: bool,
     audio_filter: Option<Box<dyn AudioFilter + Send>>,
-    event_sender: futures::sync::mpsc::UnboundedSender<PlayerEvent>,
+    event_senders: Vec<futures::sync::mpsc::UnboundedSender<PlayerEvent>>,
 }
 
 enum PlayerCommand {
-    Load(SpotifyId, bool, u32, oneshot::Sender<()>),
+    Load {
+        track_id: SpotifyId,
+        play_request_id: u64,
+        play: bool,
+        position_ms: u32,
+    },
+    Preload {
+        track_id: SpotifyId,
+    },
     Play,
     Pause,
     Stop,
     Seek(u32),
+    AddEventSender(futures::sync::mpsc::UnboundedSender<PlayerEvent>),
+    EmitVolumeSetEvent(u16),
 }
 
 #[derive(Debug, Clone)]
 pub enum PlayerEvent {
-    Started {
+    Loading {
+        play_request_id: u64,
         track_id: SpotifyId,
+        position_ms: u32,
     },
-
+    Started {
+        play_request_id: u64,
+        track_id: SpotifyId,
+        position_ms: u32,
+    },
+    Playing {
+        play_request_id: u64,
+        track_id: SpotifyId,
+        position_ms: u32,
+        duration_ms: u32,
+    },
     Changed {
         old_track_id: SpotifyId,
         new_track_id: SpotifyId,
     },
-
-    Stopped {
+    TimeToPreloadNextTrack {
+        play_request_id: u64,
         track_id: SpotifyId,
+    },
+    EndOfTrack {
+        play_request_id: u64,
+        track_id: SpotifyId,
+    },
+    Paused {
+        play_request_id: u64,
+        track_id: SpotifyId,
+        position_ms: u32,
+        duration_ms: u32,
+    },
+    Stopped {
+        play_request_id: u64,
+        track_id: SpotifyId,
+    },
+    VolumeSet {
+        volume: u16,
     },
 }
 
-type PlayerEventChannel = futures::sync::mpsc::UnboundedReceiver<PlayerEvent>;
+impl PlayerEvent {
+    pub fn get_play_request_id(&self) -> Option<u64> {
+        use PlayerEvent::*;
+        match self {
+            Loading {
+                play_request_id, ..
+            }
+            | Started {
+                play_request_id, ..
+            }
+            | Playing {
+                play_request_id, ..
+            }
+            | TimeToPreloadNextTrack {
+                play_request_id, ..
+            }
+            | EndOfTrack {
+                play_request_id, ..
+            }
+            | Paused {
+                play_request_id, ..
+            }
+            | Stopped {
+                play_request_id, ..
+            } => Some(*play_request_id),
+            Changed { .. } | VolumeSet { .. } => None,
+        }
+    }
+}
+
+pub type PlayerEventChannel = futures::sync::mpsc::UnboundedReceiver<PlayerEvent>;
 
 #[derive(Clone, Copy, Debug)]
 struct NormalisationData {
@@ -125,7 +198,7 @@ impl Player {
     where
         F: FnOnce() -> Box<dyn Sink> + Send + 'static,
     {
-        let (cmd_tx, cmd_rx) = std::sync::mpsc::channel();
+        let (cmd_tx, cmd_rx) = futures::sync::mpsc::unbounded();
         let (event_sender, event_receiver) = futures::sync::mpsc::unbounded();
 
         let handle = thread::spawn(move || {
@@ -137,38 +210,47 @@ impl Player {
                 commands: cmd_rx,
 
                 state: PlayerState::Stopped,
+                preload: PlayerPreload::None,
                 sink: sink_builder(),
                 sink_running: false,
                 audio_filter: audio_filter,
-                event_sender: event_sender,
+                event_senders: [event_sender].to_vec(),
             };
 
-            internal.run();
+            let _ = internal.wait();
+            debug!("PlayerInternal thread finished.");
         });
 
         (
             Player {
                 commands: Some(cmd_tx),
                 thread_handle: Some(handle),
+                play_request_id_generator: SeqGenerator::new(0),
             },
             event_receiver,
         )
     }
 
     fn command(&self, cmd: PlayerCommand) {
-        self.commands.as_ref().unwrap().send(cmd).unwrap();
+        self.commands.as_ref().unwrap().unbounded_send(cmd).unwrap();
     }
 
-    pub fn load(
-        &self,
-        track: SpotifyId,
-        start_playing: bool,
-        position_ms: u32,
-    ) -> oneshot::Receiver<()> {
-        let (tx, rx) = oneshot::channel();
-        self.command(PlayerCommand::Load(track, start_playing, position_ms, tx));
+    pub fn load(&mut self, track_id: SpotifyId, start_playing: bool, position_ms: u32) -> u64 {
+        let play_request_id = self.play_request_id_generator.get();
+        self.command(PlayerCommand::Load {
+            track_id,
+            play_request_id,
+            play: start_playing,
+            position_ms,
+        });
 
-        rx
+        play_request_id
+    }
+
+    pub fn preload(&mut self, track_id: SpotifyId) {
+        self.command(PlayerCommand::Preload {
+            track_id,
+        });
     }
 
     pub fn play(&self) {
@@ -186,6 +268,16 @@ impl Player {
     pub fn seek(&self, position_ms: u32) {
         self.command(PlayerCommand::Seek(position_ms));
     }
+
+    pub fn get_player_event_channel(&self) -> PlayerEventChannel {
+        let (event_sender, event_receiver) = futures::sync::mpsc::unbounded();
+        self.command(PlayerCommand::AddEventSender(event_sender));
+        event_receiver
+    }
+
+    pub fn emit_volume_set_event(&self, volume: u16) {
+        self.command(PlayerCommand::EmitVolumeSetEvent(volume));
+    }
 }
 
 impl Drop for Player {
@@ -201,27 +293,63 @@ impl Drop for Player {
     }
 }
 
+struct PlayerLoadedTrackData {
+    decoder: Decoder,
+    normalisation_factor: f32,
+    stream_loader_controller: StreamLoaderController,
+    bytes_per_second: usize,
+    duration_ms: u32,
+    stream_position: u64,
+}
+
+enum PlayerPreload {
+    None,
+    Loading {
+        track_id: SpotifyId,
+        loader: Box<dyn Future<Item = PlayerLoadedTrackData, Error = ()>>,
+    },
+    Ready {
+        track_id: SpotifyId,
+        loaded_track: PlayerLoadedTrackData,
+    },
+}
+
 type Decoder = VorbisDecoder<Subfile<AudioDecrypt<AudioFile>>>;
+
 enum PlayerState {
     Stopped,
+    Loading {
+        track_id: SpotifyId,
+        play_request_id: u64,
+        start_playback: bool,
+        loader: Box<dyn Future<Item = PlayerLoadedTrackData, Error = ()>>,
+    },
     Paused {
         track_id: SpotifyId,
+        play_request_id: u64,
         decoder: Decoder,
-        end_of_track: oneshot::Sender<()>,
         normalisation_factor: f32,
         stream_loader_controller: StreamLoaderController,
         bytes_per_second: usize,
+        duration_ms: u32,
+        stream_position: u64,
+        suggested_to_preload_next_track: bool,
     },
     Playing {
         track_id: SpotifyId,
+        play_request_id: u64,
         decoder: Decoder,
-        end_of_track: oneshot::Sender<()>,
         normalisation_factor: f32,
         stream_loader_controller: StreamLoaderController,
         bytes_per_second: usize,
+        duration_ms: u32,
+        stream_position: u64,
+        reported_nominal_start_time: Option<Instant>,
+        suggested_to_preload_next_track: bool,
     },
     EndOfTrack {
         track_id: SpotifyId,
+        play_request_id: u64,
     },
     Invalid,
 }
@@ -230,16 +358,24 @@ impl PlayerState {
     fn is_playing(&self) -> bool {
         use self::PlayerState::*;
         match *self {
-            Stopped | EndOfTrack { .. } | Paused { .. } => false,
+            Stopped | EndOfTrack { .. } | Paused { .. } | Loading { .. } => false,
             Playing { .. } => true,
             Invalid => panic!("invalid state"),
+        }
+    }
+
+    fn is_stopped(&self) -> bool {
+        use self::PlayerState::*;
+        match *self {
+            Stopped => true,
+            _ => false,
         }
     }
 
     fn decoder(&mut self) -> Option<&mut Decoder> {
         use self::PlayerState::*;
         match *self {
-            Stopped | EndOfTrack { .. } => None,
+            Stopped | EndOfTrack { .. } | Loading { .. } => None,
             Paused {
                 ref mut decoder, ..
             }
@@ -253,7 +389,7 @@ impl PlayerState {
     fn stream_loader_controller(&mut self) -> Option<&mut StreamLoaderController> {
         use self::PlayerState::*;
         match *self {
-            Stopped | EndOfTrack { .. } => None,
+            Stopped | EndOfTrack { .. } | Loading { .. } => None,
             Paused {
                 ref mut stream_loader_controller,
                 ..
@@ -271,11 +407,13 @@ impl PlayerState {
         match mem::replace(self, Invalid) {
             Playing {
                 track_id,
-                end_of_track,
+                play_request_id,
                 ..
             } => {
-                let _ = end_of_track.send(());
-                *self = EndOfTrack { track_id };
+                *self = EndOfTrack {
+                    track_id,
+                    play_request_id,
+                };
             }
             _ => panic!("Called playing_to_end_of_track in non-playing state."),
         }
@@ -286,19 +424,26 @@ impl PlayerState {
         match ::std::mem::replace(self, Invalid) {
             Paused {
                 track_id,
+                play_request_id,
                 decoder,
-                end_of_track,
                 normalisation_factor,
                 stream_loader_controller,
+                duration_ms,
                 bytes_per_second,
+                stream_position,
+                suggested_to_preload_next_track,
             } => {
                 *self = Playing {
-                    track_id: track_id,
-                    decoder: decoder,
-                    end_of_track: end_of_track,
-                    normalisation_factor: normalisation_factor,
-                    stream_loader_controller: stream_loader_controller,
-                    bytes_per_second: bytes_per_second,
+                    track_id,
+                    play_request_id,
+                    decoder,
+                    normalisation_factor,
+                    stream_loader_controller,
+                    duration_ms,
+                    bytes_per_second,
+                    stream_position,
+                    reported_nominal_start_time: None,
+                    suggested_to_preload_next_track,
                 };
             }
             _ => panic!("invalid state"),
@@ -310,19 +455,26 @@ impl PlayerState {
         match ::std::mem::replace(self, Invalid) {
             Playing {
                 track_id,
+                play_request_id,
                 decoder,
-                end_of_track,
                 normalisation_factor,
                 stream_loader_controller,
+                duration_ms,
                 bytes_per_second,
+                stream_position,
+                reported_nominal_start_time: _,
+                suggested_to_preload_next_track,
             } => {
                 *self = Paused {
-                    track_id: track_id,
-                    decoder: decoder,
-                    end_of_track: end_of_track,
-                    normalisation_factor: normalisation_factor,
-                    stream_loader_controller: stream_loader_controller,
-                    bytes_per_second: bytes_per_second,
+                    track_id,
+                    play_request_id,
+                    decoder,
+                    normalisation_factor,
+                    stream_loader_controller,
+                    duration_ms,
+                    bytes_per_second,
+                    stream_position,
+                    suggested_to_preload_next_track,
                 };
             }
             _ => panic!("invalid state"),
@@ -330,269 +482,12 @@ impl PlayerState {
     }
 }
 
-impl PlayerInternal {
-    fn run(mut self) {
-        loop {
-            let cmd = if self.state.is_playing() {
-                if self.sink_running {
-                    match self.commands.try_recv() {
-                        Ok(cmd) => Some(cmd),
-                        Err(TryRecvError::Empty) => None,
-                        Err(TryRecvError::Disconnected) => return,
-                    }
-                } else {
-                    match self.commands.recv_timeout(Duration::from_secs(5)) {
-                        Ok(cmd) => Some(cmd),
-                        Err(RecvTimeoutError::Timeout) => None,
-                        Err(RecvTimeoutError::Disconnected) => return,
-                    }
-                }
-            } else {
-                match self.commands.recv() {
-                    Ok(cmd) => Some(cmd),
-                    Err(RecvError) => return,
-                }
-            };
+struct PlayerTrackLoader {
+    session: Session,
+    config: PlayerConfig,
+}
 
-            if let Some(cmd) = cmd {
-                self.handle_command(cmd);
-            }
-
-            if self.state.is_playing() && !self.sink_running {
-                self.start_sink();
-            }
-
-            if self.sink_running {
-                let mut current_normalisation_factor: f32 = 1.0;
-
-                let packet = if let PlayerState::Playing {
-                    ref mut decoder,
-                    normalisation_factor,
-                    ..
-                } = self.state
-                {
-                    current_normalisation_factor = normalisation_factor;
-                    Some(decoder.next_packet().expect("Vorbis error"))
-                } else {
-                    None
-                };
-
-                if let Some(packet) = packet {
-                    self.handle_packet(packet, current_normalisation_factor);
-                }
-            }
-
-            if self.session.is_invalid() {
-                return;
-            }
-        }
-    }
-
-    fn start_sink(&mut self) {
-        match self.sink.start() {
-            Ok(()) => self.sink_running = true,
-            Err(err) => error!("Could not start audio: {}", err),
-        }
-    }
-
-    fn stop_sink_if_running(&mut self) {
-        if self.sink_running {
-            self.stop_sink();
-        }
-    }
-
-    fn stop_sink(&mut self) {
-        self.sink.stop().unwrap();
-        self.sink_running = false;
-    }
-
-    fn handle_packet(&mut self, packet: Option<VorbisPacket>, normalisation_factor: f32) {
-        match packet {
-            Some(mut packet) => {
-                if packet.data().len() > 0 {
-                    if let Some(ref editor) = self.audio_filter {
-                        editor.modify_stream(&mut packet.data_mut())
-                    };
-
-                    if self.config.normalisation && normalisation_factor != 1.0 {
-                        for x in packet.data_mut().iter_mut() {
-                            *x = (*x as f32 * normalisation_factor) as i16;
-                        }
-                    }
-
-                    if let Err(err) = self.sink.write(&packet.data()) {
-                        error!("Could not write audio: {}", err);
-                        self.stop_sink();
-                    }
-                }
-            }
-
-            None => {
-                self.stop_sink();
-                self.state.playing_to_end_of_track();
-            }
-        }
-    }
-
-    fn handle_command(&mut self, cmd: PlayerCommand) {
-        debug!("command={:?}", cmd);
-        match cmd {
-            PlayerCommand::Load(track_id, play, position, end_of_track) => {
-                if self.state.is_playing() {
-                    self.stop_sink_if_running();
-                }
-
-                match self.load_track(track_id, position as i64) {
-                    Some((
-                        decoder,
-                        normalisation_factor,
-                        stream_loader_controller,
-                        bytes_per_second,
-                    )) => {
-                        if play {
-                            match self.state {
-                                PlayerState::Playing {
-                                    track_id: old_track_id,
-                                    ..
-                                }
-                                | PlayerState::EndOfTrack {
-                                    track_id: old_track_id,
-                                    ..
-                                } => self.send_event(PlayerEvent::Changed {
-                                    old_track_id: old_track_id,
-                                    new_track_id: track_id,
-                                }),
-                                _ => self.send_event(PlayerEvent::Started { track_id }),
-                            }
-
-                            self.start_sink();
-
-                            self.state = PlayerState::Playing {
-                                track_id: track_id,
-                                decoder: decoder,
-                                end_of_track: end_of_track,
-                                normalisation_factor: normalisation_factor,
-                                stream_loader_controller: stream_loader_controller,
-                                bytes_per_second: bytes_per_second,
-                            };
-                        } else {
-                            self.state = PlayerState::Paused {
-                                track_id: track_id,
-                                decoder: decoder,
-                                end_of_track: end_of_track,
-                                normalisation_factor: normalisation_factor,
-                                stream_loader_controller: stream_loader_controller,
-                                bytes_per_second: bytes_per_second,
-                            };
-                            match self.state {
-                                PlayerState::Playing {
-                                    track_id: old_track_id,
-                                    ..
-                                }
-                                | PlayerState::EndOfTrack {
-                                    track_id: old_track_id,
-                                    ..
-                                } => self.send_event(PlayerEvent::Changed {
-                                    old_track_id: old_track_id,
-                                    new_track_id: track_id,
-                                }),
-                                _ => (),
-                            }
-                            self.send_event(PlayerEvent::Stopped { track_id });
-                        }
-                    }
-
-                    None => {
-                        let _ = end_of_track.send(());
-                    }
-                }
-            }
-
-            PlayerCommand::Seek(position) => {
-                if let Some(stream_loader_controller) = self.state.stream_loader_controller() {
-                    stream_loader_controller.set_random_access_mode();
-                }
-                if let Some(decoder) = self.state.decoder() {
-                    match decoder.seek(position as i64) {
-                        Ok(_) => (),
-                        Err(err) => error!("Vorbis error: {:?}", err),
-                    }
-                } else {
-                    warn!("Player::seek called from invalid state");
-                }
-
-                // If we're playing, ensure, that we have enough data leaded to avoid a buffer underrun.
-                if let Some(stream_loader_controller) = self.state.stream_loader_controller() {
-                    stream_loader_controller.set_stream_mode();
-                }
-                if let PlayerState::Playing {
-                    bytes_per_second, ..
-                } = self.state
-                {
-                    if let Some(stream_loader_controller) = self.state.stream_loader_controller() {
-                        // Request our read ahead range
-                        let request_data_length = max(
-                            (READ_AHEAD_DURING_PLAYBACK_ROUNDTRIPS
-                                * (0.001 * stream_loader_controller.ping_time_ms() as f64)
-                                * bytes_per_second as f64) as usize,
-                            (READ_AHEAD_DURING_PLAYBACK_SECONDS * bytes_per_second as f64) as usize,
-                        );
-                        stream_loader_controller.fetch_next(request_data_length);
-
-                        // Request the part we want to wait for blocking. This effecively means we wait for the previous request to partially complete.
-                        let wait_for_data_length = max(
-                            (READ_AHEAD_BEFORE_PLAYBACK_ROUNDTRIPS
-                                * (0.001 * stream_loader_controller.ping_time_ms() as f64)
-                                * bytes_per_second as f64) as usize,
-                            (READ_AHEAD_BEFORE_PLAYBACK_SECONDS * bytes_per_second as f64) as usize,
-                        );
-                        stream_loader_controller.fetch_next_blocking(wait_for_data_length);
-                    }
-                }
-            }
-
-            PlayerCommand::Play => {
-                if let PlayerState::Paused { track_id, .. } = self.state {
-                    self.state.paused_to_playing();
-
-                    self.send_event(PlayerEvent::Started { track_id });
-                    self.start_sink();
-                } else {
-                    warn!("Player::play called from invalid state");
-                }
-            }
-
-            PlayerCommand::Pause => {
-                if let PlayerState::Playing { track_id, .. } = self.state {
-                    self.state.playing_to_paused();
-
-                    self.stop_sink_if_running();
-                    self.send_event(PlayerEvent::Stopped { track_id });
-                } else {
-                    warn!("Player::pause called from invalid state");
-                }
-            }
-
-            PlayerCommand::Stop => match self.state {
-                PlayerState::Playing { track_id, .. }
-                | PlayerState::Paused { track_id, .. }
-                | PlayerState::EndOfTrack { track_id } => {
-                    self.stop_sink_if_running();
-                    self.send_event(PlayerEvent::Stopped { track_id });
-                    self.state = PlayerState::Stopped;
-                }
-                PlayerState::Stopped => {
-                    warn!("Player::stop called from invalid state");
-                }
-                PlayerState::Invalid => panic!("invalid state"),
-            },
-        }
-    }
-
-    fn send_event(&mut self, event: PlayerEvent) {
-        let _ = self.event_sender.unbounded_send(event.clone());
-    }
-
+impl PlayerTrackLoader {
     fn find_available_alternative<'a>(&self, audio: &'a AudioItem) -> Option<Cow<'a, AudioItem>> {
         if audio.available {
             Some(Cow::Borrowed(audio))
@@ -631,11 +526,7 @@ impl PlayerInternal {
         }
     }
 
-    fn load_track(
-        &self,
-        spotify_id: SpotifyId,
-        position: i64,
-    ) -> Option<(Decoder, f32, StreamLoaderController, usize)> {
+    fn load_track(&self, spotify_id: SpotifyId, position: u64) -> Option<PlayerLoadedTrackData> {
         let audio = match AudioItem::get_audio_item(&self.session, spotify_id).wait() {
             Ok(audio) => audio,
             Err(_) => {
@@ -653,6 +544,10 @@ impl PlayerInternal {
                 return None;
             }
         };
+
+        assert!(audio.duration >= 0);
+        let duration_ms = audio.duration as u32;
+
         // (Most) podcasts seem to support only 96 bit Vorbis, so fall back to it
         let formats = match self.config.bitrate {
             Bitrate::Bitrate96 => [
@@ -738,41 +633,892 @@ impl PlayerInternal {
         let mut decoder = VorbisDecoder::new(audio_file).unwrap();
 
         if position != 0 {
-            match decoder.seek(position) {
+            match decoder.seek(position as i64) {
                 Ok(_) => (),
                 Err(err) => error!("Vorbis error: {:?}", err),
             }
             stream_loader_controller.set_stream_mode();
         }
-        info!("<{}> loaded", audio.name);
-        Some((
+        let stream_position = position * 441 / 10;
+        info!("<{}> ({} ms) loaded", audio.name, audio.duration);
+        Some(PlayerLoadedTrackData {
             decoder,
             normalisation_factor,
             stream_loader_controller,
             bytes_per_second,
-        ))
+            duration_ms,
+            stream_position,
+        })
+    }
+}
+
+impl Future for PlayerInternal {
+    type Item = ();
+    type Error = ();
+
+    fn poll(&mut self) -> Poll<(), ()> {
+        let mut last_printed_stream_position_for_debug = 0;
+        loop {
+            let mut all_futures_completed_or_not_ready = true;
+
+            // process commands that were sent to us
+            let cmd = match self.commands.poll() {
+                Ok(Async::Ready(None)) => return Ok(Async::Ready(())), // client has disconnected - shut down.
+                Ok(Async::Ready(Some(cmd))) => {
+                    all_futures_completed_or_not_ready = false;
+                    Some(cmd)
+                }
+                Ok(Async::NotReady) => None,
+                Err(_) => None,
+            };
+
+            if let Some(cmd) = cmd {
+                self.handle_command(cmd);
+            }
+
+            // Handle loading of a new track to play
+            if let PlayerState::Loading {
+                ref mut loader,
+                track_id,
+                start_playback,
+                play_request_id,
+            } = self.state
+            {
+                match loader.poll() {
+                    Ok(Async::Ready(loaded_track)) => {
+                        self.start_playback(
+                            track_id,
+                            play_request_id,
+                            loaded_track,
+                            start_playback,
+                        );
+                        if let PlayerState::Loading { .. } = self.state {
+                            panic!("The state wasn't changed by start_playback()");
+                        }
+                    }
+                    Ok(Async::NotReady) => (),
+                    Err(_) => {
+                        self.handle_player_stop();
+                        assert!(self.state.is_stopped());
+                    }
+                }
+            }
+
+            // handle pending preload requests.
+            if let PlayerPreload::Loading {
+                ref mut loader,
+                track_id,
+            } = self.preload
+            {
+                match loader.poll() {
+                    Ok(Async::Ready(loaded_track)) => {
+                        self.preload = PlayerPreload::Ready {
+                            track_id,
+                            loaded_track,
+                        };
+                    }
+                    Ok(Async::NotReady) => (),
+                    Err(_) => {
+                        self.preload = PlayerPreload::None;
+                    }
+                }
+            }
+
+            if self.state.is_playing() && !self.sink_running {
+                self.start_sink();
+            }
+
+            if self.sink_running {
+                let mut current_normalisation_factor: f32 = 1.0;
+
+                let packet = if let PlayerState::Playing {
+                    track_id,
+                    play_request_id,
+                    ref mut decoder,
+                    normalisation_factor,
+                    ref mut stream_position,
+                    ref mut reported_nominal_start_time,
+                    duration_ms,
+                    ..
+                } = self.state
+                {
+                    current_normalisation_factor = normalisation_factor;
+                    let packet = decoder.next_packet().expect("Vorbis error");
+
+                    if let Some(ref packet) = packet {
+                        *stream_position = *stream_position + (packet.data().len() / 2) as u64;
+                        let stream_position_seconds = *stream_position / 44100;
+                        if stream_position_seconds != last_printed_stream_position_for_debug {
+                            trace!(
+                                "Stream position: {} ({} seconds)",
+                                *stream_position,
+                                stream_position_seconds
+                            );
+                            last_printed_stream_position_for_debug = stream_position_seconds;
+                        }
+                        let stream_position_millis = *stream_position * 10 / 441;
+
+                        let notify_about_position = match *reported_nominal_start_time {
+                            None => true,
+                            Some(reported_nominal_start_time) => {
+                                // only notify if we're behind. If we're ahead it's probably due to a buffer of the backend and we;re actually in time.
+                                let lag = (Instant::now() - reported_nominal_start_time).as_millis()
+                                    as i64
+                                    - stream_position_millis as i64;
+                                if lag > 1000 {
+                                    true
+                                } else {
+                                    false
+                                }
+                            }
+                        };
+                        if notify_about_position {
+                            *reported_nominal_start_time = Some(
+                                Instant::now()
+                                    - Duration::from_millis(stream_position_millis as u64),
+                            );
+                            self.send_event(PlayerEvent::Playing {
+                                track_id,
+                                play_request_id,
+                                position_ms: stream_position_millis as u32,
+                                duration_ms,
+                            });
+                        }
+                    }
+
+                    Some(packet)
+                } else {
+                    None
+                };
+
+                if let Some(packet) = packet {
+                    self.handle_packet(packet, current_normalisation_factor);
+                }
+            }
+
+            if let PlayerState::Playing {
+                track_id,
+                play_request_id,
+                duration_ms,
+                stream_position,
+                ref mut stream_loader_controller,
+                ref mut suggested_to_preload_next_track,
+                ..
+            }
+            | PlayerState::Paused {
+                track_id,
+                play_request_id,
+                duration_ms,
+                stream_position,
+                ref mut stream_loader_controller,
+                ref mut suggested_to_preload_next_track,
+                ..
+            } = self.state
+            {
+                let stream_position_millis = stream_position * 10 / 441;
+                if (!*suggested_to_preload_next_track)
+                    && ((duration_ms as i64 - stream_position_millis as i64)
+                        < PRELOAD_NEXT_TRACK_BEFORE_END_DURATION_MS as i64)
+                    && stream_loader_controller.range_to_end_available()
+                {
+                    *suggested_to_preload_next_track = true;
+                    self.send_event(PlayerEvent::TimeToPreloadNextTrack {
+                        track_id,
+                        play_request_id,
+                    });
+                }
+            }
+
+            if self.session.is_invalid() {
+                return Ok(Async::Ready(()));
+            }
+
+            if (!self.sink_running) && all_futures_completed_or_not_ready {
+                return Ok(Async::NotReady);
+            }
+        }
+    }
+}
+
+impl PlayerInternal {
+    fn start_sink(&mut self) {
+        match self.sink.start() {
+            Ok(()) => self.sink_running = true,
+            Err(err) => error!("Could not start audio: {}", err),
+        }
+    }
+
+    fn stop_sink_if_running(&mut self) {
+        if self.sink_running {
+            self.stop_sink();
+        }
+    }
+
+    fn stop_sink(&mut self) {
+        self.sink.stop().unwrap();
+        self.sink_running = false;
+    }
+
+    fn handle_player_stop(&mut self) {
+        match self.state {
+            PlayerState::Playing {
+                track_id,
+                play_request_id,
+                ..
+            }
+            | PlayerState::Paused {
+                track_id,
+                play_request_id,
+                ..
+            }
+            | PlayerState::EndOfTrack {
+                track_id,
+                play_request_id,
+            }
+            | PlayerState::Loading {
+                track_id,
+                play_request_id,
+                ..
+            } => {
+                self.stop_sink_if_running();
+                self.send_event(PlayerEvent::Stopped {
+                    track_id,
+                    play_request_id,
+                });
+                self.state = PlayerState::Stopped;
+            }
+            PlayerState::Stopped => (),
+            PlayerState::Invalid => panic!("invalid state"),
+        }
+    }
+
+    fn handle_packet(&mut self, packet: Option<VorbisPacket>, normalisation_factor: f32) {
+        match packet {
+            Some(mut packet) => {
+                if packet.data().len() > 0 {
+                    if let Some(ref editor) = self.audio_filter {
+                        editor.modify_stream(&mut packet.data_mut())
+                    };
+
+                    if self.config.normalisation && normalisation_factor != 1.0 {
+                        for x in packet.data_mut().iter_mut() {
+                            *x = (*x as f32 * normalisation_factor) as i16;
+                        }
+                    }
+
+                    if let Err(err) = self.sink.write(&packet.data()) {
+                        error!("Could not write audio: {}", err);
+                        self.stop_sink();
+                    }
+                }
+            }
+
+            None => {
+                self.stop_sink();
+                self.state.playing_to_end_of_track();
+                if let PlayerState::EndOfTrack {
+                    track_id,
+                    play_request_id,
+                } = self.state
+                {
+                    self.send_event(PlayerEvent::EndOfTrack {
+                        track_id,
+                        play_request_id,
+                    })
+                } else {
+                    unreachable!();
+                }
+            }
+        }
+    }
+
+    fn start_playback(
+        &mut self,
+        track_id: SpotifyId,
+        play_request_id: u64,
+        loaded_track: PlayerLoadedTrackData,
+        start_playback: bool,
+    ) {
+        let position_ms = (loaded_track.stream_position * 10 / 441) as u32;
+
+        match self.state {
+            PlayerState::Playing {
+                track_id: old_track_id,
+                ..
+            }
+            | PlayerState::Paused {
+                track_id: old_track_id,
+                ..
+            }
+            | PlayerState::EndOfTrack {
+                track_id: old_track_id,
+                ..
+            } => self.send_event(PlayerEvent::Changed {
+                old_track_id: old_track_id,
+                new_track_id: track_id,
+            }),
+            PlayerState::Stopped => self.send_event(PlayerEvent::Started {
+                track_id,
+                play_request_id,
+                position_ms,
+            }),
+            PlayerState::Loading { .. } => (),
+            PlayerState::Invalid { .. } => panic!("Player is in an invalid state."),
+        }
+
+        if start_playback {
+            self.start_sink();
+
+            self.send_event(PlayerEvent::Playing {
+                track_id,
+                play_request_id,
+                position_ms,
+                duration_ms: loaded_track.duration_ms,
+            });
+
+            self.state = PlayerState::Playing {
+                track_id: track_id,
+                play_request_id: play_request_id,
+                decoder: loaded_track.decoder,
+                normalisation_factor: loaded_track.normalisation_factor,
+                stream_loader_controller: loaded_track.stream_loader_controller,
+                duration_ms: loaded_track.duration_ms,
+                bytes_per_second: loaded_track.bytes_per_second,
+                stream_position: loaded_track.stream_position,
+                reported_nominal_start_time: Some(
+                    Instant::now() - Duration::from_millis(position_ms as u64),
+                ),
+                suggested_to_preload_next_track: false,
+            };
+        } else {
+            self.state = PlayerState::Paused {
+                track_id: track_id,
+                play_request_id: play_request_id,
+                decoder: loaded_track.decoder,
+                normalisation_factor: loaded_track.normalisation_factor,
+                stream_loader_controller: loaded_track.stream_loader_controller,
+                duration_ms: loaded_track.duration_ms,
+                bytes_per_second: loaded_track.bytes_per_second,
+                stream_position: loaded_track.stream_position,
+                suggested_to_preload_next_track: false,
+            };
+
+            self.send_event(PlayerEvent::Paused {
+                track_id,
+                play_request_id,
+                position_ms,
+                duration_ms: loaded_track.duration_ms,
+            });
+        }
+    }
+
+    fn handle_command(&mut self, cmd: PlayerCommand) {
+        debug!("command={:?}", cmd);
+        match cmd {
+            PlayerCommand::Load {
+                track_id,
+                play_request_id,
+                play,
+                position_ms,
+            } => {
+                if self.state.is_playing() {
+                    self.stop_sink_if_running();
+                }
+
+                match self.state {
+                    PlayerState::Playing {
+                        track_id: old_track_id,
+                        ..
+                    }
+                    | PlayerState::Paused {
+                        track_id: old_track_id,
+                        ..
+                    }
+                    | PlayerState::EndOfTrack {
+                        track_id: old_track_id,
+                        ..
+                    }
+                    | PlayerState::Loading {
+                        track_id: old_track_id,
+                        ..
+                    } => self.send_event(PlayerEvent::Changed {
+                        old_track_id: old_track_id,
+                        new_track_id: track_id,
+                    }),
+                    PlayerState::Stopped => self.send_event(PlayerEvent::Started {
+                        track_id,
+                        play_request_id,
+                        position_ms,
+                    }),
+                    PlayerState::Invalid { .. } => panic!("Player is in an invalid state."),
+                }
+
+                let mut load_command_processed = false;
+                if let PlayerPreload::Ready {
+                    track_id: loaded_track_id,
+                    ..
+                } = self.preload
+                {
+                    if (track_id == loaded_track_id) && (position_ms == 0) {
+                        let mut preload = PlayerPreload::None;
+                        std::mem::swap(&mut preload, &mut self.preload);
+                        if let PlayerPreload::Ready {
+                            track_id,
+                            loaded_track,
+                        } = preload
+                        {
+                            self.start_playback(track_id, play_request_id, loaded_track, play);
+                            load_command_processed = true;
+                        }
+                    }
+                }
+
+                if !load_command_processed {
+                    self.send_event(PlayerEvent::Loading {
+                        track_id,
+                        play_request_id,
+                        position_ms,
+                    });
+
+                    let loader = if let PlayerPreload::Loading {
+                        track_id: loaded_track_id,
+                        ..
+                    } = self.preload
+                    {
+                        if (track_id == loaded_track_id) && (position_ms == 0) {
+                            let mut preload = PlayerPreload::None;
+                            std::mem::swap(&mut preload, &mut self.preload);
+                            if let PlayerPreload::Loading { loader, .. } = preload {
+                                Some(loader)
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    };
+
+                    self.preload = PlayerPreload::None;
+
+                    let loader = loader
+                        .or_else(|| Some(self.load_track_threaded(track_id, position_ms as u64)));
+                    let loader = loader.unwrap();
+
+                    self.state = PlayerState::Loading {
+                        track_id,
+                        play_request_id,
+                        start_playback: play,
+                        loader,
+                    };
+                }
+            }
+
+            PlayerCommand::Preload { track_id } => {
+                if let PlayerPreload::Loading {
+                    track_id: currently_loading,
+                    ..
+                }
+                | PlayerPreload::Ready {
+                    track_id: currently_loading,
+                    ..
+                } = self.preload
+                {
+                    if currently_loading != track_id {
+                        self.preload = PlayerPreload::None;
+                    }
+                }
+                if let PlayerPreload::None = self.preload {
+                    let loader = self.load_track_threaded(track_id, 0);
+                    self.preload = PlayerPreload::Loading { track_id, loader }
+                }
+            }
+
+            PlayerCommand::Seek(position) => {
+                if let Some(stream_loader_controller) = self.state.stream_loader_controller() {
+                    stream_loader_controller.set_random_access_mode();
+                }
+                if let Some(decoder) = self.state.decoder() {
+                    match decoder.seek(position as i64) {
+                        Ok(_) => {
+                            if let PlayerState::Playing {
+                                ref mut stream_position,
+                                ..
+                            }
+                            | PlayerState::Paused {
+                                ref mut stream_position,
+                                ..
+                            } = self.state
+                            {
+                                *stream_position = position as u64 * 441 / 10;
+                            }
+                        }
+                        Err(err) => error!("Vorbis error: {:?}", err),
+                    }
+                } else {
+                    warn!("Player::seek called from invalid state");
+                }
+
+                // If we're playing, ensure, that we have enough data leaded to avoid a buffer underrun.
+                if let Some(stream_loader_controller) = self.state.stream_loader_controller() {
+                    stream_loader_controller.set_stream_mode();
+                }
+
+                self.preload_data_before_playback();
+
+                if let PlayerState::Playing {
+                    track_id,
+                    play_request_id,
+                    ref mut reported_nominal_start_time,
+                    duration_ms,
+                    ..
+                } = self.state
+                {
+                    *reported_nominal_start_time =
+                        Some(Instant::now() - Duration::from_millis(position as u64));
+                    self.send_event(PlayerEvent::Playing {
+                        track_id,
+                        play_request_id,
+                        position_ms: position,
+                        duration_ms,
+                    });
+                }
+                if let PlayerState::Paused {
+                    track_id,
+                    play_request_id,
+                    duration_ms,
+                    ..
+                } = self.state
+                {
+                    self.send_event(PlayerEvent::Paused {
+                        track_id,
+                        play_request_id,
+                        position_ms: position,
+                        duration_ms,
+                    });
+                }
+            }
+
+            PlayerCommand::Play => {
+                if let PlayerState::Paused {
+                    track_id,
+                    play_request_id,
+                    stream_position,
+                    ..
+                } = self.state
+                {
+                    self.state.paused_to_playing();
+
+                    let position_ms = (stream_position * 10 / 441) as u32;
+                    self.send_event(PlayerEvent::Started {
+                        track_id,
+                        play_request_id,
+                        position_ms,
+                    });
+                    self.start_sink();
+                } else {
+                    warn!("Player::play called from invalid state");
+                }
+            }
+
+            PlayerCommand::Pause => {
+                if let PlayerState::Playing {
+                    track_id,
+                    play_request_id,
+                    stream_position,
+                    duration_ms,
+                    ..
+                } = self.state
+                {
+                    self.state.playing_to_paused();
+
+                    self.stop_sink_if_running();
+                    let position_ms = (stream_position * 10 / 441) as u32;
+                    self.send_event(PlayerEvent::Paused {
+                        track_id,
+                        play_request_id,
+                        position_ms,
+                        duration_ms,
+                    });
+                } else {
+                    warn!("Player::pause called from invalid state");
+                }
+            }
+
+            PlayerCommand::Stop => self.handle_player_stop(),
+
+            PlayerCommand::AddEventSender(sender) => self.event_senders.push(sender),
+
+            PlayerCommand::EmitVolumeSetEvent(volume) => {
+                self.send_event(PlayerEvent::VolumeSet { volume })
+            }
+        }
+    }
+
+    fn send_event(&mut self, event: PlayerEvent) {
+        let mut index = 0;
+        while index < self.event_senders.len() {
+            match self.event_senders[index].unbounded_send(event.clone()) {
+                Ok(_) => index += 1,
+                Err(_) => {
+                    self.event_senders.remove(index);
+                }
+            }
+        }
+    }
+
+    //    fn find_available_alternative<'a>(&self, audio: &'a AudioItem) -> Option<Cow<'a, AudioItem>> {
+    //        if audio.available {
+    //            Some(Cow::Borrowed(audio))
+    //        } else {
+    //            if let Some(alternatives) = &audio.alternatives {
+    //                let alternatives = alternatives
+    //                    .iter()
+    //                    .map(|alt_id| AudioItem::get_audio_item(&self.session, *alt_id));
+    //                let alternatives = future::join_all(alternatives).wait().unwrap();
+    //                alternatives
+    //                    .into_iter()
+    //                    .find(|alt| alt.available)
+    //                    .map(Cow::Owned)
+    //            } else {
+    //                None
+    //            }
+    //        }
+    //    }
+
+    //    fn stream_data_rate(&self, format: FileFormat) -> usize {
+    //        match format {
+    //            FileFormat::OGG_VORBIS_96 => 12 * 1024,
+    //            FileFormat::OGG_VORBIS_160 => 20 * 1024,
+    //            FileFormat::OGG_VORBIS_320 => 40 * 1024,
+    //            FileFormat::MP3_256 => 32 * 1024,
+    //            FileFormat::MP3_320 => 40 * 1024,
+    //            FileFormat::MP3_160 => 20 * 1024,
+    //            FileFormat::MP3_96 => 12 * 1024,
+    //            FileFormat::MP3_160_ENC => 20 * 1024,
+    //            FileFormat::MP4_128_DUAL => 16 * 1024,
+    //            FileFormat::OTHER3 => 40 * 1024, // better some high guess than nothing
+    //            FileFormat::AAC_160 => 20 * 1024,
+    //            FileFormat::AAC_320 => 40 * 1024,
+    //            FileFormat::MP4_128 => 16 * 1024,
+    //            FileFormat::OTHER5 => 40 * 1024, // better some high guess than nothing
+    //        }
+    //    }
+
+    fn load_track_threaded(
+        &self,
+        spotify_id: SpotifyId,
+        position: u64,
+    ) -> Box<dyn Future<Item = PlayerLoadedTrackData, Error = ()>> {
+        // This method creates a future that returns the loaded stream and associated info.
+        // Ideally all work should be done using asynchronous code. However, seek() on the
+        // audio stream is implemented in a blocking fashion. Thus, we can't turn it into future
+        // easily. Instead we spawn a thread to do the work and return a one-shot channel as the
+        // future to work with.
+
+        let loader = PlayerTrackLoader {
+            session: self.session.clone(),
+            config: self.config.clone(),
+        };
+
+        let (result_tx, result_rx) = futures::sync::oneshot::channel();
+
+        std::thread::spawn(move || {
+            loader
+                .load_track(spotify_id, position)
+                .and_then(move |data| {
+                    let _ = result_tx.send(data);
+                    Some(())
+                });
+        });
+
+        Box::new(result_rx.map_err(|_| ()))
+    }
+
+    //    fn load_track(
+    //        &self,
+    //        spotify_id: SpotifyId,
+    //        position: u64,
+    //    ) -> Option<(Decoder, f32, StreamLoaderController, usize, u64)> {
+    //        let audio = match AudioItem::get_audio_item(&self.session, spotify_id).wait() {
+    //            Ok(audio) => audio,
+    //            Err(_) => {
+    //                error!("Unable to load audio item.");
+    //                return None;
+    //            }
+    //        };
+    //
+    //        info!("Loading <{}> with Spotify URI <{}>", audio.name, audio.uri);
+    //
+    //        let audio = match self.find_available_alternative(&audio) {
+    //            Some(audio) => audio,
+    //            None => {
+    //                warn!("<{}> is not available", audio.uri);
+    //                return None;
+    //            }
+    //        };
+    //        // (Most) podcasts seem to support only 96 bit Vorbis, so fall back to it
+    //        let formats = match self.config.bitrate {
+    //            Bitrate::Bitrate96 => [
+    //                FileFormat::OGG_VORBIS_96,
+    //                FileFormat::OGG_VORBIS_160,
+    //                FileFormat::OGG_VORBIS_320,
+    //            ],
+    //            Bitrate::Bitrate160 => [
+    //                FileFormat::OGG_VORBIS_160,
+    //                FileFormat::OGG_VORBIS_96,
+    //                FileFormat::OGG_VORBIS_320,
+    //            ],
+    //            Bitrate::Bitrate320 => [
+    //                FileFormat::OGG_VORBIS_320,
+    //                FileFormat::OGG_VORBIS_160,
+    //                FileFormat::OGG_VORBIS_96,
+    //            ],
+    //        };
+    //        let format = formats
+    //            .iter()
+    //            .find(|format| audio.files.contains_key(format))
+    //            .unwrap();
+    //
+    //        let file_id = match audio.files.get(&format) {
+    //            Some(&file_id) => file_id,
+    //            None => {
+    //                warn!("<{}> in not available in format {:?}", audio.name, format);
+    //                return None;
+    //            }
+    //        };
+    //
+    //        let bytes_per_second = self.stream_data_rate(*format);
+    //        let play_from_beginning = position == 0;
+    //
+    //        let key = self.session.audio_key().request(spotify_id, file_id);
+    //        let encrypted_file = AudioFile::open(
+    //            &self.session,
+    //            file_id,
+    //            bytes_per_second,
+    //            play_from_beginning,
+    //        );
+    //
+    //        let encrypted_file = match encrypted_file.wait() {
+    //            Ok(encrypted_file) => encrypted_file,
+    //            Err(_) => {
+    //                error!("Unable to load encrypted file.");
+    //                return None;
+    //            }
+    //        };
+    //
+    //        let mut stream_loader_controller = encrypted_file.get_stream_loader_controller();
+    //
+    //        if play_from_beginning {
+    //            // No need to seek -> we stream from the beginning
+    //            stream_loader_controller.set_stream_mode();
+    //        } else {
+    //            // we need to seek -> we set stream mode after the initial seek.
+    //            stream_loader_controller.set_random_access_mode();
+    //        }
+    //
+    //        let key = match key.wait() {
+    //            Ok(key) => key,
+    //            Err(_) => {
+    //                error!("Unable to load decryption key");
+    //                return None;
+    //            }
+    //        };
+    //
+    //        let mut decrypted_file = AudioDecrypt::new(key, encrypted_file);
+    //
+    //        let normalisation_factor = match NormalisationData::parse_from_file(&mut decrypted_file) {
+    //            Ok(normalisation_data) => {
+    //                NormalisationData::get_factor(&self.config, normalisation_data)
+    //            }
+    //            Err(_) => {
+    //                warn!("Unable to extract normalisation data, using default value.");
+    //                1.0 as f32
+    //            }
+    //        };
+    //
+    //        let audio_file = Subfile::new(decrypted_file, 0xa7);
+    //
+    //        let mut decoder = VorbisDecoder::new(audio_file).unwrap();
+    //
+    //        if position != 0 {
+    //            match decoder.seek(position as i64) {
+    //                Ok(_) => (),
+    //                Err(err) => error!("Vorbis error: {:?}", err),
+    //            }
+    //            stream_loader_controller.set_stream_mode();
+    //        }
+    //        let stream_position = position * 441 / 10;
+    //        info!("<{}> loaded", audio.name);
+    //        Some((
+    //            decoder,
+    //            normalisation_factor,
+    //            stream_loader_controller,
+    //            bytes_per_second,
+    //            stream_position,
+    //        ))
+    //    }
+
+    fn preload_data_before_playback(&mut self) {
+        if let PlayerState::Playing {
+            bytes_per_second,
+            ref mut stream_loader_controller,
+            ..
+        } = self.state
+        {
+            // Request our read ahead range
+            let request_data_length = max(
+                (READ_AHEAD_DURING_PLAYBACK_ROUNDTRIPS
+                    * (0.001 * stream_loader_controller.ping_time_ms() as f64)
+                    * bytes_per_second as f64) as usize,
+                (READ_AHEAD_DURING_PLAYBACK_SECONDS * bytes_per_second as f64) as usize,
+            );
+            stream_loader_controller.fetch_next(request_data_length);
+
+            // Request the part we want to wait for blocking. This effecively means we wait for the previous request to partially complete.
+            let wait_for_data_length = max(
+                (READ_AHEAD_BEFORE_PLAYBACK_ROUNDTRIPS
+                    * (0.001 * stream_loader_controller.ping_time_ms() as f64)
+                    * bytes_per_second as f64) as usize,
+                (READ_AHEAD_BEFORE_PLAYBACK_SECONDS * bytes_per_second as f64) as usize,
+            );
+            stream_loader_controller.fetch_next_blocking(wait_for_data_length);
+        }
     }
 }
 
 impl Drop for PlayerInternal {
     fn drop(&mut self) {
-        debug!("drop Player[{}]", self.session.session_id());
+        debug!("drop PlayerInternal[{}]", self.session.session_id());
     }
 }
 
 impl ::std::fmt::Debug for PlayerCommand {
     fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
         match *self {
-            PlayerCommand::Load(track, play, position, _) => f
+            PlayerCommand::Load {
+                track_id,
+                play,
+                position_ms,
+                ..
+            } => f
                 .debug_tuple("Load")
-                .field(&track)
+                .field(&track_id)
                 .field(&play)
-                .field(&position)
+                .field(&position_ms)
                 .finish(),
+            PlayerCommand::Preload { track_id } => {
+                f.debug_tuple("Preload").field(&track_id).finish()
+            }
             PlayerCommand::Play => f.debug_tuple("Play").finish(),
             PlayerCommand::Pause => f.debug_tuple("Pause").finish(),
             PlayerCommand::Stop => f.debug_tuple("Stop").finish(),
             PlayerCommand::Seek(position) => f.debug_tuple("Seek").field(&position).finish(),
+            PlayerCommand::AddEventSender(_) => f.debug_tuple("AddEventSender").finish(),
+            PlayerCommand::EmitVolumeSetEvent(volume) => {
+                f.debug_tuple("VolumeSet").field(&volume).finish()
+            }
         }
     }
 }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -884,7 +884,6 @@ impl PlayerInternal {
         }
     }
 
-
     fn handle_player_stop(&mut self) {
         match self.state {
             PlayerState::Playing {
@@ -1224,7 +1223,6 @@ impl PlayerInternal {
                 // We need to load the track - either from scratch or by completing a preload.
                 // In any case we go into a Loading state to load the track.
                 if !load_command_processed {
-
                     self.ensure_sink_stopped();
 
                     self.send_event(PlayerEvent::Loading {

--- a/src/main.rs
+++ b/src/main.rs
@@ -539,16 +539,18 @@ impl Future for Main {
             if let Some(ref mut player_event_channel) = self.player_event_channel {
                 if let Async::Ready(Some(event)) = player_event_channel.poll().unwrap() {
                     if let Some(ref program) = self.player_event_program {
-                        let child = run_program_on_events(event, program)
-                            .expect("program failed to start")
-                            .map(|status| {
-                                if !status.success() {
-                                    error!("child exited with status {:?}", status.code());
-                                }
-                            })
-                            .map_err(|e| error!("failed to wait on child process: {}", e));
+                        if let Some(child) = run_program_on_events(event, program) {
+                            let child = child
+                                .expect("program failed to start")
+                                .map(|status| {
+                                    if !status.success() {
+                                        error!("child exited with status {:?}", status.code());
+                                    }
+                                })
+                                .map_err(|e| error!("failed to wait on child process: {}", e));
 
-                        self.handle.spawn(child);
+                            self.handle.spawn(child);
+                        }
                     }
                 }
             }

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -25,14 +25,15 @@ pub fn run_program_on_events(event: PlayerEvent, onevent: &str) -> io::Result<Ch
             env_vars.insert("OLD_TRACK_ID", old_track_id.to_base62());
             env_vars.insert("TRACK_ID", new_track_id.to_base62());
         }
-        PlayerEvent::Started { track_id } => {
+        PlayerEvent::Started { track_id, .. } => {
             env_vars.insert("PLAYER_EVENT", "start".to_string());
             env_vars.insert("TRACK_ID", track_id.to_base62());
         }
-        PlayerEvent::Stopped { track_id } => {
+        PlayerEvent::Stopped { track_id, .. } => {
             env_vars.insert("PLAYER_EVENT", "stop".to_string());
             env_vars.insert("TRACK_ID", track_id.to_base62());
         }
+        _ => (),
     }
     run_program(onevent, env_vars)
 }

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -14,7 +14,7 @@ fn run_program(program: &str, env_vars: HashMap<&str, String>) -> io::Result<Chi
         .spawn_async()
 }
 
-pub fn run_program_on_events(event: PlayerEvent, onevent: &str) -> io::Result<Child> {
+pub fn run_program_on_events(event: PlayerEvent, onevent: &str) -> Option<io::Result<Child>> {
     let mut env_vars = HashMap::new();
     match event {
         PlayerEvent::Changed {
@@ -33,7 +33,7 @@ pub fn run_program_on_events(event: PlayerEvent, onevent: &str) -> io::Result<Ch
             env_vars.insert("PLAYER_EVENT", "stop".to_string());
             env_vars.insert("TRACK_ID", track_id.to_base62());
         }
-        _ => (),
+        _ => return None,
     }
-    run_program(onevent, env_vars)
+    Some(run_program(onevent, env_vars))
 }


### PR DESCRIPTION
This PR allows librespot to perform gapless playback (issue #21). As far as I can see it's working well, but given the extent of the changes, it requires a good amount of testing.

**Features of this PR so far:**
- Upgrade of plumbing between spirc and player.
- Gapless playback: pre-loading and keeping the sink open.
- Improve notifications to Spotify: while loading a track, the status kPlayStatusLoading is sent and while playing, the correct playback position is transmitted (after loading, seek and buffer under runs).
- More and more detailed player events are produced.

The reason for having "additional features" in this one PR is that the necessary changes to the plumbing between the player and spirc made them come out naturally.

**And now to the more technical details:**
One of the first realisations was, that for gapless play there has to be better comunication between the player and spirc. Initially I thought about beefing up the future that notifies spirc about the end of a track, but then I realised, that this would kind of duplicate the player events channel that is already there. Thus, I decided to beef up the player events channel instead and get rid of the existing future. The player can now feed multiple player event channels and spirc takes one of them to listen to player events. This allows spirc to know about when to preload the next track. As a by product, it also allows spirc to have more detailed information about the player's status, in particular the current playback position.

To be able to preload tracks, loading of tracks has to happen in a non-blocking way. Initially I started to convert PlayerInternal::load_track() into a proper future. However, I eventually realised, that the call to seek() is blocking and can't be converted to proper async code easily. Thus load_track() now spawns a new (short lived) thread to load a track and put the result onto a one-shot channel. Thus, we effectively get a future that loads the next track.

I turned PlayerInternal into a future so run() is now replaced by poll(). But it still contains blocking code as before. Thus, it must not be spawned onto the tokio reactor but instead run via wait() in a dedicated thread. That's the same as before, the thread just does player.wait() instead of player.run(). The reason for this is to give PlayerInternal's main loop a context to poll multiple channels and futures as needed without having to resort to timed cycles and similar crutches.

The code is set up such that the player emits a TimeToPreloadNextTrack event when playback is 30 seconds or less to the end of the track AND the remainder of the track has been downloaded. This is the signal to SpircTask to examine the playlist (using preview_next_track()) and call player.preload_track() to have the player start with the download.

In the old code, spirc uses the protobuf frame it communicates with the server with to store its own state machine (e.g. store the playing status). This was no longer sufficient. E.g. when the status is kPlayStatusLoading, spirc must know whether it is loading to play or loading to pause. Thus, I gave SpircTask its own state (SpircPlayStatus) which allows it to accurately track what is going on.


**Next steps:**
The added events also allow to expose more information to external programs through run_program_on_events. E.g. volume changes now emit events on the channel which would make fixing #410 trivial. 


