### PR TITLE
Disable gapless playback via runtime flag

### DIFF
--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -30,6 +30,7 @@ pub struct PlayerConfig {
     pub bitrate: Bitrate,
     pub normalisation: bool,
     pub normalisation_pregain: f32,
+    pub gapless: bool,
 }
 
 impl Default for PlayerConfig {
@@ -38,6 +39,7 @@ impl Default for PlayerConfig {
             bitrate: Bitrate::default(),
             normalisation: false,
             normalisation_pregain: 0.0,
+            gapless: false,
         }
     }
 }

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -39,7 +39,7 @@ impl Default for PlayerConfig {
             bitrate: Bitrate::default(),
             normalisation: false,
             normalisation_pregain: 0.0,
-            gapless: false,
+            gapless: true,
         }
     }
 }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -828,7 +828,8 @@ impl Future for PlayerInternal {
                 ..
             } = self.state
             {
-                if (!*suggested_to_preload_next_track)
+                if self.config.gapless
+                    && (!*suggested_to_preload_next_track)
                     && ((duration_ms as i64 - Self::position_pcm_to_ms(stream_position_pcm) as i64)
                         < PRELOAD_NEXT_TRACK_BEFORE_END_DURATION_MS as i64)
                     && stream_loader_controller.range_to_end_available()

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -828,8 +828,7 @@ impl Future for PlayerInternal {
                 ..
             } = self.state
             {
-                if self.config.gapless
-                    && (!*suggested_to_preload_next_track)
+                if (!*suggested_to_preload_next_track)
                     && ((duration_ms as i64 - Self::position_pcm_to_ms(stream_position_pcm) as i64)
                         < PRELOAD_NEXT_TRACK_BEFORE_END_DURATION_MS as i64)
                     && stream_loader_controller.range_to_end_available()
@@ -1066,6 +1065,9 @@ impl PlayerInternal {
         play: bool,
         position_ms: u32,
     ) {
+        if !self.config.gapless {
+            self.ensure_sink_stopped();
+        }
         // emit the correct player event
         match self.state {
             PlayerState::Playing {

--- a/src/main.rs
+++ b/src/main.rs
@@ -180,6 +180,11 @@ fn setup(args: &[String]) -> Setup {
             "",
             "autoplay",
             "autoplay similar songs when your music ends.",
+        )
+        .optflag(
+            "",
+            "gapless",
+            "enable gapless playback.",
         );
 
     let matches = match opts.parse(&args[1..]) {
@@ -312,9 +317,9 @@ fn setup(args: &[String]) -> Setup {
             .as_ref()
             .map(|bitrate| Bitrate::from_str(bitrate).expect("Invalid bitrate"))
             .unwrap_or(Bitrate::default());
-
         PlayerConfig {
             bitrate: bitrate,
+            gapless: matches.opt_present("gapless"),
             normalisation: matches.opt_present("enable-volume-normalisation"),
             normalisation_pregain: matches
                 .opt_str("normalisation-pregain")

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,8 +183,8 @@ fn setup(args: &[String]) -> Setup {
         )
         .optflag(
             "",
-            "gapless",
-            "enable gapless playback.",
+            "disable-gapless",
+            "disable gapless playback.",
         );
 
     let matches = match opts.parse(&args[1..]) {
@@ -319,7 +319,7 @@ fn setup(args: &[String]) -> Setup {
             .unwrap_or(Bitrate::default());
         PlayerConfig {
             bitrate: bitrate,
-            gapless: matches.opt_present("gapless"),
+            gapless: !matches.opt_present("disable-gapless"),
             normalisation: matches.opt_present("enable-volume-normalisation"),
             normalisation_pregain: matches
                 .opt_str("normalisation-pregain")


### PR DESCRIPTION
Follow up to the work in #430, added a runtime flag for the feature. 

@kaymes  I didn't look at your implementation in detail - but from a [quick glance](https://github.com/ashthespy/librespot/blob/2935544be86c479a223f87d7a42ca22f0fe61d63/playback/src/player.rs#L1229-L1231)  this should suffice or will the sink continue to remain open? 
