### PR TITLE
Allow use of HTTP proxies listening on port 80

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -287,7 +287,7 @@ fn setup(args: &[String]) -> Setup {
                 |s| {
                     match Url::parse(&s) {
                         Ok(url) => {
-                            if url.host().is_none() || url.port().is_none() {
+                            if url.host().is_none() || url.port_or_known_default().is_none() {
                                 panic!("Invalid proxy url, only urls on the format \"http://host:port\" are allowed");
                             }
 


### PR DESCRIPTION
Since port 80 is the default port for the HTTP protocol, `url.port()` returns `None`, causing an "invalid proxy" message.  Using `port_or_known_default()` will only return `None` if the both the port has been omitted and an unknown protocol has been specified.

You can verify this like so:
```
$ librespot --proxy http://1.2.3.4:80
thread 'main' panicked at 'Invalid proxy url, only urls on the format "http://host:port" are allowed: "http://1.2.3.4/"', src/main.rs:291:33
```
