### PR TITLE
Refactor Volume control, allow for a fixed volume option

### DIFF
--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -84,6 +84,32 @@ pub struct ConnectConfig {
     pub name: String,
     pub device_type: DeviceType,
     pub volume: u16,
-    pub linear_volume: bool,
+    pub volume_ctrl: VolumeCtrl,
     pub autoplay: bool,
+}
+
+#[derive(Clone, Debug)]
+pub enum VolumeCtrl {
+    Linear,
+    Log,
+    Fixed,
+}
+
+impl FromStr for VolumeCtrl {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        use self::VolumeCtrl::*;
+        match s.to_lowercase().as_ref() {
+            "linear" => Ok(Linear),
+            "log" => Ok(Log),
+            "fixed" => Ok(Fixed),
+            _ => Err(()),
+        }
+    }
+}
+
+impl Default for VolumeCtrl {
+    fn default() -> VolumeCtrl {
+        VolumeCtrl::Linear
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ use url::Url;
 
 use librespot::core::authentication::{get_credentials, Credentials};
 use librespot::core::cache::Cache;
-use librespot::core::config::{ConnectConfig, DeviceType, SessionConfig};
+use librespot::core::config::{ConnectConfig, DeviceType, SessionConfig, VolumeCtrl};
 use librespot::core::session::Session;
 use librespot::core::version;
 
@@ -173,10 +173,11 @@ fn setup(args: &[String]) -> Setup {
             "Pregain (dB) applied by volume normalisation",
             "PREGAIN",
         )
-        .optflag(
+        .optopt(
             "",
-            "linear-volume",
-            "increase volume linear instead of logarithmic.",
+            "volume-ctrl",
+            "Volume control type - [linear, log, fixed]. Default is logarithmic",
+            "VOLUME_CTRL"
         )
         .optflag(
             "",
@@ -337,11 +338,17 @@ fn setup(args: &[String]) -> Setup {
             .map(|device_type| DeviceType::from_str(device_type).expect("Invalid device type"))
             .unwrap_or(DeviceType::default());
 
+        let volume_ctrl = matches
+            .opt_str("volume-ctrl")
+            .as_ref()
+            .map(|volume_ctrl| VolumeCtrl::from_str(volume_ctrl).expect("Invalid volume ctrl type"))
+            .unwrap_or(VolumeCtrl::default());
+
         ConnectConfig {
             name: name,
             device_type: device_type,
             volume: initial_volume,
-            linear_volume: matches.opt_present("linear-volume"),
+            volume_ctrl: volume_ctrl,
             autoplay: matches.opt_present("autoplay"),
         }
     };


### PR DESCRIPTION
This is a (long) overdue follow up to https://github.com/librespot-org/librespot/pull/286#issuecomment-509263437.

I have refactored the old `--linear-volume` flag to a more generic `--volume-ctrl` flag that takes the options of `[linear, log, fixed]`. It defaults as previously to `log`. 

What `fixed` does is disable the client side volume control, by setting `kVolumeSteps` to 0, so no volume events are passed to the client.
![image](https://user-images.githubusercontent.com/16233271/76242952-cff6c200-6237-11ea-80e4-9cf1145bde46.png)

As usual, this will need a update of the wiki, and should be considered a "breaking change" when considering the versioning. 

Fixes #48, Closes #286