### PR TITLE
Add more data to player events and fire more of them

### DIFF
--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -99,14 +99,16 @@ pub enum PlayerEvent {
     // after a buffer-underrun
     Playing {
         play_request_id: u64,
-        track_meta_data: TrackMetaData,
+        track_id: SpotifyId,
         position_ms: u32,
+        duration_ms: u32,
     },
     // The player entered a paused state.
     Paused {
         play_request_id: u64,
-        track_meta_data: TrackMetaData,
+        track_id: SpotifyId,
         position_ms: u32,
+        duration_ms: u32,
     },
     // The player thinks it's a good idea to issue a preload command for the next track now.
     // This event is intended for use within spirc.
@@ -119,7 +121,7 @@ pub enum PlayerEvent {
     // which will trigger another event (e.g. Changed or Stopped)
     EndOfTrack {
         play_request_id: u64,
-        track_meta_data: TrackMetaData,
+        track_id: SpotifyId,
     },
     // The mixer volume was set to a new level.
     VolumeSet {
@@ -324,19 +326,12 @@ impl Drop for Player {
     }
 }
 
-#[derive(Debug, Clone)]
-pub struct TrackMetaData {
-    pub track_id: SpotifyId,
-    pub normalisation_factor: f32,
-    pub duration_ms: u32,
-    pub bytes_per_second: usize,
-    pub title: String,
-}
-
 struct PlayerLoadedTrackData {
-    track_meta_data: TrackMetaData,
     decoder: Decoder,
+    normalisation_factor: f32,
     stream_loader_controller: StreamLoaderController,
+    bytes_per_second: usize,
+    duration_ms: u32,
     stream_position_pcm: u64,
 }
 
@@ -347,6 +342,7 @@ enum PlayerPreload {
         loader: Box<dyn Future<Item = PlayerLoadedTrackData, Error = ()>>,
     },
     Ready {
+        track_id: SpotifyId,
         loaded_track: PlayerLoadedTrackData,
     },
 }
@@ -362,23 +358,30 @@ enum PlayerState {
         loader: Box<dyn Future<Item = PlayerLoadedTrackData, Error = ()>>,
     },
     Paused {
-        track_meta_data: TrackMetaData,
+        track_id: SpotifyId,
         play_request_id: u64,
         decoder: Decoder,
+        normalisation_factor: f32,
         stream_loader_controller: StreamLoaderController,
+        bytes_per_second: usize,
+        duration_ms: u32,
         stream_position_pcm: u64,
         suggested_to_preload_next_track: bool,
     },
     Playing {
-        track_meta_data: TrackMetaData,
+        track_id: SpotifyId,
         play_request_id: u64,
         decoder: Decoder,
+        normalisation_factor: f32,
         stream_loader_controller: StreamLoaderController,
+        bytes_per_second: usize,
+        duration_ms: u32,
         stream_position_pcm: u64,
         reported_nominal_start_time: Option<Instant>,
         suggested_to_preload_next_track: bool,
     },
     EndOfTrack {
+        track_id: SpotifyId,
         play_request_id: u64,
         loaded_track: PlayerLoadedTrackData,
     },
@@ -437,18 +440,24 @@ impl PlayerState {
         use self::PlayerState::*;
         match mem::replace(self, Invalid) {
             Playing {
-                track_meta_data,
+                track_id,
                 play_request_id,
                 decoder,
+                duration_ms,
+                bytes_per_second,
+                normalisation_factor,
                 stream_loader_controller,
                 stream_position_pcm,
                 ..
             } => {
                 *self = EndOfTrack {
+                    track_id,
                     play_request_id,
                     loaded_track: PlayerLoadedTrackData {
-                        track_meta_data,
                         decoder,
+                        duration_ms,
+                        bytes_per_second,
+                        normalisation_factor,
                         stream_loader_controller,
                         stream_position_pcm,
                     },
@@ -462,18 +471,24 @@ impl PlayerState {
         use self::PlayerState::*;
         match ::std::mem::replace(self, Invalid) {
             Paused {
-                track_meta_data,
+                track_id,
                 play_request_id,
                 decoder,
+                normalisation_factor,
                 stream_loader_controller,
+                duration_ms,
+                bytes_per_second,
                 stream_position_pcm,
                 suggested_to_preload_next_track,
             } => {
                 *self = Playing {
-                    track_meta_data,
+                    track_id,
                     play_request_id,
                     decoder,
+                    normalisation_factor,
                     stream_loader_controller,
+                    duration_ms,
+                    bytes_per_second,
                     stream_position_pcm,
                     reported_nominal_start_time: None,
                     suggested_to_preload_next_track,
@@ -487,19 +502,25 @@ impl PlayerState {
         use self::PlayerState::*;
         match ::std::mem::replace(self, Invalid) {
             Playing {
-                track_meta_data,
+                track_id,
                 play_request_id,
                 decoder,
+                normalisation_factor,
                 stream_loader_controller,
+                duration_ms,
+                bytes_per_second,
                 stream_position_pcm,
                 reported_nominal_start_time: _,
                 suggested_to_preload_next_track,
             } => {
                 *self = Paused {
-                    track_meta_data,
+                    track_id,
                     play_request_id,
                     decoder,
+                    normalisation_factor,
                     stream_loader_controller,
+                    duration_ms,
+                    bytes_per_second,
                     stream_position_pcm,
                     suggested_to_preload_next_track,
                 };
@@ -669,15 +690,11 @@ impl PlayerTrackLoader {
         let stream_position_pcm = PlayerInternal::position_ms_to_pcm(position_ms);
         info!("<{}> ({} ms) loaded", audio.name, audio.duration);
         Some(PlayerLoadedTrackData {
-            track_meta_data: TrackMetaData {
-                track_id: spotify_id,
-                normalisation_factor,
-                bytes_per_second,
-                duration_ms,
-                title: audio.name.clone(),
-            },
             decoder,
+            normalisation_factor,
             stream_loader_controller,
+            bytes_per_second,
+            duration_ms,
             stream_position_pcm,
         })
     }
@@ -712,14 +729,19 @@ impl Future for PlayerInternal {
             // Handle loading of a new track to play
             if let PlayerState::Loading {
                 ref mut loader,
+                track_id,
                 start_playback,
                 play_request_id,
-                ..
             } = self.state
             {
                 match loader.poll() {
                     Ok(Async::Ready(loaded_track)) => {
-                        self.start_playback(play_request_id, loaded_track, start_playback);
+                        self.start_playback(
+                            track_id,
+                            play_request_id,
+                            loaded_track,
+                            start_playback,
+                        );
                         if let PlayerState::Loading { .. } = self.state {
                             panic!("The state wasn't changed by start_playback()");
                         }
@@ -733,10 +755,17 @@ impl Future for PlayerInternal {
             }
 
             // handle pending preload requests.
-            if let PlayerPreload::Loading { ref mut loader, .. } = self.preload {
+            if let PlayerPreload::Loading {
+                ref mut loader,
+                track_id,
+            } = self.preload
+            {
                 match loader.poll() {
                     Ok(Async::Ready(loaded_track)) => {
-                        self.preload = PlayerPreload::Ready { loaded_track };
+                        self.preload = PlayerPreload::Ready {
+                            track_id,
+                            loaded_track,
+                        };
                     }
                     Ok(Async::NotReady) => (),
                     Err(_) => {
@@ -749,16 +778,16 @@ impl Future for PlayerInternal {
                 self.ensure_sink_running();
 
                 if let PlayerState::Playing {
-                    ref track_meta_data,
+                    track_id,
                     play_request_id,
                     ref mut decoder,
+                    normalisation_factor,
                     ref mut stream_position_pcm,
                     ref mut reported_nominal_start_time,
+                    duration_ms,
                     ..
                 } = self.state
                 {
-                    let track_meta_data = track_meta_data.clone();
-                    let normalisation_factor = track_meta_data.normalisation_factor;
                     let packet = decoder.next_packet().expect("Vorbis error");
 
                     if let Some(ref packet) = packet {
@@ -786,9 +815,10 @@ impl Future for PlayerInternal {
                                     - Duration::from_millis(stream_position_millis as u64),
                             );
                             self.send_event(PlayerEvent::Playing {
-                                track_meta_data,
+                                track_id,
                                 play_request_id,
                                 position_ms: stream_position_millis as u32,
+                                duration_ms,
                             });
                         }
                     }
@@ -800,16 +830,18 @@ impl Future for PlayerInternal {
             }
 
             if let PlayerState::Playing {
-                ref track_meta_data,
+                track_id,
                 play_request_id,
+                duration_ms,
                 stream_position_pcm,
                 ref mut stream_loader_controller,
                 ref mut suggested_to_preload_next_track,
                 ..
             }
             | PlayerState::Paused {
-                ref track_meta_data,
+                track_id,
                 play_request_id,
+                duration_ms,
                 stream_position_pcm,
                 ref mut stream_loader_controller,
                 ref mut suggested_to_preload_next_track,
@@ -817,15 +849,13 @@ impl Future for PlayerInternal {
             } = self.state
             {
                 if (!*suggested_to_preload_next_track)
-                    && ((track_meta_data.duration_ms as i64
-                        - Self::position_pcm_to_ms(stream_position_pcm) as i64)
+                    && ((duration_ms as i64 - Self::position_pcm_to_ms(stream_position_pcm) as i64)
                         < PRELOAD_NEXT_TRACK_BEFORE_END_DURATION_MS as i64)
                     && stream_loader_controller.range_to_end_available()
                 {
                     *suggested_to_preload_next_track = true;
-                    let track_meta_data = track_meta_data.clone();
                     self.send_event(PlayerEvent::TimeToPreloadNextTrack {
-                        track_id: track_meta_data.track_id,
+                        track_id,
                         play_request_id,
                     });
                 }
@@ -872,21 +902,17 @@ impl PlayerInternal {
     fn handle_player_stop(&mut self) {
         match self.state {
             PlayerState::Playing {
-                track_meta_data: TrackMetaData { track_id, .. },
+                track_id,
                 play_request_id,
                 ..
             }
             | PlayerState::Paused {
-                track_meta_data: TrackMetaData { track_id, .. },
+                track_id,
                 play_request_id,
                 ..
             }
             | PlayerState::EndOfTrack {
-                loaded_track:
-                    PlayerLoadedTrackData {
-                        track_meta_data: TrackMetaData { track_id, .. },
-                        ..
-                    },
+                track_id,
                 play_request_id,
                 ..
             }
@@ -909,20 +935,21 @@ impl PlayerInternal {
 
     fn handle_play(&mut self) {
         if let PlayerState::Paused {
-            ref track_meta_data,
+            track_id,
             play_request_id,
             stream_position_pcm,
+            duration_ms,
             ..
         } = self.state
         {
-            let track_meta_data = track_meta_data.clone();
             self.state.paused_to_playing();
 
             let position_ms = Self::position_pcm_to_ms(stream_position_pcm);
             self.send_event(PlayerEvent::Playing {
-                track_meta_data,
+                track_id,
                 play_request_id,
                 position_ms,
+                duration_ms,
             });
             self.ensure_sink_running();
         } else {
@@ -932,22 +959,22 @@ impl PlayerInternal {
 
     fn handle_pause(&mut self) {
         if let PlayerState::Playing {
-            ref track_meta_data,
+            track_id,
             play_request_id,
             stream_position_pcm,
+            duration_ms,
             ..
         } = self.state
         {
-            let track_meta_data = track_meta_data.clone();
-
             self.state.playing_to_paused();
 
             self.ensure_sink_stopped();
             let position_ms = Self::position_pcm_to_ms(stream_position_pcm);
             self.send_event(PlayerEvent::Paused {
-                track_meta_data,
+                track_id,
                 play_request_id,
                 position_ms,
+                duration_ms,
             });
         } else {
             warn!("Player::pause called from invalid state");
@@ -978,18 +1005,13 @@ impl PlayerInternal {
             None => {
                 self.state.playing_to_end_of_track();
                 if let PlayerState::EndOfTrack {
-                    loaded_track:
-                        PlayerLoadedTrackData {
-                            ref track_meta_data,
-                            ..
-                        },
+                    track_id,
                     play_request_id,
                     ..
                 } = self.state
                 {
-                    let track_meta_data = track_meta_data.clone();
                     self.send_event(PlayerEvent::EndOfTrack {
-                        track_meta_data,
+                        track_id,
                         play_request_id,
                     })
                 } else {
@@ -1001,6 +1023,7 @@ impl PlayerInternal {
 
     fn start_playback(
         &mut self,
+        track_id: SpotifyId,
         play_request_id: u64,
         loaded_track: PlayerLoadedTrackData,
         start_playback: bool,
@@ -1011,16 +1034,20 @@ impl PlayerInternal {
             self.ensure_sink_running();
 
             self.send_event(PlayerEvent::Playing {
-                track_meta_data: loaded_track.track_meta_data.clone(),
+                track_id,
                 play_request_id,
                 position_ms,
+                duration_ms: loaded_track.duration_ms,
             });
 
             self.state = PlayerState::Playing {
-                track_meta_data: loaded_track.track_meta_data,
+                track_id: track_id,
                 play_request_id: play_request_id,
                 decoder: loaded_track.decoder,
+                normalisation_factor: loaded_track.normalisation_factor,
                 stream_loader_controller: loaded_track.stream_loader_controller,
+                duration_ms: loaded_track.duration_ms,
+                bytes_per_second: loaded_track.bytes_per_second,
                 stream_position_pcm: loaded_track.stream_position_pcm,
                 reported_nominal_start_time: Some(
                     Instant::now() - Duration::from_millis(position_ms as u64),
@@ -1030,21 +1057,23 @@ impl PlayerInternal {
         } else {
             self.ensure_sink_stopped();
 
-            let track_meta_data = loaded_track.track_meta_data.clone();
-
             self.state = PlayerState::Paused {
-                track_meta_data: loaded_track.track_meta_data,
+                track_id: track_id,
                 play_request_id: play_request_id,
                 decoder: loaded_track.decoder,
+                normalisation_factor: loaded_track.normalisation_factor,
                 stream_loader_controller: loaded_track.stream_loader_controller,
+                duration_ms: loaded_track.duration_ms,
+                bytes_per_second: loaded_track.bytes_per_second,
                 stream_position_pcm: loaded_track.stream_position_pcm,
                 suggested_to_preload_next_track: false,
             };
 
             self.send_event(PlayerEvent::Paused {
-                track_meta_data,
+                track_id,
                 play_request_id,
                 position_ms,
+                duration_ms: loaded_track.duration_ms,
             });
         }
     }
@@ -1062,31 +1091,15 @@ impl PlayerInternal {
         // emit the correct player event
         match self.state {
             PlayerState::Playing {
-                track_meta_data:
-                    TrackMetaData {
-                        track_id: old_track_id,
-                        ..
-                    },
+                track_id: old_track_id,
                 ..
             }
             | PlayerState::Paused {
-                track_meta_data:
-                    TrackMetaData {
-                        track_id: old_track_id,
-                        ..
-                    },
+                track_id: old_track_id,
                 ..
             }
             | PlayerState::EndOfTrack {
-                loaded_track:
-                    PlayerLoadedTrackData {
-                        track_meta_data:
-                            TrackMetaData {
-                                track_id: old_track_id,
-                                ..
-                            },
-                        ..
-                    },
+                track_id: old_track_id,
                 ..
             }
             | PlayerState::Loading {
@@ -1110,18 +1123,16 @@ impl PlayerInternal {
         // Check if there's a matching loaded track in the EndOfTrack player state.
         // This is the case if we're repeating the same track again.
         if let PlayerState::EndOfTrack {
-            ref mut loaded_track,
+            track_id: previous_track_id,
             ..
         } = self.state
         {
-            if loaded_track.track_meta_data.track_id == track_id {
+            if previous_track_id == track_id {
                 let mut loaded_track = match mem::replace(&mut self.state, PlayerState::Invalid) {
                     PlayerState::EndOfTrack { loaded_track, .. } => loaded_track,
                     _ => unreachable!(),
                 };
 
-                //let loaded_track = mem::replace(&mut *loaded_track, None);
-                //if let Some(mut loaded_track) = loaded_track {
                 if Self::position_ms_to_pcm(position_ms) != loaded_track.stream_position_pcm {
                     loaded_track
                         .stream_loader_controller
@@ -1134,32 +1145,31 @@ impl PlayerInternal {
                     loaded_track.stream_position_pcm = Self::position_ms_to_pcm(position_ms);
                 }
                 self.preload = PlayerPreload::None;
-                self.start_playback(play_request_id, loaded_track, play);
+                self.start_playback(track_id, play_request_id, loaded_track, play);
                 if let PlayerState::Invalid = self.state {
                     panic!("start_playback() hasn't set a valid player state.");
                 }
                 return;
-                //}
             }
         }
 
         // Check if we are already playing the track. If so, just do a seek and update our info.
         if let PlayerState::Playing {
-            ref track_meta_data,
+            track_id: current_track_id,
             ref mut stream_position_pcm,
             ref mut decoder,
             ref mut stream_loader_controller,
             ..
         }
         | PlayerState::Paused {
-            ref track_meta_data,
+            track_id: current_track_id,
             ref mut stream_position_pcm,
             ref mut decoder,
             ref mut stream_loader_controller,
             ..
         } = self.state
         {
-            if track_meta_data.track_id == track_id {
+            if current_track_id == track_id {
                 // we can use the current decoder. Ensure it's at the correct position.
                 if Self::position_ms_to_pcm(position_ms) != *stream_position_pcm {
                     stream_loader_controller.set_random_access_mode();
@@ -1173,29 +1183,35 @@ impl PlayerInternal {
                 let old_state = mem::replace(&mut self.state, PlayerState::Invalid);
 
                 if let PlayerState::Playing {
-                    track_meta_data,
                     stream_position_pcm,
                     decoder,
                     stream_loader_controller,
+                    bytes_per_second,
+                    duration_ms,
+                    normalisation_factor,
                     ..
                 }
                 | PlayerState::Paused {
-                    track_meta_data,
                     stream_position_pcm,
                     decoder,
                     stream_loader_controller,
+                    bytes_per_second,
+                    duration_ms,
+                    normalisation_factor,
                     ..
                 } = old_state
                 {
                     let loaded_track = PlayerLoadedTrackData {
-                        track_meta_data,
                         decoder,
+                        normalisation_factor,
                         stream_loader_controller,
+                        bytes_per_second,
+                        duration_ms,
                         stream_position_pcm,
                     };
 
                     self.preload = PlayerPreload::None;
-                    self.start_playback(play_request_id, loaded_track, play);
+                    self.start_playback(track_id, play_request_id, loaded_track, play);
 
                     if let PlayerState::Invalid = self.state {
                         panic!("start_playback() hasn't set a valid player state.");
@@ -1210,17 +1226,17 @@ impl PlayerInternal {
 
         // Check if the requested track has been preloaded already. If so use the preloaded data.
         if let PlayerPreload::Ready {
-            loaded_track:
-                PlayerLoadedTrackData {
-                    ref track_meta_data,
-                    ..
-                },
+            track_id: loaded_track_id,
             ..
         } = self.preload
         {
-            if track_id == track_meta_data.track_id {
+            if track_id == loaded_track_id {
                 let preload = std::mem::replace(&mut self.preload, PlayerPreload::None);
-                if let PlayerPreload::Ready { mut loaded_track } = preload {
+                if let PlayerPreload::Ready {
+                    track_id,
+                    mut loaded_track,
+                } = preload
+                {
                     if Self::position_ms_to_pcm(position_ms) != loaded_track.stream_position_pcm {
                         loaded_track
                             .stream_loader_controller
@@ -1228,7 +1244,7 @@ impl PlayerInternal {
                         let _ = loaded_track.decoder.seek(position_ms as i64); // This may be blocking
                         loaded_track.stream_loader_controller.set_stream_mode();
                     }
-                    self.start_playback(play_request_id, loaded_track, play);
+                    self.start_playback(track_id, play_request_id, loaded_track, play);
                     return;
                 } else {
                     unreachable!();
@@ -1293,15 +1309,7 @@ impl PlayerInternal {
             ..
         }
         | PlayerPreload::Ready {
-            loaded_track:
-                PlayerLoadedTrackData {
-                    track_meta_data:
-                        TrackMetaData {
-                            track_id: currently_loading,
-                            ..
-                        },
-                    ..
-                },
+            track_id: currently_loading,
             ..
         } = self.preload
         {
@@ -1315,23 +1323,19 @@ impl PlayerInternal {
         }
 
         if let PlayerState::Playing {
-            ref track_meta_data,
+            track_id: current_track_id,
             ..
         }
         | PlayerState::Paused {
-            ref track_meta_data,
+            track_id: current_track_id,
             ..
         }
         | PlayerState::EndOfTrack {
-            loaded_track:
-                PlayerLoadedTrackData {
-                    ref track_meta_data,
-                    ..
-                },
+            track_id: current_track_id,
             ..
         } = self.state
         {
-            if track_meta_data.track_id == track_id {
+            if current_track_id == track_id {
                 // we already have the requested track loaded.
                 preload_track = false;
             }
@@ -1378,32 +1382,34 @@ impl PlayerInternal {
         self.preload_data_before_playback();
 
         if let PlayerState::Playing {
-            ref track_meta_data,
+            track_id,
             play_request_id,
             ref mut reported_nominal_start_time,
+            duration_ms,
             ..
         } = self.state
         {
             *reported_nominal_start_time =
                 Some(Instant::now() - Duration::from_millis(position_ms as u64));
-            let track_meta_data = track_meta_data.clone();
             self.send_event(PlayerEvent::Playing {
-                track_meta_data,
+                track_id,
                 play_request_id,
                 position_ms,
+                duration_ms,
             });
         }
         if let PlayerState::Paused {
-            ref track_meta_data,
+            track_id,
             play_request_id,
+            duration_ms,
             ..
         } = self.state
         {
-            let track_meta_data = track_meta_data.clone();
             self.send_event(PlayerEvent::Paused {
-                track_meta_data,
+                track_id,
                 play_request_id,
                 position_ms,
+                duration_ms,
             });
         }
     }
@@ -1480,7 +1486,7 @@ impl PlayerInternal {
 
     fn preload_data_before_playback(&mut self) {
         if let PlayerState::Playing {
-            ref track_meta_data,
+            bytes_per_second,
             ref mut stream_loader_controller,
             ..
         } = self.state
@@ -1489,9 +1495,8 @@ impl PlayerInternal {
             let request_data_length = max(
                 (READ_AHEAD_DURING_PLAYBACK_ROUNDTRIPS
                     * (0.001 * stream_loader_controller.ping_time_ms() as f64)
-                    * track_meta_data.bytes_per_second as f64) as usize,
-                (READ_AHEAD_DURING_PLAYBACK_SECONDS * track_meta_data.bytes_per_second as f64)
-                    as usize,
+                    * bytes_per_second as f64) as usize,
+                (READ_AHEAD_DURING_PLAYBACK_SECONDS * bytes_per_second as f64) as usize,
             );
             stream_loader_controller.fetch_next(request_data_length);
 
@@ -1499,9 +1504,8 @@ impl PlayerInternal {
             let wait_for_data_length = max(
                 (READ_AHEAD_BEFORE_PLAYBACK_ROUNDTRIPS
                     * (0.001 * stream_loader_controller.ping_time_ms() as f64)
-                    * track_meta_data.bytes_per_second as f64) as usize,
-                (READ_AHEAD_BEFORE_PLAYBACK_SECONDS * track_meta_data.bytes_per_second as f64)
-                    as usize,
+                    * bytes_per_second as f64) as usize,
+                (READ_AHEAD_BEFORE_PLAYBACK_SECONDS * bytes_per_second as f64) as usize,
             );
             stream_loader_controller.fetch_next_blocking(wait_for_data_length);
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -543,6 +543,7 @@ impl Future for Main {
 
             if let Some(ref mut player_event_channel) = self.player_event_channel {
                 if let Async::Ready(Some(event)) = player_event_channel.poll().unwrap() {
+                    progress = true;
                     if let Some(ref program) = self.player_event_program {
                         if let Some(child) = run_program_on_events(event, program) {
                             let child = child

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -1,5 +1,4 @@
 use librespot::playback::player::PlayerEvent;
-use librespot_playback::player::TrackMetaData;
 use log::info;
 use std::collections::HashMap;
 use std::io;
@@ -13,12 +12,6 @@ fn run_program(program: &str, env_vars: HashMap<&str, String>) -> io::Result<Chi
         .args(&v)
         .envs(env_vars.iter())
         .spawn_async()
-}
-
-fn add_meta_data_to_env_vars(env_vars: &mut HashMap<&str, String>, track_meta_data: TrackMetaData) {
-    env_vars.insert("TRACK_ID", track_meta_data.track_id.to_base62());
-    env_vars.insert("DURATION_MS", track_meta_data.duration_ms.to_string());
-    env_vars.insert("TRACK_TITLE", track_meta_data.title);
 }
 
 pub fn run_program_on_events(event: PlayerEvent, onevent: &str) -> Option<io::Result<Child>> {
@@ -41,21 +34,25 @@ pub fn run_program_on_events(event: PlayerEvent, onevent: &str) -> Option<io::Re
             env_vars.insert("TRACK_ID", track_id.to_base62());
         }
         PlayerEvent::Playing {
-            track_meta_data,
+            track_id,
+            duration_ms,
             position_ms,
             ..
         } => {
             env_vars.insert("PLAYER_EVENT", "playing".to_string());
-            add_meta_data_to_env_vars(&mut env_vars, track_meta_data);
+            env_vars.insert("TRACK_ID", track_id.to_base62());
+            env_vars.insert("DURATION_MS", duration_ms.to_string());
             env_vars.insert("POSITION_MS", position_ms.to_string());
         }
         PlayerEvent::Paused {
-            track_meta_data,
+            track_id,
+            duration_ms,
             position_ms,
             ..
         } => {
             env_vars.insert("PLAYER_EVENT", "paused".to_string());
-            add_meta_data_to_env_vars(&mut env_vars, track_meta_data);
+            env_vars.insert("TRACK_ID", track_id.to_base62());
+            env_vars.insert("DURATION_MS", duration_ms.to_string());
             env_vars.insert("POSITION_MS", position_ms.to_string());
         }
         PlayerEvent::VolumeSet { volume } => {

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -18,7 +18,7 @@ fn run_program(program: &str, env_vars: HashMap<&str, String>) -> io::Result<Chi
 fn add_meta_data_to_env_vars(env_vars: &mut HashMap<&str, String>, track_meta_data: TrackMetaData) {
     env_vars.insert("TRACK_ID", track_meta_data.track_id.to_base62());
     env_vars.insert("DURATION_MS", track_meta_data.duration_ms.to_string());
-    env_vars.insert("TITLE", track_meta_data.title);
+    env_vars.insert("TRACK_TITLE", track_meta_data.title);
 }
 
 pub fn run_program_on_events(event: PlayerEvent, onevent: &str) -> Option<io::Result<Child>> {


### PR DESCRIPTION
This PR adds more metadata to the PlayerEvents. I also added some comments that explain which PlayerEvent is fired when.

More PlayerEvents are now exposed through the --onevent script and the additional meta data is made available through additional environment variables.

Currently the additional metadata that is being exported is the title of the current track and its length.
It would be nice to add the Artist and maybe the cover art URL as well but this requires loading of additional information from the server. At this stage I'm only making available what's already there. So that's half of #439. 
(Loading the Artist info shouldn't be too difficult, but there doesn't seem to be an interface for the cover art yet - at least I couldn't find it in the code or protobuf definition).

While doing so I realised that a growing set of metadata variables is getting passed around within the player. Thus I decided to refactor this and bundle them into a TrackMetaData struct. This should make it much easier to add more fields in the future.

The events that trigger the --onevent script are:
start
change
stop
playing
paused
volume_set

The first three events are as before and the last three are new. 

Only playing and paused provide the additional meta data. The reason is that start and change are fired before the track has been loaded, so the data isn't available.

The volume_set event solves one half of #410. (the second half is suppressing the volume change within librespot).