### PR TITLE
softmixer: Reduce special-casing

### DIFF
--- a/playback/src/mixer/softmixer.rs
+++ b/playback/src/mixer/softmixer.rs
@@ -37,10 +37,8 @@ struct SoftVolumeApplier {
 impl AudioFilter for SoftVolumeApplier {
     fn modify_stream(&self, data: &mut [i16]) {
         let volume = self.volume.load(Ordering::Relaxed) as u16;
-        if volume != 0xFFFF {
-            for x in data.iter_mut() {
-                *x = (*x as i32 * volume as i32 / 0xFFFF) as i16;
-            }
+        for x in data.iter_mut() {
+            *x = (*x as i32 * volume as i32 / 0xFFFF) as i16;
         }
     }
 }


### PR DESCRIPTION
Sometimes saving a multiplication per sample doesn't seem to be worth the complication of the code, I'd say.