### PR TITLE
Only format with stable rustfmt

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,23 @@ cache:
 # But don't cache the cargo registry
 before_cache:
   - rm -rf /home/travis/.cargo/registry
-  
+
+matrix:
+  # Performance tweak
+  fast_finish: true
+  # Ignore failures in nightly, not ideal, but necessary
+  allow_failures:
+  - rust: nightly
+
+  # Only run the formatting check for stable
+  include:
+  - name: 'Rust: format check'
+    rust: stable
+    install:
+    - rustup component add rustfmt
+    script:
+    - cargo fmt --verbose --all -- --check
+
 addons:
   apt:
     packages:
@@ -26,14 +42,12 @@ addons:
       - libsdl2-dev
 
 before_script:
-    - rustup component add rustfmt
     - mkdir -p ~/.cargo
     - echo '[target.armv7-unknown-linux-gnueabihf]' > ~/.cargo/config
     - echo 'linker = "arm-linux-gnueabihf-gcc"' >> ~/.cargo/config
     - rustup target add armv7-unknown-linux-gnueabihf
 
 script:
-    - cargo +stable fmt --all -- --check
     - cargo build --locked --no-default-features
     - cargo build --locked --examples
     - cargo build --locked --no-default-features --features "with-tremor"

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_script:
     - rustup target add armv7-unknown-linux-gnueabihf
 
 script:
-    - cargo fmt --all -- --check
+    - cargo +stable fmt --all -- --check
     - cargo build --locked --no-default-features
     - cargo build --locked --examples
     - cargo build --locked --no-default-features --features "with-tremor"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,10 +31,10 @@ Make any changes that you are going to make to the code, but do not commit yet.
 
 Make sure that the code is correctly formatted by running:
 ```bash
-cargo fmt --all
+cargo +stable fmt --all
 ```
 
-This command runs the previously installed ```rustfmt```, a code formatting tool that will automatically correct any formatting that you have used that does not conform with the librespot code style. Once that command has run, you will need to rebuild the project:
+This command runs the previously installed stable version of ```rustfmt```, a code formatting tool that will automatically correct any formatting that you have used that does not conform with the librespot code style. Once that command has run, you will need to rebuild the project:
 
 ```bash
 cargo build


### PR DESCRIPTION
This means there are 5 distinct travis jobs - delaying the nightly build as we're only allowed 4 parrallel. But I've also made nightly an allowed_fail and enabled fast_finish which means the over-all time-to-ci-result is at worst the same as before. We'll see formatting failures in under 2 minutes which is nice.