### PR TITLE
Update package.metadata.deb to modern standards

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,9 +76,9 @@ default = ["librespot-playback/rodio-backend"]
 [package.metadata.deb]
 maintainer = "librespot-org"
 copyright = "2018 Paul Liétar"
-license_file = ["LICENSE", "4"]
+license-file = ["LICENSE", "4"]
 depends = "$auto"
-extended_description = """\
+extended-description = """\
 librespot is an open source client library for Spotify. It enables applications \
 to use Spotify's service, without using the official but closed-source \
 libspotify. Additionally, it will provide extra features which are not \


### PR DESCRIPTION
This weekend I tried to generate a deb package of librespot using cargo-deb and ran into some minor problems. After two minor edits I got a working package :)
