### PR TITLE
Make sequences wrap around to avoid overflows

### DIFF
--- a/core/src/util/mod.rs
+++ b/core/src/util/mod.rs
@@ -38,7 +38,7 @@ pub trait Seq {
 macro_rules! impl_seq {
     ($($ty:ty)*) => { $(
         impl Seq for $ty {
-            fn next(&self) -> Self { *self + 1 }
+            fn next(&self) -> Self { (*self).wrapping_add(1) }
         }
     )* }
 }


### PR DESCRIPTION
Instead of aborting with an `attempt to add with overflow` error, wrap the sequence around so that it goes back to 0 once it has reached the maximum value for the integer type.  Fixes #437.

Everything that uses sequences seems to treat them as unique values for matching asynchronous responses back to requests, so having the sequence number wrap at some point long after the original response has been received should cause no problems.