### PR TITLE
Don't send kPlayStatusLoading.

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1191,10 +1191,11 @@ impl SpircTask {
                 self.play_request_id = Some(self.player.load(track, start_playing, position_ms));
 
                 self.update_state_position(position_ms);
-                self.state.set_status(PlayStatus::kPlayStatusLoading);
                 if start_playing {
+                    self.state.set_status(PlayStatus::kPlayStatusPlay);
                     self.play_status = SpircPlayStatus::LoadingPlay { position_ms };
                 } else {
+                    self.state.set_status(PlayStatus::kPlayStatusPause);
                     self.play_status = SpircPlayStatus::LoadingPause { position_ms };
                 }
             }


### PR DESCRIPTION
It seems like Spotify changed the way the app behaves for kPlayStatusLoading. When I wrote this code, I tested it quite a bit with the desktop client (Linux) and the Android app. The behaviour for kPlayStatusLoading was that the desktop client would grey out the progress bar and the Android app just ignored it.
My understanding of kPlayStatusLoading was that it should be sent while loading a track but not yet playing it, so that's what I programmed.

With the new behaviour of the app, it seems like my interpretation of kPlayStatusLoading was wrong because the way the app behaves is indeed annoying and doesn't make sense when loading a track. Maybe it is intended to be sent during the start-up phase of a user-controlled client. I don't know.

In any case, librespot should probably refrain from using kPlayStatusLoading for now.

This PR changes the behaviour such that instead of kPlayStatusLoading a kPlayStatusPlay or kPlayStatusPaused is sent. When the track is actually loaded, the status is sent again (as before) so the timing is corrected.

The behaviour is that when you start to play a track, the progress bar in the client starts moving even though librespot is still loading. Once the track is loaded the bar jumps back to the correct position.

Not 100% clean but this was the behaviour of the app before Spotify changed it. Thus it should solve #461.
