### PR TITLE
Skip unplayable tracks instead of stopping

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -910,13 +910,17 @@ impl SpircTask {
             | SpircPlayStatus::Stopped => (),
         }
     }
+
     // Mark unavailable tracks so we can skip them later
     fn handle_unavailable(&mut self, track_id: SpotifyId) {
-        let unavailables = self.get_track_index_for_spotify_id(
-            &track_id,
-            self.state.get_playing_track_index() as usize,
-        );
-
+        let playing_index = self.state.get_playing_track_index() as usize;
+        let search_from = if playing_index == self.state.get_track().len() - 1 {
+            trace!("Cycling back to 0 instead of {:?}", playing_index);
+            0
+        } else {
+            playing_index
+        };
+        let unavailables = self.get_track_index_for_spotify_id(&track_id, search_from);
         for &index in unavailables.iter() {
             debug_assert_eq!(self.state.get_track()[index].get_gid(), track_id.to_raw());
             let mut unplayable_track_ref = TrackRef::new();

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -913,20 +913,7 @@ impl SpircTask {
 
     // Mark unavailable tracks so we can skip them later
     fn handle_unavailable(&mut self, track_id: SpotifyId) {
-        let playing_index = self.state.get_playing_track_index() as usize;
-        let mut unavailables = self.get_track_index_for_spotify_id(&track_id, playing_index);
-        if unavailables.is_empty() {
-            trace!(
-                "Couldn't find unavailables searching from {:?} -- {:?}, cycling through entire playlist",
-                playing_index,
-                self.state.get_track().len()
-            );
-            // We could just do this everytime, but for most cases it's needless overhead.
-            // we are still repeating the serach for (playing_index..) in this case
-            unavailables = self.get_track_index_for_spotify_id(&track_id, 0);
-        }
-        // Sanity check
-        debug_assert!(!unavailables.is_empty());
+        let unavailables = self.get_track_index_for_spotify_id(&track_id, 0);
         for &index in unavailables.iter() {
             debug_assert_eq!(self.state.get_track()[index].get_gid(), track_id.to_raw());
             let mut unplayable_track_ref = TrackRef::new();
@@ -1191,6 +1178,8 @@ impl SpircTask {
             .filter(|&(_, track_ref)| track_ref.get_gid() == track_id.to_raw())
             .map(|(idx, _)| start_index + idx)
             .collect();
+        // Sanity check
+        debug_assert!(!index.is_empty());
         index
     }
 
@@ -1222,9 +1211,7 @@ impl SpircTask {
         {
             warn!(
                 "Skipping track <{:?}> at position [{}] of {}",
-                track_ref.get_uri(),
-                new_playlist_index,
-                tracks_len
+                track_ref, new_playlist_index, tracks_len
             );
 
             new_playlist_index += 1;

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1170,9 +1170,9 @@ impl SpircTask {
     }
 
     fn get_track_id_to_play_from_playlist(&self, index: u32) -> Option<(SpotifyId, u32)> {
-        let tracks_len = self.state.get_track().len() as u32;
+        let tracks_len = self.state.get_track().len();
 
-        let mut new_playlist_index = index;
+        let mut new_playlist_index = index as usize;
 
         if new_playlist_index >= tracks_len {
             new_playlist_index = 0;
@@ -1184,7 +1184,7 @@ impl SpircTask {
         // tracks in each frame either have a gid or uri (that may or may not be a valid track)
         // E.g - context based frames sometimes contain tracks with <spotify:meta:page:>
 
-        let mut track_ref = self.state.get_track()[new_playlist_index as usize].clone();
+        let mut track_ref = self.state.get_track()[new_playlist_index].clone();
         let mut track_id = self.get_spotify_id_for_track(&track_ref);
         while track_id.is_err() || track_id.unwrap().audio_type == SpotifyAudioType::NonPlayable {
             warn!(
@@ -1203,12 +1203,12 @@ impl SpircTask {
                 warn!("No playable track found in state: {:?}", self.state);
                 return None;
             }
-            track_ref = self.state.get_track()[index as usize].clone();
+            track_ref = self.state.get_track()[new_playlist_index].clone();
             track_id = self.get_spotify_id_for_track(&track_ref);
         }
 
         match track_id {
-            Ok(track_id) => Some((track_id, new_playlist_index)),
+            Ok(track_id) => Some((track_id, new_playlist_index as u32)),
             Err(_) => None,
         }
     }


### PR DESCRIPTION
Restoring the previous behaviour of skipping unplayable tracks. 
Not tested the case when a unplayable track is at the end of a playlist though..
>
>Yeah, sorry; here's one example:
>- https://open.spotify.com/playlist/4HrLayxlfZuW8YNwuK1g41?si=6_9XTofvTSW1ry4IY-95eg
>- spotify:playlist:4HrLayxlfZuW8YNwuK1g41
>
>_Originally posted by @pachulo in https://github.com/balbuze/volumio-plugins/issues/266#issuecomment-622396906_

@kaymes Do you see any issues?