### PR TITLE
Alsa backend better buffering

### DIFF
--- a/playback/src/audio_backend/alsa.rs
+++ b/playback/src/audio_backend/alsa.rs
@@ -111,6 +111,7 @@ impl Sink for AlsaSink {
             pcm.drain().unwrap();
         }
         self.pcm = None;
+        self.buffered_data = 0;
         Ok(())
     }
 

--- a/playback/src/audio_backend/alsa.rs
+++ b/playback/src/audio_backend/alsa.rs
@@ -41,7 +41,8 @@ fn open_device(dev_name: &str) -> Result<(PCM), Box<Error>> {
         hwp.set_format(Format::s16())?;
         hwp.set_rate(44100, ValueOr::Nearest)?;
         hwp.set_channels(2)?;
-        hwp.set_buffer_size_near(22050)?; // ~ 0.5s latency
+        hwp.set_period_size_near(5512, ValueOr::Nearest)?; // Period of roughly 125ms
+        hwp.set_buffer_size_near(22048)?; // ~ 0.5s latency
         pcm.hw_params(&hwp)?;
 
         let swp = pcm.sw_params_current()?;

--- a/playback/src/audio_backend/alsa.rs
+++ b/playback/src/audio_backend/alsa.rs
@@ -35,7 +35,7 @@ fn list_outputs() {
 
 fn open_device(dev_name: &str) -> Result<(PCM, Frames), Box<Error>> {
     let pcm = PCM::new(dev_name, Direction::Playback, false)?;
-    let period_size = PREFERED_PERIOD_SIZE;
+    let mut period_size = PREFERED_PERIOD_SIZE;
     // http://www.linuxjournal.com/article/6735?page=0,1#N0x19ab2890.0x19ba78d8
     // latency = period_size * periods / (rate * bytes_per_frame)
     // For 16 Bit stereo data, one frame has a length of four bytes.
@@ -50,7 +50,7 @@ fn open_device(dev_name: &str) -> Result<(PCM, Frames), Box<Error>> {
         hwp.set_format(Format::s16())?;
         hwp.set_rate(44100, ValueOr::Nearest)?;
         hwp.set_channels(2)?;
-        let period_size = hwp.set_period_size_near(period_size, ValueOr::Greater)?;
+        period_size = hwp.set_period_size_near(period_size, ValueOr::Greater)?;
         hwp.set_buffer_size_near(period_size * BUFFERED_PERIODS)?;
         pcm.hw_params(&hwp)?;
 


### PR DESCRIPTION
Based on experience with the alsa pulse plugin and raspotify (Particularly I was looking into the problem described in dtcooper/raspotify#210) and a comparison with aplay (Which can be regarded as a reference implementation of alsa playback and did fine job using the pipe backend) I started looking into the alsa backend, because it was clear that something was wrong there.

By comparing hw_params used in librespot with those in aplay and also a brief look through aplay.c, I was able to come up with the following two improvements to buffering in the alsa backend:

  1. Introduce a decent period size relative to the desired buffer. This reduces the load on the CPU because it increases the wakeup interval.
  2. Only write to the pcm when a full period of data is available. This again increased performance quite considerably, though the effect probably relies a lot more on the specific pcm. I also changed the struct to a regular one since I had to introduce values for the buffer. I wasn't a big fan of the tuple struct anyway since there is no intuitive association of a datum for AlsaSink with index 0 and 1 and adding 2 and 3 would not make that any better.

~NOTE: I did not look for a suitable buffer type before implementing the buffer/buffered_data combination. If anyone is aware of a suitable solution I will gladly make the change if that is preferable.~ Now replaced with a vector to match the actual period size. Could still be replaced with a buffer type