### PR TITLE
Ability to get the Spotify URI from a SpotifyId

### DIFF
--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -104,6 +104,20 @@ impl SpotifyId {
         std::str::from_utf8(&data).unwrap().to_owned()
     }
 
+    pub fn to_uri(&self) -> String {
+        match self.audio_type {
+            SpotifyAudioType::Track => {
+                format!("spotify:track:{}", self.to_base62())
+            }
+            SpotifyAudioType::Podcast => {
+                format!("spotify:episode:{}", self.to_base62())
+            }
+            SpotifyAudioType::NonPlayable => {
+                format!("spotify:unknown:{}", self.to_base62())
+            }
+        }
+    }
+
     pub fn to_raw(&self) -> [u8; 16] {
         self.id.to_be_bytes()
     }

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -106,15 +106,9 @@ impl SpotifyId {
 
     pub fn to_uri(&self) -> String {
         match self.audio_type {
-            SpotifyAudioType::Track => {
-                format!("spotify:track:{}", self.to_base62())
-            }
-            SpotifyAudioType::Podcast => {
-                format!("spotify:episode:{}", self.to_base62())
-            }
-            SpotifyAudioType::NonPlayable => {
-                format!("spotify:unknown:{}", self.to_base62())
-            }
+            SpotifyAudioType::Track => format!("spotify:track:{}", self.to_base62()),
+            SpotifyAudioType::Podcast => format!("spotify:episode:{}", self.to_base62()),
+            SpotifyAudioType::NonPlayable => format!("spotify:unknown:{}", self.to_base62()),
         }
     }
 


### PR DESCRIPTION
Was possible to determine different types of `SpotifyId` referencing the `audio_type` to format the URI when referencing it but having to write a `match` every time is redundant.

Added function due to ability to call it inside of Spotifyd when setting env for callback commands on player event.