### PR TITLE
Fix all warnings and lints.

### DIFF
--- a/audio/src/fetch.rs
+++ b/audio/src/fetch.rs
@@ -431,20 +431,16 @@ impl AudioFile {
 
     pub fn get_stream_loader_controller(&self) -> StreamLoaderController {
         match self {
-            AudioFile::Streaming(ref stream) => {
-                StreamLoaderController {
-                    channel_tx: Some(stream.stream_loader_command_tx.clone()),
-                    stream_shared: Some(stream.shared.clone()),
-                    file_size: stream.shared.file_size,
-                }
-            }
-            AudioFile::Cached(ref file) => {
-                StreamLoaderController {
-                    channel_tx: None,
-                    stream_shared: None,
-                    file_size: file.metadata().unwrap().len() as usize,
-                }
-            }
+            AudioFile::Streaming(ref stream) => StreamLoaderController {
+                channel_tx: Some(stream.stream_loader_command_tx.clone()),
+                stream_shared: Some(stream.shared.clone()),
+                file_size: stream.shared.file_size,
+            },
+            AudioFile::Cached(ref file) => StreamLoaderController {
+                channel_tx: None,
+                stream_shared: None,
+                file_size: file.metadata().unwrap().len() as usize,
+            },
         }
     }
 }

--- a/audio/src/lewton_decoder.rs
+++ b/audio/src/lewton_decoder.rs
@@ -71,10 +71,6 @@ impl fmt::Display for VorbisError {
 }
 
 impl error::Error for VorbisError {
-    fn description(&self) -> &str {
-        error::Error::description(&self.0)
-    }
-
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         error::Error::source(&self.0)
     }

--- a/audio/src/lewton_decoder.rs
+++ b/audio/src/lewton_decoder.rs
@@ -57,13 +57,13 @@ impl From<lewton::VorbisError> for VorbisError {
 }
 
 impl fmt::Debug for VorbisError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.0, f)
     }
 }
 
 impl fmt::Display for VorbisError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }

--- a/audio/src/lewton_decoder.rs
+++ b/audio/src/lewton_decoder.rs
@@ -1,6 +1,4 @@
-extern crate lewton;
-
-use self::lewton::inside_ogg::OggStreamReader;
+use lewton::inside_ogg::OggStreamReader;
 
 use std::error;
 use std::fmt;
@@ -25,10 +23,10 @@ where
     }
 
     pub fn next_packet(&mut self) -> Result<Option<VorbisPacket>, VorbisError> {
-        use self::lewton::audio::AudioReadError::AudioIsHeader;
-        use self::lewton::OggReadError::NoCapturePatternFound;
-        use self::lewton::VorbisError::BadAudio;
-        use self::lewton::VorbisError::OggError;
+        use lewton::audio::AudioReadError::AudioIsHeader;
+        use lewton::OggReadError::NoCapturePatternFound;
+        use lewton::VorbisError::BadAudio;
+        use lewton::VorbisError::OggError;
         loop {
             match self.0.read_dec_packet_itl() {
                 Ok(Some(packet)) => return Ok(Some(VorbisPacket(packet))),

--- a/audio/src/lib.rs
+++ b/audio/src/lib.rs
@@ -1,17 +1,9 @@
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate futures;
 #[macro_use]
 extern crate log;
-
-extern crate aes_ctr;
-extern crate bit_set;
-extern crate byteorder;
-extern crate bytes;
-extern crate num_bigint;
-extern crate num_traits;
-extern crate tempfile;
-
-extern crate librespot_core;
 
 mod decrypt;
 mod fetch;

--- a/audio/src/libvorbis_decoder.rs
+++ b/audio/src/libvorbis_decoder.rs
@@ -73,10 +73,6 @@ impl fmt::Display for VorbisError {
 }
 
 impl error::Error for VorbisError {
-    fn description(&self) -> &str {
-        error::Error::description(&self.0)
-    }
-
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         error::Error::source(&self.0)
     }

--- a/audio/src/libvorbis_decoder.rs
+++ b/audio/src/libvorbis_decoder.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "with-tremor")]
-extern crate librespot_tremor as vorbis;
+use librespot_tremor as vorbis;
 
 use std::error;
 use std::fmt;

--- a/audio/src/libvorbis_decoder.rs
+++ b/audio/src/libvorbis_decoder.rs
@@ -1,7 +1,5 @@
 #[cfg(feature = "with-tremor")]
 extern crate librespot_tremor as vorbis;
-#[cfg(not(feature = "with-tremor"))]
-extern crate vorbis;
 
 use std::error;
 use std::fmt;
@@ -61,13 +59,13 @@ impl From<vorbis::VorbisError> for VorbisError {
 }
 
 impl fmt::Debug for VorbisError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Debug::fmt(&self.0, f)
     }
 }
 
 impl fmt::Display for VorbisError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::Display::fmt(&self.0, f)
     }
 }

--- a/audio/src/range_set.rs
+++ b/audio/src/range_set.rs
@@ -10,20 +10,20 @@ pub struct Range {
 
 impl fmt::Display for Range {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        return write!(f, "[{}, {}]", self.start, self.start + self.length - 1);
+        write!(f, "[{}, {}]", self.start, self.start + self.length - 1)
     }
 }
 
 impl Range {
     pub fn new(start: usize, length: usize) -> Range {
-        return Range {
-            start: start,
-            length: length,
-        };
+        Range {
+            start,
+            length,
+        }
     }
 
     pub fn end(&self) -> usize {
-        return self.start + self.length;
+        self.start + self.length
     }
 }
 
@@ -50,7 +50,7 @@ impl RangeSet {
     }
 
     pub fn is_empty(&self) -> bool {
-        return self.ranges.is_empty();
+        self.ranges.is_empty()
     }
 
     pub fn len(&self) -> usize {
@@ -58,15 +58,15 @@ impl RangeSet {
         for range in self.ranges.iter() {
             result += range.length;
         }
-        return result;
+        result
     }
 
     pub fn get_range(&self, index: usize) -> Range {
-        return self.ranges[index].clone();
+        self.ranges[index]
     }
 
     pub fn iter(&self) -> Iter<Range> {
-        return self.ranges.iter();
+        self.ranges.iter()
     }
 
     pub fn contains(&self, value: usize) -> bool {
@@ -77,7 +77,7 @@ impl RangeSet {
                 return true;
             }
         }
-        return false;
+        false
     }
 
     pub fn contained_length_from_value(&self, value: usize) -> usize {
@@ -88,7 +88,7 @@ impl RangeSet {
                 return range.end() - value;
             }
         }
-        return 0;
+        0
     }
 
     #[allow(dead_code)]
@@ -98,12 +98,12 @@ impl RangeSet {
                 return false;
             }
         }
-        return true;
+        true
     }
 
     pub fn add_range(&mut self, range: &Range) {
-        if range.length <= 0 {
-            // the interval is empty or invalid -> nothing to do.
+        if range.length == 0 {
+            // the interval is empty -> nothing to do.
             return;
         }
 
@@ -111,7 +111,7 @@ impl RangeSet {
             // the new range is clear of any ranges we already iterated over.
             if range.end() < self.ranges[index].start {
                 // the new range starts after anything we already passed and ends before the next range starts (they don't touch) -> insert it.
-                self.ranges.insert(index, range.clone());
+                self.ranges.insert(index, *range);
                 return;
             } else if range.start <= self.ranges[index].end()
                 && self.ranges[index].start <= range.end()
@@ -119,7 +119,7 @@ impl RangeSet {
                 // the new range overlaps (or touches) the first range. They are to be merged.
                 // In addition we might have to merge further ranges in as well.
 
-                let mut new_range = range.clone();
+                let mut new_range = *range;
 
                 while index < self.ranges.len() && self.ranges[index].start <= new_range.end() {
                     let new_end = max(new_range.end(), self.ranges[index].end());
@@ -134,7 +134,7 @@ impl RangeSet {
         }
 
         // the new range is after everything else -> just add it
-        self.ranges.push(range.clone());
+        self.ranges.push(*range);
     }
 
     #[allow(dead_code)]
@@ -148,11 +148,11 @@ impl RangeSet {
     pub fn union(&self, other: &RangeSet) -> RangeSet {
         let mut result = self.clone();
         result.add_range_set(other);
-        return result;
+        result
     }
 
     pub fn subtract_range(&mut self, range: &Range) {
-        if range.length <= 0 {
+        if range.length == 0 {
             return;
         }
 
@@ -208,7 +208,7 @@ impl RangeSet {
     pub fn minus(&self, other: &RangeSet) -> RangeSet {
         let mut result = self.clone();
         result.subtract_range_set(other);
-        return result;
+        result
     }
 
     pub fn intersection(&self, other: &RangeSet) -> RangeSet {
@@ -244,6 +244,6 @@ impl RangeSet {
             }
         }
 
-        return result;
+        result
     }
 }

--- a/audio/src/range_set.rs
+++ b/audio/src/range_set.rs
@@ -15,10 +15,7 @@ impl fmt::Display for Range {
 
 impl Range {
     pub fn new(start: usize, length: usize) -> Range {
-        Range {
-            start,
-            length,
-        }
+        Range { start, length }
     }
 
     pub fn end(&self) -> usize {
@@ -64,7 +61,7 @@ impl RangeSet {
         self.ranges[index]
     }
 
-    pub fn iter(&self) -> impl Iterator<Item=&Range> {
+    pub fn iter(&self) -> impl Iterator<Item = &Range> {
         self.ranges.iter()
     }
 

--- a/audio/src/range_set.rs
+++ b/audio/src/range_set.rs
@@ -1,6 +1,5 @@
 use std::cmp::{max, min};
 use std::fmt;
-use std::slice::Iter;
 
 #[derive(Copy, Clone)]
 pub struct Range {
@@ -65,7 +64,7 @@ impl RangeSet {
         self.ranges[index]
     }
 
-    pub fn iter(&self) -> Iter<Range> {
+    pub fn iter(&self) -> impl Iterator<Item=&Range> {
         self.ranges.iter()
     }
 

--- a/connect/src/context.rs
+++ b/connect/src/context.rs
@@ -1,8 +1,6 @@
 use crate::protocol::spirc::TrackRef;
 use librespot_core::spotify_id::SpotifyId;
 
-use serde;
-
 #[derive(Deserialize, Debug)]
 pub struct StationContext {
     pub uri: Option<String>,

--- a/connect/src/lib.rs
+++ b/connect/src/lib.rs
@@ -1,32 +1,12 @@
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate log;
 #[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
-extern crate serde;
 
-extern crate base64;
-extern crate futures;
-extern crate hyper;
-extern crate num_bigint;
-extern crate protobuf;
-extern crate rand;
-extern crate tokio_core;
-extern crate url;
-
-extern crate aes_ctr;
-extern crate block_modes;
-extern crate hmac;
-extern crate sha1;
-
-#[cfg(feature = "with-dns-sd")]
-extern crate dns_sd;
-
-#[cfg(not(feature = "with-dns-sd"))]
-extern crate libmdns;
-
-extern crate librespot_core;
 extern crate librespot_playback as playback;
 extern crate librespot_protocol as protocol;
 

--- a/connect/src/lib.rs
+++ b/connect/src/lib.rs
@@ -7,8 +7,8 @@ extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 
-extern crate librespot_playback as playback;
-extern crate librespot_protocol as protocol;
+use librespot_playback as playback;
+use librespot_protocol as protocol;
 
 pub mod context;
 pub mod discovery;

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1251,7 +1251,7 @@ struct CommandSender<'a> {
 }
 
 impl<'a> CommandSender<'a> {
-    fn new(spirc: &'a mut SpircTask, cmd: MessageType) -> CommandSender {
+    fn new(spirc: &'a mut SpircTask, cmd: MessageType) -> CommandSender<'_> {
         let mut frame = protocol::spirc::Frame::new();
         frame.set_version(1);
         frame.set_protocol_version(::std::convert::Into::into("2.0.0"));
@@ -1266,7 +1266,7 @@ impl<'a> CommandSender<'a> {
         }
     }
 
-    fn recipient(mut self, recipient: &'a str) -> CommandSender {
+    fn recipient(mut self, recipient: &'a str) -> CommandSender<'_> {
         self.frame.mut_recipient().push(recipient.to_owned());
         self
     }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -452,8 +452,7 @@ impl SpircTask {
             Ok(dur) => dur,
             Err(err) => err.duration(),
         };
-        (dur.as_secs() as i64 + self.session.time_delta()) * 1000
-            + dur.subsec_millis() as i64
+        (dur.as_secs() as i64 + self.session.time_delta()) * 1000 + dur.subsec_millis() as i64
     }
 
     fn ensure_mixer_started(&mut self) {
@@ -1260,10 +1259,7 @@ impl<'a> CommandSender<'a> {
         frame.set_typ(cmd);
         frame.set_device_state(spirc.device.clone());
         frame.set_state_update_id(spirc.now_ms());
-        CommandSender {
-            spirc,
-            frame,
-        }
+        CommandSender { spirc, frame }
     }
 
     fn recipient(mut self, recipient: &'a str) -> CommandSender<'_> {

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,6 +1,3 @@
-extern crate rand;
-extern crate vergen;
-
 use rand::distributions::Alphanumeric;
 use rand::Rng;
 use vergen::{generate_cargo_keys, ConstantsFlags};

--- a/core/src/apresolve.rs
+++ b/core/src/apresolve.rs
@@ -62,9 +62,9 @@ fn apresolve(
     let ap = data.and_then(move |data| {
         let mut aps = data.ap_list.iter().filter(|ap| {
             if let Some(p) = p {
-                Uri::from_str(ap).ok().map_or(false, |uri| {
-                    uri.port().map_or(false, |port| port == p)
-                })
+                Uri::from_str(ap)
+                    .ok()
+                    .map_or(false, |uri| uri.port().map_or(false, |port| port == p))
             } else if use_proxy {
                 // It is unlikely that the proxy will accept CONNECT on anything other than 443.
                 Uri::from_str(ap)

--- a/core/src/audio_key.rs
+++ b/core/src/audio_key.rs
@@ -62,8 +62,8 @@ impl AudioKeyManager {
 
     fn send_key_request(&self, seq: u32, track: SpotifyId, file: FileId) {
         let mut data: Vec<u8> = Vec::new();
-        data.write(&file.0).unwrap();
-        data.write(&track.to_raw()).unwrap();
+        data.write_all(&file.0).unwrap();
+        data.write_all(&track.to_raw()).unwrap();
         data.write_u32::<BigEndian>(seq).unwrap();
         data.write_u16::<BigEndian>(0x0000).unwrap();
 

--- a/core/src/authentication.rs
+++ b/core/src/authentication.rs
@@ -1,11 +1,8 @@
 use aes::Aes192;
-use base64;
 use byteorder::{BigEndian, ByteOrder};
 use hmac::Hmac;
 use pbkdf2::pbkdf2;
 use protobuf::ProtobufEnum;
-use serde;
-use serde_json;
 use sha1::{Digest, Sha1};
 use std::fs::File;
 use std::io::{self, Read, Write};
@@ -31,7 +28,7 @@ pub struct Credentials {
 impl Credentials {
     pub fn with_password(username: String, password: String) -> Credentials {
         Credentials {
-            username: username,
+            username,
             auth_type: AuthenticationType::AUTHENTICATION_USER_PASS,
             auth_data: password.into_bytes(),
         }
@@ -107,9 +104,9 @@ impl Credentials {
         let auth_data = read_bytes(&mut cursor).unwrap();
 
         Credentials {
-            username: username,
-            auth_type: auth_type,
-            auth_data: auth_data,
+            username,
+            auth_type,
+            auth_data,
         }
     }
 

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -32,7 +32,7 @@ impl Cache {
 
         Cache {
             root: location,
-            use_audio_cache: use_audio_cache,
+            use_audio_cache,
         }
     }
 }

--- a/core/src/channel.rs
+++ b/core/src/channel.rs
@@ -88,7 +88,7 @@ impl ChannelManager {
     }
 
     pub fn get_download_rate_estimate(&self) -> usize {
-        return self.lock(|inner| inner.download_rate_estimate);
+        self.lock(|inner| inner.download_rate_estimate)
     }
 
     pub(crate) fn shutdown(&self) {
@@ -137,7 +137,7 @@ impl Stream for Channel {
             match self.state.clone() {
                 ChannelState::Closed => panic!("Polling already terminated channel"),
                 ChannelState::Header(mut data) => {
-                    if data.len() == 0 {
+                    if data.is_empty() {
                         data = try_ready!(self.recv_packet());
                     }
 
@@ -158,7 +158,7 @@ impl Stream for Channel {
 
                 ChannelState::Data => {
                     let data = try_ready!(self.recv_packet());
-                    if data.len() == 0 {
+                    if data.is_empty() {
                         self.receiver.close();
                         self.state = ChannelState::Closed;
                         return Ok(Async::Ready(None));

--- a/core/src/component.rs
+++ b/core/src/component.rs
@@ -43,7 +43,7 @@ pub(crate) struct Lazy<T>(Mutex<bool>, UnsafeCell<Option<T>>);
 unsafe impl<T: Sync> Sync for Lazy<T> {}
 unsafe impl<T: Send> Send for Lazy<T> {}
 
-#[cfg_attr(feature = "cargo-clippy", allow(mutex_atomic))]
+#[allow(clippy::mutex_atomic)]
 impl<T> Lazy<T> {
     pub(crate) fn new() -> Lazy<T> {
         Lazy(Mutex::new(false), UnsafeCell::new(None))

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -57,7 +57,7 @@ impl FromStr for DeviceType {
 }
 
 impl fmt::Display for DeviceType {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         use self::DeviceType::*;
         match *self {
             Unknown => f.write_str("Unknown"),

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -18,7 +18,7 @@ impl Default for SessionConfig {
         let device_id = Uuid::new_v4().to_hyphenated().to_string();
         SessionConfig {
             user_agent: version::version_string(),
-            device_id: device_id,
+            device_id,
             proxy: None,
             ap_port: None,
         }

--- a/core/src/connection/handshake.rs
+++ b/core/src/connection/handshake.rs
@@ -21,6 +21,7 @@ pub struct Handshake<T> {
     state: HandshakeState<T>,
 }
 
+#[allow(clippy::large_enum_variant)]
 enum HandshakeState<T> {
     ClientHello(WriteAll<T, Vec<u8>>),
     APResponse(RecvPacket<T, APResponseMessage>),

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -29,7 +29,7 @@ pub fn connect(
         Some(ref url) => {
             info!("Using proxy \"{}\"", url);
             match url.to_socket_addrs().and_then(|mut iter| {
-                iter.next().ok_or(io::Error::new(
+                iter.next().ok_or_else(|| io::Error::new(
                     io::ErrorKind::NotFound,
                     "Can't resolve proxy server address",
                 ))
@@ -40,7 +40,7 @@ pub fn connect(
         }
         None => {
             match addr.to_socket_addrs().and_then(|mut iter| {
-                iter.next().ok_or(io::Error::new(
+                iter.next().ok_or_else(|| io::Error::new(
                     io::ErrorKind::NotFound,
                     "Can't resolve server address",
                 ))

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -29,10 +29,12 @@ pub fn connect(
         Some(ref url) => {
             info!("Using proxy \"{}\"", url);
             match url.to_socket_addrs().and_then(|mut iter| {
-                iter.next().ok_or_else(|| io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "Can't resolve proxy server address",
-                ))
+                iter.next().ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "Can't resolve proxy server address",
+                    )
+                })
             }) {
                 Ok(socket_addr) => (socket_addr, Some(addr)),
                 Err(error) => return Box::new(futures::future::err(error)),
@@ -40,10 +42,9 @@ pub fn connect(
         }
         None => {
             match addr.to_socket_addrs().and_then(|mut iter| {
-                iter.next().ok_or_else(|| io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "Can't resolve server address",
-                ))
+                iter.next().ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::NotFound, "Can't resolve server address")
+                })
             }) {
                 Ok(socket_addr) => (socket_addr, None),
                 Err(error) => return Box::new(futures::future::err(error)),

--- a/core/src/diffie_hellman.rs
+++ b/core/src/diffie_hellman.rs
@@ -30,8 +30,8 @@ impl DHLocalKeys {
         let public_key = util::powm(&DH_GENERATOR, &private_key, &DH_PRIME);
 
         DHLocalKeys {
-            private_key: private_key,
-            public_key: public_key,
+            private_key,
+            public_key,
         }
     }
 

--- a/core/src/keymaster.rs
+++ b/core/src/keymaster.rs
@@ -1,5 +1,4 @@
 use futures::Future;
-use serde_json;
 
 use crate::mercury::MercuryError;
 use crate::session::Session;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate error_chain;
 #[macro_use]
@@ -8,30 +10,6 @@ extern crate lazy_static;
 extern crate log;
 #[macro_use]
 extern crate serde_derive;
-
-extern crate aes;
-extern crate base64;
-extern crate byteorder;
-extern crate bytes;
-extern crate hmac;
-extern crate httparse;
-extern crate hyper;
-extern crate hyper_proxy;
-extern crate num_bigint;
-extern crate num_integer;
-extern crate num_traits;
-extern crate pbkdf2;
-extern crate protobuf;
-extern crate rand;
-extern crate serde;
-extern crate serde_json;
-extern crate sha1;
-extern crate shannon;
-extern crate tokio_codec;
-extern crate tokio_core;
-extern crate tokio_io;
-extern crate url;
-extern crate uuid;
 
 extern crate librespot_protocol as protocol;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -11,7 +11,7 @@ extern crate log;
 #[macro_use]
 extern crate serde_derive;
 
-extern crate librespot_protocol as protocol;
+use librespot_protocol as protocol;
 
 #[macro_use]
 mod component;

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(feature = "cargo-clippy", allow(unused_io_amount))]
-
 #[macro_use]
 extern crate error_chain;
 #[macro_use]

--- a/core/src/mercury/mod.rs
+++ b/core/src/mercury/mod.rs
@@ -3,7 +3,6 @@ use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
 use futures::sync::{mpsc, oneshot};
 use futures::{Async, Future, Poll};
-use protobuf;
 use std::collections::HashMap;
 use std::mem;
 
@@ -117,7 +116,7 @@ impl MercuryManager {
             manager.lock(move |inner| {
                 if !inner.invalid {
                     debug!("subscribed uri={} count={}", uri, response.payload.len());
-                    if response.payload.len() > 0 {
+                    if !response.payload.is_empty() {
                         // Old subscription protocol, watch the provided list of URIs
                         for sub in response.payload {
                             let mut sub: protocol::pubsub::Subscription =
@@ -204,30 +203,28 @@ impl MercuryManager {
             if let Some(cb) = pending.callback {
                 let _ = cb.send(Err(MercuryError));
             }
-        } else {
-            if cmd == 0xb5 {
-                self.lock(|inner| {
-                    let mut found = false;
-                    inner.subscriptions.retain(|&(ref prefix, ref sub)| {
-                        if response.uri.starts_with(prefix) {
-                            found = true;
+        } else if cmd == 0xb5 {
+            self.lock(|inner| {
+                let mut found = false;
+                inner.subscriptions.retain(|&(ref prefix, ref sub)| {
+                    if response.uri.starts_with(prefix) {
+                        found = true;
 
-                            // if send fails, remove from list of subs
-                            // TODO: send unsub message
-                            sub.unbounded_send(response.clone()).is_ok()
-                        } else {
-                            // URI doesn't match
-                            true
-                        }
-                    });
-
-                    if !found {
-                        debug!("unknown subscription uri={}", response.uri);
+                        // if send fails, remove from list of subs
+                        // TODO: send unsub message
+                        sub.unbounded_send(response.clone()).is_ok()
+                    } else {
+                        // URI doesn't match
+                        true
                     }
-                })
-            } else if let Some(cb) = pending.callback {
-                let _ = cb.send(Ok(response));
-            }
+                });
+
+                if !found {
+                    debug!("unknown subscription uri={}", response.uri);
+                }
+            })
+        } else if let Some(cb) = pending.callback {
+            let _ = cb.send(Ok(response));
         }
     }
 

--- a/core/src/mercury/sender.rs
+++ b/core/src/mercury/sender.rs
@@ -13,8 +13,8 @@ impl MercurySender {
     // TODO: pub(super) when stable
     pub(crate) fn new(mercury: MercuryManager, uri: String) -> MercurySender {
         MercurySender {
-            mercury: mercury,
-            uri: uri,
+            mercury,
+            uri,
             pending: VecDeque::new(),
         }
     }

--- a/core/src/mercury/types.rs
+++ b/core/src/mercury/types.rs
@@ -77,7 +77,7 @@ impl MercuryRequest {
 
         for p in &self.payload {
             packet.write_u16::<BigEndian>(p.len() as u16).unwrap();
-            packet.write(p).unwrap();
+            packet.write_all(p).unwrap();
         }
 
         packet

--- a/core/src/proxytunnel.rs
+++ b/core/src/proxytunnel.rs
@@ -1,9 +1,7 @@
-use std::error::Error;
 use std::io;
 use std::str::FromStr;
 
 use futures::{Async, Future, Poll};
-use httparse;
 use hyper::Uri;
 use tokio_io::io::{read, write_all, Read, Window, WriteAll};
 use tokio_io::{AsyncRead, AsyncWrite};
@@ -58,7 +56,7 @@ impl<T: AsyncRead + AsyncWrite> Future for ProxyTunnel<T> {
                     let status = match response.parse(&buf) {
                         Ok(status) => status,
                         Err(err) => {
-                            return Err(io::Error::new(io::ErrorKind::Other, err.description()));
+                            return Err(io::Error::new(io::ErrorKind::Other, err.to_string()));
                         }
                     };
 
@@ -102,8 +100,8 @@ fn proxy_connect<T: AsyncWrite>(connection: T, connect_url: &str) -> WriteAll<T,
     let buffer = format!(
         "CONNECT {0}:{1} HTTP/1.1\r\n\
          \r\n",
-        uri.host().expect(&format!("No host in {}", uri)),
-        uri.port().expect(&format!("No port in {}", uri))
+        uri.host().unwrap_or_else(|| panic!("No host in {}", uri)),
+        uri.port().unwrap_or_else(|| panic!("No port in {}", uri))
     )
     .into_bytes();
 

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -80,7 +80,7 @@ impl Session {
                 transport,
                 config,
                 cache,
-                reusable_credentials.username.clone(),
+                reusable_credentials.username,
             );
 
             handle.spawn(task.map_err(|e| {
@@ -108,7 +108,7 @@ impl Session {
         debug!("new Session[{}]", session_id);
 
         let session = Session(Arc::new(SessionInternal {
-            config: config,
+            config,
             data: RwLock::new(SessionData {
                 country: String::new(),
                 canonical_username: username,
@@ -126,7 +126,7 @@ impl Session {
 
             handle: handle.remote().clone(),
 
-            session_id: session_id,
+            session_id,
         }));
 
         let sender_task = sender_rx
@@ -178,7 +178,7 @@ impl Session {
         );
     }
 
-    #[cfg_attr(feature = "cargo-clippy", allow(match_same_arms))]
+    #[allow(clippy::match_same_arms)]
     fn dispatch(&self, cmd: u8, data: Bytes) {
         match cmd {
             0x4 => {
@@ -300,7 +300,7 @@ where
                 Ok(Async::NotReady) => return Ok(Async::NotReady),
                 Err(e) => {
                     session.shutdown();
-                    return Err(From::from(e));
+                    return Err(e);
                 }
             };
 

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -16,8 +16,7 @@ pub struct SpotifyId {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SpotifyIdError;
 
-const BASE62_DIGITS: &[u8] =
-    b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const BASE62_DIGITS: &[u8] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const BASE16_DIGITS: &[u8] = b"0123456789abcdef";
 
 impl SpotifyId {

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -122,13 +122,13 @@ impl FileId {
 }
 
 impl fmt::Debug for FileId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("FileId").field(&self.to_base16()).finish()
     }
 }
 
 impl fmt::Display for FileId {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(&self.to_base16())
     }
 }

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -1,4 +1,3 @@
-use std;
 use std::fmt;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -17,12 +16,12 @@ pub struct SpotifyId {
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 pub struct SpotifyIdError;
 
-const BASE62_DIGITS: &'static [u8] =
+const BASE62_DIGITS: &[u8] =
     b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
-const BASE16_DIGITS: &'static [u8] = b"0123456789abcdef";
+const BASE16_DIGITS: &[u8] = b"0123456789abcdef";
 
 impl SpotifyId {
-    fn as_track(n: u128) -> SpotifyId {
+    fn track(n: u128) -> SpotifyId {
         SpotifyId {
             id: n.to_owned(),
             audio_type: SpotifyAudioType::Track,
@@ -38,11 +37,11 @@ impl SpotifyId {
                 None => return Err(SpotifyIdError),
                 Some(x) => x as u128,
             };
-            n = n * 16;
-            n = n + d;
+            n *= 16;
+            n += d;
         }
 
-        Ok(SpotifyId::as_track(n))
+        Ok(SpotifyId::track(n))
     }
 
     pub fn from_base62(id: &str) -> Result<SpotifyId, SpotifyIdError> {
@@ -54,10 +53,10 @@ impl SpotifyId {
                 None => return Err(SpotifyIdError),
                 Some(x) => x as u128,
             };
-            n = n * 62;
-            n = n + d;
+            n *= 62;
+            n += d;
         }
-        Ok(SpotifyId::as_track(n))
+        Ok(SpotifyId::track(n))
     }
 
     pub fn from_raw(data: &[u8]) -> Result<SpotifyId, SpotifyIdError> {
@@ -68,11 +67,11 @@ impl SpotifyId {
         let mut arr: [u8; 16] = Default::default();
         arr.copy_from_slice(&data[0..16]);
 
-        Ok(SpotifyId::as_track(u128::from_be_bytes(arr)))
+        Ok(SpotifyId::track(u128::from_be_bytes(arr)))
     }
 
     pub fn from_uri(uri: &str) -> Result<SpotifyId, SpotifyIdError> {
-        let parts = uri.split(":").collect::<Vec<&str>>();
+        let parts = uri.split(':').collect::<Vec<&str>>();
         let gid = parts.last().unwrap();
         if uri.contains(":episode:") {
             let mut spotify_id = SpotifyId::from_base62(gid).unwrap();

--- a/metadata/src/cover.rs
+++ b/metadata/src/cover.rs
@@ -12,7 +12,7 @@ pub fn get(session: &Session, file: FileId) -> ChannelData {
     let mut packet: Vec<u8> = Vec::new();
     packet.write_u16::<BigEndian>(channel_id).unwrap();
     packet.write_u16::<BigEndian>(0).unwrap();
-    packet.write(&file.0).unwrap();
+    packet.write_all(&file.0).unwrap();
     session.send_packet(0x19, packet);
 
     data

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate log;
 
-extern crate librespot_protocol as protocol;
+use librespot_protocol as protocol;
 
 pub mod cover;
 

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -1,12 +1,8 @@
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate log;
 
-extern crate byteorder;
-extern crate futures;
-extern crate linear_map;
-extern crate protobuf;
-
-extern crate librespot_core;
 extern crate librespot_protocol as protocol;
 
 pub mod cover;
@@ -453,11 +449,11 @@ impl Metadata for Show {
 struct StrChunks<'s>(&'s str, usize);
 
 trait StrChunksExt {
-    fn chunks(&self, size: usize) -> StrChunks;
+    fn chunks(&self, size: usize) -> StrChunks<'_>;
 }
 
 impl StrChunksExt for str {
-    fn chunks(&self, size: usize) -> StrChunks {
+    fn chunks(&self, size: usize) -> StrChunks<'_> {
         StrChunks(self, size)
     }
 }

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -97,7 +97,7 @@ impl AudioFiles for Track {
     ) -> Box<dyn Future<Item = AudioItem, Error = MercuryError>> {
         Box::new(Self::get(session, id).and_then(move |item| {
             Ok(AudioItem {
-                id: id,
+                id,
                 uri: format!("spotify:track:{}", id.to_base62()),
                 files: item.files,
                 name: item.name,
@@ -116,7 +116,7 @@ impl AudioFiles for Episode {
     ) -> Box<dyn Future<Item = AudioItem, Error = MercuryError>> {
         Box::new(Self::get(session, id).and_then(move |item| {
             Ok(AudioItem {
-                id: id,
+                id,
                 uri: format!("spotify:episode:{}", id.to_base62()),
                 files: item.files,
                 name: item.name,
@@ -239,8 +239,8 @@ impl Metadata for Track {
             name: msg.get_name().to_owned(),
             duration: msg.get_duration(),
             album: SpotifyId::from_raw(msg.get_album().get_gid()).unwrap(),
-            artists: artists,
-            files: files,
+            artists,
+            files,
             alternatives: msg
                 .get_alternative()
                 .iter()
@@ -289,9 +289,9 @@ impl Metadata for Album {
         Album {
             id: SpotifyId::from_raw(msg.get_gid()).unwrap(),
             name: msg.get_name().to_owned(),
-            artists: artists,
-            tracks: tracks,
-            covers: covers,
+            artists,
+            tracks,
+            covers,
         }
     }
 }
@@ -309,7 +309,7 @@ impl Metadata for Playlist {
             .get_items()
             .iter()
             .map(|item| {
-                let uri_split = item.get_uri().split(":");
+                let uri_split = item.get_uri().split(':');
                 let uri_parts: Vec<&str> = uri_split.collect();
                 SpotifyId::from_base62(uri_parts[2]).unwrap()
             })
@@ -326,7 +326,7 @@ impl Metadata for Playlist {
         Playlist {
             revision: msg.get_revision().to_vec(),
             name: msg.get_attributes().get_name().to_owned(),
-            tracks: tracks,
+            tracks,
             user: msg.get_owner_username().to_string(),
         }
     }
@@ -359,7 +359,7 @@ impl Metadata for Artist {
         Artist {
             id: SpotifyId::from_raw(msg.get_gid()).unwrap(),
             name: msg.get_name().to_owned(),
-            top_tracks: top_tracks,
+            top_tracks,
         }
     }
 }
@@ -405,8 +405,8 @@ impl Metadata for Episode {
             duration: msg.get_duration().to_owned(),
             language: msg.get_language().to_owned(),
             show: SpotifyId::from_raw(msg.get_show().get_gid()).unwrap(),
-            covers: covers,
-            files: files,
+            covers,
+            files,
             available: parse_restrictions(msg.get_restriction(), &country, "premium"),
             explicit: msg.get_explicit().to_owned(),
         }
@@ -444,8 +444,8 @@ impl Metadata for Show {
             id: SpotifyId::from_raw(msg.get_gid()).unwrap(),
             name: msg.get_name().to_owned(),
             publisher: msg.get_publisher().to_owned(),
-            episodes: episodes,
-            covers: covers,
+            episodes,
+            covers,
         }
     }
 }

--- a/playback/src/audio_backend/alsa.rs
+++ b/playback/src/audio_backend/alsa.rs
@@ -25,7 +25,7 @@ fn list_outputs() {
     }
 }
 
-fn open_device(dev_name: &str) -> Result<(PCM), Box<Error>> {
+fn open_device(dev_name: &str) -> Result<PCM, Box<Error>> {
     let pcm = PCM::new(dev_name, Direction::Playback, false)?;
     // http://www.linuxjournal.com/article/6735?page=0,1#N0x19ab2890.0x19ba78d8
     // latency = period_size * periods / (rate * bytes_per_frame)

--- a/playback/src/audio_backend/jackaudio.rs
+++ b/playback/src/audio_backend/jackaudio.rs
@@ -8,6 +8,7 @@ use std::sync::mpsc::{sync_channel, Receiver, SyncSender};
 
 pub struct JackSink {
     send: SyncSender<i16>,
+    #[allow(dead_code)]
     active_client: AsyncClient<(), JackData>,
 }
 
@@ -44,7 +45,7 @@ impl Open for JackSink {
     fn open(client_name: Option<String>) -> JackSink {
         info!("Using jack sink!");
 
-        let client_name = client_name.unwrap_or("librespot".to_string());
+        let client_name = client_name.unwrap_or_else(|| "librespot".to_string());
         let (client, _status) =
             Client::new(&client_name[..], client_options::NO_START_SERVER).unwrap();
         let ch_r = client
@@ -64,7 +65,7 @@ impl Open for JackSink {
 
         JackSink {
             send: tx,
-            active_client: active_client,
+            active_client,
         }
     }
 }

--- a/playback/src/audio_backend/mod.rs
+++ b/playback/src/audio_backend/mod.rs
@@ -55,7 +55,7 @@ pub const BACKENDS: &[(&str, BackendCtor)] = &[
     #[cfg(feature = "alsa-backend")]
     ("alsa", mk_sink::<AlsaSink>),
     #[cfg(feature = "portaudio-backend")]
-    ("portaudio", mk_sink::<PortAudioSink>),
+    ("portaudio", mk_sink::<PortAudioSink<'_>>),
     #[cfg(feature = "pulseaudio-backend")]
     ("pulseaudio", mk_sink::<PulseAudioSink>),
     #[cfg(feature = "jackaudio-backend")]

--- a/playback/src/audio_backend/mod.rs
+++ b/playback/src/audio_backend/mod.rs
@@ -49,7 +49,9 @@ use self::pipe::StdoutSink;
 mod subprocess;
 use self::subprocess::SubprocessSink;
 
-pub const BACKENDS: &'static [(&'static str, fn(Option<String>) -> Box<dyn Sink>)] = &[
+pub type BackendCtor = fn(Option<String>) -> Box<dyn Sink>;
+
+pub const BACKENDS: &[(&str, BackendCtor)] = &[
     #[cfg(feature = "alsa-backend")]
     ("alsa", mk_sink::<AlsaSink>),
     #[cfg(feature = "portaudio-backend")]
@@ -66,7 +68,7 @@ pub const BACKENDS: &'static [(&'static str, fn(Option<String>) -> Box<dyn Sink>
     ("subprocess", mk_sink::<SubprocessSink>),
 ];
 
-pub fn find(name: Option<String>) -> Option<fn(Option<String>) -> Box<dyn Sink>> {
+pub fn find(name: Option<String>) -> Option<BackendCtor> {
     if let Some(name) = name {
         BACKENDS
             .iter()

--- a/playback/src/audio_backend/portaudio.rs
+++ b/playback/src/audio_backend/portaudio.rs
@@ -1,5 +1,4 @@
 use super::{Open, Sink};
-use portaudio_rs;
 use portaudio_rs::device::{get_default_output_index, DeviceIndex, DeviceInfo};
 use portaudio_rs::stream::*;
 use std::io;

--- a/playback/src/audio_backend/rodio.rs
+++ b/playback/src/audio_backend/rodio.rs
@@ -1,6 +1,4 @@
 use super::{Open, Sink};
-extern crate cpal;
-extern crate rodio;
 use std::process::exit;
 use std::{io, thread, time};
 

--- a/playback/src/audio_backend/rodio.rs
+++ b/playback/src/audio_backend/rodio.rs
@@ -8,7 +8,7 @@ pub struct RodioSink {
     rodio_sink: rodio::Sink,
 }
 
-fn list_formats(ref device: &rodio::Device) {
+fn list_formats(device: &rodio::Device) {
     let default_fmt = match device.default_output_format() {
         Ok(fmt) => cpal::SupportedFormat::from(fmt),
         Err(e) => {
@@ -60,10 +60,8 @@ impl Open for RodioSink {
         debug!("Using rodio sink");
 
         let mut rodio_device = rodio::default_output_device().expect("no output device available");
-        if device.is_some() {
-            let device_name = device.unwrap();
-
-            if device_name == "?".to_string() {
+        if let Some(device_name) = device {
+            if device_name == "?" {
                 list_outputs();
                 exit(0)
             }

--- a/playback/src/audio_backend/sdl.rs
+++ b/playback/src/audio_backend/sdl.rs
@@ -28,7 +28,7 @@ impl Open for SdlSink {
             .open_queue(None, &desired_spec)
             .expect("Could not open SDL audio device");
 
-        SdlSink { queue: queue }
+        SdlSink { queue }
     }
 }
 

--- a/playback/src/audio_backend/subprocess.rs
+++ b/playback/src/audio_backend/subprocess.rs
@@ -14,7 +14,7 @@ impl Open for SubprocessSink {
     fn open(shell_command: Option<String>) -> SubprocessSink {
         if let Some(shell_command) = shell_command {
             SubprocessSink {
-                shell_command: shell_command,
+                shell_command,
                 child: None,
             }
         } else {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -3,8 +3,8 @@
 #[macro_use]
 extern crate log;
 
-extern crate librespot_audio as audio;
-extern crate librespot_metadata as metadata;
+use librespot_audio as audio;
+use librespot_metadata as metadata;
 
 pub mod audio_backend;
 pub mod config;

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -1,30 +1,9 @@
+#![deny(rust_2018_idioms)]
+
 #[macro_use]
 extern crate log;
 
-extern crate byteorder;
-extern crate futures;
-extern crate shell_words;
-
-#[cfg(feature = "alsa-backend")]
-extern crate alsa;
-
-#[cfg(feature = "portaudio-rs")]
-extern crate portaudio_rs;
-
-#[cfg(feature = "libpulse-sys")]
-extern crate libpulse_sys;
-
-#[cfg(feature = "jackaudio-backend")]
-extern crate jack;
-
-#[cfg(feature = "sdl-backend")]
-extern crate sdl2;
-
-#[cfg(feature = "libc")]
-extern crate libc;
-
 extern crate librespot_audio as audio;
-extern crate librespot_core;
 extern crate librespot_metadata as metadata;
 
 pub mod audio_backend;

--- a/playback/src/mixer/alsamixer.rs
+++ b/playback/src/mixer/alsamixer.rs
@@ -2,24 +2,21 @@ use super::AudioFilter;
 use super::{Mixer, MixerConfig};
 use std::error::Error;
 
-use alsa;
-
 #[derive(Clone)]
 pub struct AlsaMixer {
     config: MixerConfig,
 }
 
 impl AlsaMixer {
-    fn map_volume(&self, set_volume: Option<u16>) -> Result<(u16), Box<dyn Error>> {
+    fn map_volume(&self, set_volume: Option<u16>) -> Result<u16, Box<dyn Error>> {
         let mixer = alsa::mixer::Mixer::new(&self.config.card, false)?;
         let sid = alsa::mixer::SelemId::new(&*self.config.mixer, self.config.index);
 
-        let selem = mixer.find_selem(&sid).expect(
-            format!(
+        let selem = mixer.find_selem(&sid).unwrap_or_else(||
+            panic!(
                 "Couldn't find simple mixer control for {}",
                 self.config.mixer
             )
-            .as_str(),
         );
         let (min, max) = selem.get_playback_volume_range();
         let range = (max - min) as f64;
@@ -52,7 +49,7 @@ impl Mixer for AlsaMixer {
             "Setting up new mixer: card:{} mixer:{} index:{}",
             config.card, config.mixer, config.index
         );
-        AlsaMixer { config: config }
+        AlsaMixer { config }
     }
 
     fn start(&self) {}

--- a/playback/src/mixer/alsamixer.rs
+++ b/playback/src/mixer/alsamixer.rs
@@ -12,12 +12,12 @@ impl AlsaMixer {
         let mixer = alsa::mixer::Mixer::new(&self.config.card, false)?;
         let sid = alsa::mixer::SelemId::new(&*self.config.mixer, self.config.index);
 
-        let selem = mixer.find_selem(&sid).unwrap_or_else(||
+        let selem = mixer.find_selem(&sid).unwrap_or_else(|| {
             panic!(
                 "Couldn't find simple mixer control for {}",
                 self.config.mixer
             )
-        );
+        });
         let (min, max) = selem.get_playback_volume_range();
         let range = (max - min) as f64;
 

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -44,7 +44,9 @@ fn mk_sink<M: Mixer + 'static>(device: Option<MixerConfig>) -> Box<dyn Mixer> {
     Box::new(M::open(device))
 }
 
-pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<fn(Option<MixerConfig>) -> Box<dyn Mixer>> {
+pub type MixerCtor = fn(Option<MixerConfig>) -> Box<dyn Mixer>;
+
+pub fn find<T: AsRef<str>>(name: Option<T>) -> Option<MixerCtor> {
     match name.as_ref().map(AsRef::as_ref) {
         None | Some("softvol") => Some(mk_sink::<SoftMixer>),
         #[cfg(feature = "alsa-backend")]

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1547,10 +1547,7 @@ struct Subfile<T: Read + Seek> {
 impl<T: Read + Seek> Subfile<T> {
     pub fn new(mut stream: T, offset: u64) -> Subfile<T> {
         stream.seek(SeekFrom::Start(offset)).unwrap();
-        Subfile {
-            stream,
-            offset,
-        }
+        Subfile { stream, offset }
     }
 }
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -972,6 +972,7 @@ impl PlayerInternal {
         }
     }
 
+    #[allow(clippy::float_cmp)]
     fn handle_packet(&mut self, packet: Option<VorbisPacket>, normalisation_factor: f32) {
         match packet {
             Some(mut packet) => {
@@ -980,7 +981,6 @@ impl PlayerInternal {
                         editor.modify_stream(&mut packet.data_mut())
                     };
 
-                    #[allow(clippy::float_cmp)]
                     if self.config.normalisation && normalisation_factor != 1.0 {
                         for x in packet.data_mut().iter_mut() {
                             *x = (*x as f32 * normalisation_factor) as i16;
@@ -1465,12 +1465,9 @@ impl PlayerInternal {
         let (result_tx, result_rx) = futures::sync::oneshot::channel();
 
         std::thread::spawn(move || {
-            loader
-                .load_track(spotify_id, position_ms)
-                .and_then(move |data| {
-                    let _ = result_tx.send(data);
-                    Some(())
-                });
+            if let Some(data) = loader.load_track(spotify_id, position_ms) {
+                let _ = result_tx.send(data);
+            };
         });
 
         Box::new(result_rx.map_err(|_| ()))

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1511,7 +1511,7 @@ impl Drop for PlayerInternal {
 }
 
 impl ::std::fmt::Debug for PlayerCommand {
-    fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
         match *self {
             PlayerCommand::Load {
                 track_id,

--- a/protocol/src/authentication.rs
+++ b/protocol/src/authentication.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ClientResponseEncrypted {
     // message fields
     login_credentials: ::protobuf::SingularPtrField<LoginCredentials>,
@@ -56,9 +56,10 @@ impl ClientResponseEncrypted {
 
     // required .LoginCredentials login_credentials = 10;
 
-
     pub fn get_login_credentials(&self) -> &LoginCredentials {
-        self.login_credentials.as_ref().unwrap_or_else(|| LoginCredentials::default_instance())
+        self.login_credentials
+            .as_ref()
+            .unwrap_or_else(|| LoginCredentials::default_instance())
     }
     pub fn clear_login_credentials(&mut self) {
         self.login_credentials.clear();
@@ -84,14 +85,16 @@ impl ClientResponseEncrypted {
 
     // Take field
     pub fn take_login_credentials(&mut self) -> LoginCredentials {
-        self.login_credentials.take().unwrap_or_else(|| LoginCredentials::new())
+        self.login_credentials
+            .take()
+            .unwrap_or_else(|| LoginCredentials::new())
     }
 
     // optional .AccountCreation account_creation = 20;
 
-
     pub fn get_account_creation(&self) -> AccountCreation {
-        self.account_creation.unwrap_or(AccountCreation::ACCOUNT_CREATION_ALWAYS_PROMPT)
+        self.account_creation
+            .unwrap_or(AccountCreation::ACCOUNT_CREATION_ALWAYS_PROMPT)
     }
     pub fn clear_account_creation(&mut self) {
         self.account_creation = ::std::option::Option::None;
@@ -108,9 +111,10 @@ impl ClientResponseEncrypted {
 
     // optional .FingerprintResponseUnion fingerprint_response = 30;
 
-
     pub fn get_fingerprint_response(&self) -> &FingerprintResponseUnion {
-        self.fingerprint_response.as_ref().unwrap_or_else(|| FingerprintResponseUnion::default_instance())
+        self.fingerprint_response
+            .as_ref()
+            .unwrap_or_else(|| FingerprintResponseUnion::default_instance())
     }
     pub fn clear_fingerprint_response(&mut self) {
         self.fingerprint_response.clear();
@@ -136,14 +140,17 @@ impl ClientResponseEncrypted {
 
     // Take field
     pub fn take_fingerprint_response(&mut self) -> FingerprintResponseUnion {
-        self.fingerprint_response.take().unwrap_or_else(|| FingerprintResponseUnion::new())
+        self.fingerprint_response
+            .take()
+            .unwrap_or_else(|| FingerprintResponseUnion::new())
     }
 
     // optional .PeerTicketUnion peer_ticket = 40;
 
-
     pub fn get_peer_ticket(&self) -> &PeerTicketUnion {
-        self.peer_ticket.as_ref().unwrap_or_else(|| PeerTicketUnion::default_instance())
+        self.peer_ticket
+            .as_ref()
+            .unwrap_or_else(|| PeerTicketUnion::default_instance())
     }
     pub fn clear_peer_ticket(&mut self) {
         self.peer_ticket.clear();
@@ -169,14 +176,17 @@ impl ClientResponseEncrypted {
 
     // Take field
     pub fn take_peer_ticket(&mut self) -> PeerTicketUnion {
-        self.peer_ticket.take().unwrap_or_else(|| PeerTicketUnion::new())
+        self.peer_ticket
+            .take()
+            .unwrap_or_else(|| PeerTicketUnion::new())
     }
 
     // required .SystemInfo system_info = 50;
 
-
     pub fn get_system_info(&self) -> &SystemInfo {
-        self.system_info.as_ref().unwrap_or_else(|| SystemInfo::default_instance())
+        self.system_info
+            .as_ref()
+            .unwrap_or_else(|| SystemInfo::default_instance())
     }
     pub fn clear_system_info(&mut self) {
         self.system_info.clear();
@@ -206,7 +216,6 @@ impl ClientResponseEncrypted {
     }
 
     // optional string platform_model = 60;
-
 
     pub fn get_platform_model(&self) -> &str {
         match self.platform_model.as_ref() {
@@ -238,11 +247,12 @@ impl ClientResponseEncrypted {
 
     // Take field
     pub fn take_platform_model(&mut self) -> ::std::string::String {
-        self.platform_model.take().unwrap_or_else(|| ::std::string::String::new())
+        self.platform_model
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string version_string = 70;
-
 
     pub fn get_version_string(&self) -> &str {
         match self.version_string.as_ref() {
@@ -274,14 +284,17 @@ impl ClientResponseEncrypted {
 
     // Take field
     pub fn take_version_string(&mut self) -> ::std::string::String {
-        self.version_string.take().unwrap_or_else(|| ::std::string::String::new())
+        self.version_string
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional .LibspotifyAppKey appkey = 80;
 
-
     pub fn get_appkey(&self) -> &LibspotifyAppKey {
-        self.appkey.as_ref().unwrap_or_else(|| LibspotifyAppKey::default_instance())
+        self.appkey
+            .as_ref()
+            .unwrap_or_else(|| LibspotifyAppKey::default_instance())
     }
     pub fn clear_appkey(&mut self) {
         self.appkey.clear();
@@ -307,14 +320,17 @@ impl ClientResponseEncrypted {
 
     // Take field
     pub fn take_appkey(&mut self) -> LibspotifyAppKey {
-        self.appkey.take().unwrap_or_else(|| LibspotifyAppKey::new())
+        self.appkey
+            .take()
+            .unwrap_or_else(|| LibspotifyAppKey::new())
     }
 
     // optional .ClientInfo client_info = 90;
 
-
     pub fn get_client_info(&self) -> &ClientInfo {
-        self.client_info.as_ref().unwrap_or_else(|| ClientInfo::default_instance())
+        self.client_info
+            .as_ref()
+            .unwrap_or_else(|| ClientInfo::default_instance())
     }
     pub fn clear_client_info(&mut self) {
         self.client_info.clear();
@@ -356,69 +372,109 @@ impl ::protobuf::Message for ClientResponseEncrypted {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.fingerprint_response {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.peer_ticket {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.system_info {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.appkey {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.client_info {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.login_credentials)?;
-                },
-                20 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.account_creation, 20, &mut self.unknown_fields)?
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.login_credentials,
+                    )?;
+                }
+                20 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.account_creation,
+                    20,
+                    &mut self.unknown_fields,
+                )?,
                 30 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.fingerprint_response)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.fingerprint_response,
+                    )?;
+                }
                 40 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.peer_ticket)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.peer_ticket,
+                    )?;
+                }
                 50 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.system_info)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.system_info,
+                    )?;
+                }
                 60 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.platform_model)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.platform_model,
+                    )?;
+                }
                 70 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.version_string)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.version_string,
+                    )?;
+                }
                 80 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.appkey)?;
-                },
+                }
                 90 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.client_info)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.client_info,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -466,7 +522,10 @@ impl ::protobuf::Message for ClientResponseEncrypted {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.login_credentials.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -541,75 +600,118 @@ impl ::protobuf::Message for ClientResponseEncrypted {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<LoginCredentials>>(
-                    "login_credentials",
-                    |m: &ClientResponseEncrypted| { &m.login_credentials },
-                    |m: &mut ClientResponseEncrypted| { &mut m.login_credentials },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<AccountCreation>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<LoginCredentials>,
+                    >(
+                        "login_credentials",
+                        |m: &ClientResponseEncrypted| &m.login_credentials,
+                        |m: &mut ClientResponseEncrypted| &mut m.login_credentials,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<AccountCreation>,
+                >(
                     "account_creation",
-                    |m: &ClientResponseEncrypted| { &m.account_creation },
-                    |m: &mut ClientResponseEncrypted| { &mut m.account_creation },
+                    |m: &ClientResponseEncrypted| &m.account_creation,
+                    |m: &mut ClientResponseEncrypted| &mut m.account_creation,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<FingerprintResponseUnion>>(
-                    "fingerprint_response",
-                    |m: &ClientResponseEncrypted| { &m.fingerprint_response },
-                    |m: &mut ClientResponseEncrypted| { &mut m.fingerprint_response },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PeerTicketUnion>>(
-                    "peer_ticket",
-                    |m: &ClientResponseEncrypted| { &m.peer_ticket },
-                    |m: &mut ClientResponseEncrypted| { &mut m.peer_ticket },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<SystemInfo>>(
-                    "system_info",
-                    |m: &ClientResponseEncrypted| { &m.system_info },
-                    |m: &mut ClientResponseEncrypted| { &mut m.system_info },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "platform_model",
-                    |m: &ClientResponseEncrypted| { &m.platform_model },
-                    |m: &mut ClientResponseEncrypted| { &mut m.platform_model },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "version_string",
-                    |m: &ClientResponseEncrypted| { &m.version_string },
-                    |m: &mut ClientResponseEncrypted| { &mut m.version_string },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<LibspotifyAppKey>>(
-                    "appkey",
-                    |m: &ClientResponseEncrypted| { &m.appkey },
-                    |m: &mut ClientResponseEncrypted| { &mut m.appkey },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ClientInfo>>(
-                    "client_info",
-                    |m: &ClientResponseEncrypted| { &m.client_info },
-                    |m: &mut ClientResponseEncrypted| { &mut m.client_info },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<FingerprintResponseUnion>,
+                    >(
+                        "fingerprint_response",
+                        |m: &ClientResponseEncrypted| &m.fingerprint_response,
+                        |m: &mut ClientResponseEncrypted| &mut m.fingerprint_response,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<PeerTicketUnion>,
+                    >(
+                        "peer_ticket",
+                        |m: &ClientResponseEncrypted| &m.peer_ticket,
+                        |m: &mut ClientResponseEncrypted| &mut m.peer_ticket,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<SystemInfo>,
+                    >(
+                        "system_info",
+                        |m: &ClientResponseEncrypted| &m.system_info,
+                        |m: &mut ClientResponseEncrypted| &mut m.system_info,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "platform_model",
+                        |m: &ClientResponseEncrypted| &m.platform_model,
+                        |m: &mut ClientResponseEncrypted| &mut m.platform_model,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "version_string",
+                        |m: &ClientResponseEncrypted| &m.version_string,
+                        |m: &mut ClientResponseEncrypted| &mut m.version_string,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<LibspotifyAppKey>,
+                    >(
+                        "appkey",
+                        |m: &ClientResponseEncrypted| &m.appkey,
+                        |m: &mut ClientResponseEncrypted| &mut m.appkey,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ClientInfo>,
+                    >(
+                        "client_info",
+                        |m: &ClientResponseEncrypted| &m.client_info,
+                        |m: &mut ClientResponseEncrypted| &mut m.client_info,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ClientResponseEncrypted>(
                     "ClientResponseEncrypted",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static ClientResponseEncrypted {
-        static mut instance: ::protobuf::lazy::Lazy<ClientResponseEncrypted> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ClientResponseEncrypted,
-        };
-        unsafe {
-            instance.get(ClientResponseEncrypted::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<ClientResponseEncrypted> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ClientResponseEncrypted,
+            };
+        unsafe { instance.get(ClientResponseEncrypted::new) }
     }
 }
 
@@ -640,7 +742,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientResponseEncrypted {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct LoginCredentials {
     // message fields
     username: ::protobuf::SingularField<::std::string::String>,
@@ -663,7 +765,6 @@ impl LoginCredentials {
     }
 
     // optional string username = 10;
-
 
     pub fn get_username(&self) -> &str {
         match self.username.as_ref() {
@@ -695,14 +796,16 @@ impl LoginCredentials {
 
     // Take field
     pub fn take_username(&mut self) -> ::std::string::String {
-        self.username.take().unwrap_or_else(|| ::std::string::String::new())
+        self.username
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // required .AuthenticationType typ = 20;
 
-
     pub fn get_typ(&self) -> AuthenticationType {
-        self.typ.unwrap_or(AuthenticationType::AUTHENTICATION_USER_PASS)
+        self.typ
+            .unwrap_or(AuthenticationType::AUTHENTICATION_USER_PASS)
     }
     pub fn clear_typ(&mut self) {
         self.typ = ::std::option::Option::None;
@@ -718,7 +821,6 @@ impl LoginCredentials {
     }
 
     // optional bytes auth_data = 30;
-
 
     pub fn get_auth_data(&self) -> &[u8] {
         match self.auth_data.as_ref() {
@@ -750,7 +852,9 @@ impl LoginCredentials {
 
     // Take field
     pub fn take_auth_data(&mut self) -> ::std::vec::Vec<u8> {
-        self.auth_data.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.auth_data
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -762,22 +866,34 @@ impl ::protobuf::Message for LoginCredentials {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.username)?;
-                },
-                20 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.typ, 20, &mut self.unknown_fields)?
-                },
+                }
+                20 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.typ,
+                    20,
+                    &mut self.unknown_fields,
+                )?,
                 30 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.auth_data)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -801,7 +917,10 @@ impl ::protobuf::Message for LoginCredentials {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.username.as_ref() {
             os.write_string(10, &v)?;
         }
@@ -846,32 +965,46 @@ impl ::protobuf::Message for LoginCredentials {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "username",
-                    |m: &LoginCredentials| { &m.username },
-                    |m: &mut LoginCredentials| { &mut m.username },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<AuthenticationType>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "username",
+                        |m: &LoginCredentials| &m.username,
+                        |m: &mut LoginCredentials| &mut m.username,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<AuthenticationType>,
+                >(
                     "typ",
-                    |m: &LoginCredentials| { &m.typ },
-                    |m: &mut LoginCredentials| { &mut m.typ },
+                    |m: &LoginCredentials| &m.typ,
+                    |m: &mut LoginCredentials| &mut m.typ,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "auth_data",
-                    |m: &LoginCredentials| { &m.auth_data },
-                    |m: &mut LoginCredentials| { &mut m.auth_data },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "auth_data",
+                        |m: &LoginCredentials| &m.auth_data,
+                        |m: &mut LoginCredentials| &mut m.auth_data,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<LoginCredentials>(
                     "LoginCredentials",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -882,9 +1015,7 @@ impl ::protobuf::Message for LoginCredentials {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const LoginCredentials,
         };
-        unsafe {
-            instance.get(LoginCredentials::new)
-        }
+        unsafe { instance.get(LoginCredentials::new) }
     }
 }
 
@@ -909,7 +1040,7 @@ impl ::protobuf::reflect::ProtobufValue for LoginCredentials {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct FingerprintResponseUnion {
     // message fields
     grain: ::protobuf::SingularPtrField<FingerprintGrainResponse>,
@@ -932,9 +1063,10 @@ impl FingerprintResponseUnion {
 
     // optional .FingerprintGrainResponse grain = 10;
 
-
     pub fn get_grain(&self) -> &FingerprintGrainResponse {
-        self.grain.as_ref().unwrap_or_else(|| FingerprintGrainResponse::default_instance())
+        self.grain
+            .as_ref()
+            .unwrap_or_else(|| FingerprintGrainResponse::default_instance())
     }
     pub fn clear_grain(&mut self) {
         self.grain.clear();
@@ -960,14 +1092,17 @@ impl FingerprintResponseUnion {
 
     // Take field
     pub fn take_grain(&mut self) -> FingerprintGrainResponse {
-        self.grain.take().unwrap_or_else(|| FingerprintGrainResponse::new())
+        self.grain
+            .take()
+            .unwrap_or_else(|| FingerprintGrainResponse::new())
     }
 
     // optional .FingerprintHmacRipemdResponse hmac_ripemd = 20;
 
-
     pub fn get_hmac_ripemd(&self) -> &FingerprintHmacRipemdResponse {
-        self.hmac_ripemd.as_ref().unwrap_or_else(|| FingerprintHmacRipemdResponse::default_instance())
+        self.hmac_ripemd
+            .as_ref()
+            .unwrap_or_else(|| FingerprintHmacRipemdResponse::default_instance())
     }
     pub fn clear_hmac_ripemd(&mut self) {
         self.hmac_ripemd.clear();
@@ -993,7 +1128,9 @@ impl FingerprintResponseUnion {
 
     // Take field
     pub fn take_hmac_ripemd(&mut self) -> FingerprintHmacRipemdResponse {
-        self.hmac_ripemd.take().unwrap_or_else(|| FingerprintHmacRipemdResponse::new())
+        self.hmac_ripemd
+            .take()
+            .unwrap_or_else(|| FingerprintHmacRipemdResponse::new())
     }
 }
 
@@ -1003,28 +1140,40 @@ impl ::protobuf::Message for FingerprintResponseUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.hmac_ripemd {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.grain)?;
-                },
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.hmac_ripemd)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.hmac_ripemd,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1047,7 +1196,10 @@ impl ::protobuf::Message for FingerprintResponseUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.grain.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1093,40 +1245,50 @@ impl ::protobuf::Message for FingerprintResponseUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<FingerprintGrainResponse>>(
-                    "grain",
-                    |m: &FingerprintResponseUnion| { &m.grain },
-                    |m: &mut FingerprintResponseUnion| { &mut m.grain },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<FingerprintHmacRipemdResponse>>(
-                    "hmac_ripemd",
-                    |m: &FingerprintResponseUnion| { &m.hmac_ripemd },
-                    |m: &mut FingerprintResponseUnion| { &mut m.hmac_ripemd },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<FingerprintGrainResponse>,
+                    >(
+                        "grain",
+                        |m: &FingerprintResponseUnion| &m.grain,
+                        |m: &mut FingerprintResponseUnion| &mut m.grain,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<FingerprintHmacRipemdResponse>,
+                    >(
+                        "hmac_ripemd",
+                        |m: &FingerprintResponseUnion| &m.hmac_ripemd,
+                        |m: &mut FingerprintResponseUnion| &mut m.hmac_ripemd,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<FingerprintResponseUnion>(
                     "FingerprintResponseUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static FingerprintResponseUnion {
-        static mut instance: ::protobuf::lazy::Lazy<FingerprintResponseUnion> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const FingerprintResponseUnion,
-        };
-        unsafe {
-            instance.get(FingerprintResponseUnion::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<FingerprintResponseUnion> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const FingerprintResponseUnion,
+            };
+        unsafe { instance.get(FingerprintResponseUnion::new) }
     }
 }
 
@@ -1150,7 +1312,7 @@ impl ::protobuf::reflect::ProtobufValue for FingerprintResponseUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct FingerprintGrainResponse {
     // message fields
     encrypted_key: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -1171,7 +1333,6 @@ impl FingerprintGrainResponse {
     }
 
     // required bytes encrypted_key = 10;
-
 
     pub fn get_encrypted_key(&self) -> &[u8] {
         match self.encrypted_key.as_ref() {
@@ -1203,7 +1364,9 @@ impl FingerprintGrainResponse {
 
     // Take field
     pub fn take_encrypted_key(&mut self) -> ::std::vec::Vec<u8> {
-        self.encrypted_key.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.encrypted_key
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -1215,16 +1378,28 @@ impl ::protobuf::Message for FingerprintGrainResponse {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.encrypted_key)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.encrypted_key,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1242,7 +1417,10 @@ impl ::protobuf::Message for FingerprintGrainResponse {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.encrypted_key.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -1281,35 +1459,40 @@ impl ::protobuf::Message for FingerprintGrainResponse {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "encrypted_key",
-                    |m: &FingerprintGrainResponse| { &m.encrypted_key },
-                    |m: &mut FingerprintGrainResponse| { &mut m.encrypted_key },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "encrypted_key",
+                        |m: &FingerprintGrainResponse| &m.encrypted_key,
+                        |m: &mut FingerprintGrainResponse| &mut m.encrypted_key,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<FingerprintGrainResponse>(
                     "FingerprintGrainResponse",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static FingerprintGrainResponse {
-        static mut instance: ::protobuf::lazy::Lazy<FingerprintGrainResponse> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const FingerprintGrainResponse,
-        };
-        unsafe {
-            instance.get(FingerprintGrainResponse::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<FingerprintGrainResponse> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const FingerprintGrainResponse,
+            };
+        unsafe { instance.get(FingerprintGrainResponse::new) }
     }
 }
 
@@ -1332,7 +1515,7 @@ impl ::protobuf::reflect::ProtobufValue for FingerprintGrainResponse {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct FingerprintHmacRipemdResponse {
     // message fields
     hmac: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -1353,7 +1536,6 @@ impl FingerprintHmacRipemdResponse {
     }
 
     // required bytes hmac = 10;
-
 
     pub fn get_hmac(&self) -> &[u8] {
         match self.hmac.as_ref() {
@@ -1397,16 +1579,24 @@ impl ::protobuf::Message for FingerprintHmacRipemdResponse {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.hmac)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1424,7 +1614,10 @@ impl ::protobuf::Message for FingerprintHmacRipemdResponse {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.hmac.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -1463,35 +1656,40 @@ impl ::protobuf::Message for FingerprintHmacRipemdResponse {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "hmac",
-                    |m: &FingerprintHmacRipemdResponse| { &m.hmac },
-                    |m: &mut FingerprintHmacRipemdResponse| { &mut m.hmac },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "hmac",
+                        |m: &FingerprintHmacRipemdResponse| &m.hmac,
+                        |m: &mut FingerprintHmacRipemdResponse| &mut m.hmac,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<FingerprintHmacRipemdResponse>(
                     "FingerprintHmacRipemdResponse",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static FingerprintHmacRipemdResponse {
-        static mut instance: ::protobuf::lazy::Lazy<FingerprintHmacRipemdResponse> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const FingerprintHmacRipemdResponse,
-        };
-        unsafe {
-            instance.get(FingerprintHmacRipemdResponse::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<FingerprintHmacRipemdResponse> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const FingerprintHmacRipemdResponse,
+            };
+        unsafe { instance.get(FingerprintHmacRipemdResponse::new) }
     }
 }
 
@@ -1514,7 +1712,7 @@ impl ::protobuf::reflect::ProtobufValue for FingerprintHmacRipemdResponse {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct PeerTicketUnion {
     // message fields
     public_key: ::protobuf::SingularPtrField<PeerTicketPublicKey>,
@@ -1537,9 +1735,10 @@ impl PeerTicketUnion {
 
     // optional .PeerTicketPublicKey public_key = 10;
 
-
     pub fn get_public_key(&self) -> &PeerTicketPublicKey {
-        self.public_key.as_ref().unwrap_or_else(|| PeerTicketPublicKey::default_instance())
+        self.public_key
+            .as_ref()
+            .unwrap_or_else(|| PeerTicketPublicKey::default_instance())
     }
     pub fn clear_public_key(&mut self) {
         self.public_key.clear();
@@ -1565,14 +1764,17 @@ impl PeerTicketUnion {
 
     // Take field
     pub fn take_public_key(&mut self) -> PeerTicketPublicKey {
-        self.public_key.take().unwrap_or_else(|| PeerTicketPublicKey::new())
+        self.public_key
+            .take()
+            .unwrap_or_else(|| PeerTicketPublicKey::new())
     }
 
     // optional .PeerTicketOld old_ticket = 20;
 
-
     pub fn get_old_ticket(&self) -> &PeerTicketOld {
-        self.old_ticket.as_ref().unwrap_or_else(|| PeerTicketOld::default_instance())
+        self.old_ticket
+            .as_ref()
+            .unwrap_or_else(|| PeerTicketOld::default_instance())
     }
     pub fn clear_old_ticket(&mut self) {
         self.old_ticket.clear();
@@ -1598,7 +1800,9 @@ impl PeerTicketUnion {
 
     // Take field
     pub fn take_old_ticket(&mut self) -> PeerTicketOld {
-        self.old_ticket.take().unwrap_or_else(|| PeerTicketOld::new())
+        self.old_ticket
+            .take()
+            .unwrap_or_else(|| PeerTicketOld::new())
     }
 }
 
@@ -1608,28 +1812,44 @@ impl ::protobuf::Message for PeerTicketUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.old_ticket {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.public_key)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.public_key,
+                    )?;
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.old_ticket)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.old_ticket,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1652,7 +1872,10 @@ impl ::protobuf::Message for PeerTicketUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.public_key.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1698,27 +1921,38 @@ impl ::protobuf::Message for PeerTicketUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PeerTicketPublicKey>>(
-                    "public_key",
-                    |m: &PeerTicketUnion| { &m.public_key },
-                    |m: &mut PeerTicketUnion| { &mut m.public_key },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PeerTicketOld>>(
-                    "old_ticket",
-                    |m: &PeerTicketUnion| { &m.old_ticket },
-                    |m: &mut PeerTicketUnion| { &mut m.old_ticket },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<PeerTicketPublicKey>,
+                    >(
+                        "public_key",
+                        |m: &PeerTicketUnion| &m.public_key,
+                        |m: &mut PeerTicketUnion| &mut m.public_key,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<PeerTicketOld>,
+                    >(
+                        "old_ticket",
+                        |m: &PeerTicketUnion| &m.old_ticket,
+                        |m: &mut PeerTicketUnion| &mut m.old_ticket,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<PeerTicketUnion>(
                     "PeerTicketUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1729,9 +1963,7 @@ impl ::protobuf::Message for PeerTicketUnion {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const PeerTicketUnion,
         };
-        unsafe {
-            instance.get(PeerTicketUnion::new)
-        }
+        unsafe { instance.get(PeerTicketUnion::new) }
     }
 }
 
@@ -1755,7 +1987,7 @@ impl ::protobuf::reflect::ProtobufValue for PeerTicketUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct PeerTicketPublicKey {
     // message fields
     public_key: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -1776,7 +2008,6 @@ impl PeerTicketPublicKey {
     }
 
     // required bytes public_key = 10;
-
 
     pub fn get_public_key(&self) -> &[u8] {
         match self.public_key.as_ref() {
@@ -1808,7 +2039,9 @@ impl PeerTicketPublicKey {
 
     // Take field
     pub fn take_public_key(&mut self) -> ::std::vec::Vec<u8> {
-        self.public_key.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.public_key
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -1820,16 +2053,24 @@ impl ::protobuf::Message for PeerTicketPublicKey {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.public_key)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1847,7 +2088,10 @@ impl ::protobuf::Message for PeerTicketPublicKey {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.public_key.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -1886,22 +2130,28 @@ impl ::protobuf::Message for PeerTicketPublicKey {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "public_key",
-                    |m: &PeerTicketPublicKey| { &m.public_key },
-                    |m: &mut PeerTicketPublicKey| { &mut m.public_key },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "public_key",
+                        |m: &PeerTicketPublicKey| &m.public_key,
+                        |m: &mut PeerTicketPublicKey| &mut m.public_key,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<PeerTicketPublicKey>(
                     "PeerTicketPublicKey",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1912,9 +2162,7 @@ impl ::protobuf::Message for PeerTicketPublicKey {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const PeerTicketPublicKey,
         };
-        unsafe {
-            instance.get(PeerTicketPublicKey::new)
-        }
+        unsafe { instance.get(PeerTicketPublicKey::new) }
     }
 }
 
@@ -1937,7 +2185,7 @@ impl ::protobuf::reflect::ProtobufValue for PeerTicketPublicKey {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct PeerTicketOld {
     // message fields
     peer_ticket: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -1959,7 +2207,6 @@ impl PeerTicketOld {
     }
 
     // required bytes peer_ticket = 10;
-
 
     pub fn get_peer_ticket(&self) -> &[u8] {
         match self.peer_ticket.as_ref() {
@@ -1991,11 +2238,12 @@ impl PeerTicketOld {
 
     // Take field
     pub fn take_peer_ticket(&mut self) -> ::std::vec::Vec<u8> {
-        self.peer_ticket.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.peer_ticket
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // required bytes peer_ticket_signature = 20;
-
 
     pub fn get_peer_ticket_signature(&self) -> &[u8] {
         match self.peer_ticket_signature.as_ref() {
@@ -2027,7 +2275,9 @@ impl PeerTicketOld {
 
     // Take field
     pub fn take_peer_ticket_signature(&mut self) -> ::std::vec::Vec<u8> {
-        self.peer_ticket_signature.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.peer_ticket_signature
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -2042,19 +2292,31 @@ impl ::protobuf::Message for PeerTicketOld {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.peer_ticket)?;
-                },
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.peer_ticket_signature)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.peer_ticket_signature,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2075,7 +2337,10 @@ impl ::protobuf::Message for PeerTicketOld {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.peer_ticket.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -2117,27 +2382,38 @@ impl ::protobuf::Message for PeerTicketOld {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "peer_ticket",
-                    |m: &PeerTicketOld| { &m.peer_ticket },
-                    |m: &mut PeerTicketOld| { &mut m.peer_ticket },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "peer_ticket_signature",
-                    |m: &PeerTicketOld| { &m.peer_ticket_signature },
-                    |m: &mut PeerTicketOld| { &mut m.peer_ticket_signature },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "peer_ticket",
+                        |m: &PeerTicketOld| &m.peer_ticket,
+                        |m: &mut PeerTicketOld| &mut m.peer_ticket,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "peer_ticket_signature",
+                        |m: &PeerTicketOld| &m.peer_ticket_signature,
+                        |m: &mut PeerTicketOld| &mut m.peer_ticket_signature,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<PeerTicketOld>(
                     "PeerTicketOld",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -2148,9 +2424,7 @@ impl ::protobuf::Message for PeerTicketOld {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const PeerTicketOld,
         };
-        unsafe {
-            instance.get(PeerTicketOld::new)
-        }
+        unsafe { instance.get(PeerTicketOld::new) }
     }
 }
 
@@ -2174,7 +2448,7 @@ impl ::protobuf::reflect::ProtobufValue for PeerTicketOld {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct SystemInfo {
     // message fields
     cpu_family: ::std::option::Option<CpuFamily>,
@@ -2205,7 +2479,6 @@ impl SystemInfo {
 
     // required .CpuFamily cpu_family = 10;
 
-
     pub fn get_cpu_family(&self) -> CpuFamily {
         self.cpu_family.unwrap_or(CpuFamily::CPU_UNKNOWN)
     }
@@ -2223,7 +2496,6 @@ impl SystemInfo {
     }
 
     // optional uint32 cpu_subtype = 20;
-
 
     pub fn get_cpu_subtype(&self) -> u32 {
         self.cpu_subtype.unwrap_or(0)
@@ -2243,7 +2515,6 @@ impl SystemInfo {
 
     // optional uint32 cpu_ext = 30;
 
-
     pub fn get_cpu_ext(&self) -> u32 {
         self.cpu_ext.unwrap_or(0)
     }
@@ -2261,7 +2532,6 @@ impl SystemInfo {
     }
 
     // optional .Brand brand = 40;
-
 
     pub fn get_brand(&self) -> Brand {
         self.brand.unwrap_or(Brand::BRAND_UNBRANDED)
@@ -2281,7 +2551,6 @@ impl SystemInfo {
 
     // optional uint32 brand_flags = 50;
 
-
     pub fn get_brand_flags(&self) -> u32 {
         self.brand_flags.unwrap_or(0)
     }
@@ -2299,7 +2568,6 @@ impl SystemInfo {
     }
 
     // required .Os os = 60;
-
 
     pub fn get_os(&self) -> Os {
         self.os.unwrap_or(Os::OS_UNKNOWN)
@@ -2319,7 +2587,6 @@ impl SystemInfo {
 
     // optional uint32 os_version = 70;
 
-
     pub fn get_os_version(&self) -> u32 {
         self.os_version.unwrap_or(0)
     }
@@ -2338,7 +2605,6 @@ impl SystemInfo {
 
     // optional uint32 os_ext = 80;
 
-
     pub fn get_os_ext(&self) -> u32 {
         self.os_ext.unwrap_or(0)
     }
@@ -2356,7 +2622,6 @@ impl SystemInfo {
     }
 
     // optional string system_information_string = 90;
-
 
     pub fn get_system_information_string(&self) -> &str {
         match self.system_information_string.as_ref() {
@@ -2388,11 +2653,12 @@ impl SystemInfo {
 
     // Take field
     pub fn take_system_information_string(&mut self) -> ::std::string::String {
-        self.system_information_string.take().unwrap_or_else(|| ::std::string::String::new())
+        self.system_information_string
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string device_id = 100;
-
 
     pub fn get_device_id(&self) -> &str {
         match self.device_id.as_ref() {
@@ -2424,7 +2690,9 @@ impl SystemInfo {
 
     // Take field
     pub fn take_device_id(&mut self) -> ::std::string::String {
-        self.device_id.take().unwrap_or_else(|| ::std::string::String::new())
+        self.device_id
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -2439,63 +2707,97 @@ impl ::protobuf::Message for SystemInfo {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                10 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.cpu_family, 10, &mut self.unknown_fields)?
-                },
+                10 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.cpu_family,
+                    10,
+                    &mut self.unknown_fields,
+                )?,
                 20 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.cpu_subtype = ::std::option::Option::Some(tmp);
-                },
+                }
                 30 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.cpu_ext = ::std::option::Option::Some(tmp);
-                },
-                40 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.brand, 40, &mut self.unknown_fields)?
-                },
+                }
+                40 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.brand,
+                    40,
+                    &mut self.unknown_fields,
+                )?,
                 50 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.brand_flags = ::std::option::Option::Some(tmp);
-                },
-                60 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.os, 60, &mut self.unknown_fields)?
-                },
+                }
+                60 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.os,
+                    60,
+                    &mut self.unknown_fields,
+                )?,
                 70 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.os_version = ::std::option::Option::Some(tmp);
-                },
+                }
                 80 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.os_ext = ::std::option::Option::Some(tmp);
-                },
+                }
                 90 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.system_information_string)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.system_information_string,
+                    )?;
+                }
                 100 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.device_id)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2540,7 +2842,10 @@ impl ::protobuf::Message for SystemInfo {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.cpu_family {
             os.write_enum(10, v.value())?;
         }
@@ -2606,67 +2911,102 @@ impl ::protobuf::Message for SystemInfo {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<CpuFamily>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<CpuFamily>,
+                >(
                     "cpu_family",
-                    |m: &SystemInfo| { &m.cpu_family },
-                    |m: &mut SystemInfo| { &mut m.cpu_family },
+                    |m: &SystemInfo| &m.cpu_family,
+                    |m: &mut SystemInfo| &mut m.cpu_family,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "cpu_subtype",
-                    |m: &SystemInfo| { &m.cpu_subtype },
-                    |m: &mut SystemInfo| { &mut m.cpu_subtype },
+                    |m: &SystemInfo| &m.cpu_subtype,
+                    |m: &mut SystemInfo| &mut m.cpu_subtype,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "cpu_ext",
-                    |m: &SystemInfo| { &m.cpu_ext },
-                    |m: &mut SystemInfo| { &mut m.cpu_ext },
+                    |m: &SystemInfo| &m.cpu_ext,
+                    |m: &mut SystemInfo| &mut m.cpu_ext,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Brand>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Brand>,
+                >(
                     "brand",
-                    |m: &SystemInfo| { &m.brand },
-                    |m: &mut SystemInfo| { &mut m.brand },
+                    |m: &SystemInfo| &m.brand,
+                    |m: &mut SystemInfo| &mut m.brand,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "brand_flags",
-                    |m: &SystemInfo| { &m.brand_flags },
-                    |m: &mut SystemInfo| { &mut m.brand_flags },
+                    |m: &SystemInfo| &m.brand_flags,
+                    |m: &mut SystemInfo| &mut m.brand_flags,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Os>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Os>,
+                >(
                     "os",
-                    |m: &SystemInfo| { &m.os },
-                    |m: &mut SystemInfo| { &mut m.os },
+                    |m: &SystemInfo| &m.os,
+                    |m: &mut SystemInfo| &mut m.os,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "os_version",
-                    |m: &SystemInfo| { &m.os_version },
-                    |m: &mut SystemInfo| { &mut m.os_version },
+                    |m: &SystemInfo| &m.os_version,
+                    |m: &mut SystemInfo| &mut m.os_version,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "os_ext",
-                    |m: &SystemInfo| { &m.os_ext },
-                    |m: &mut SystemInfo| { &mut m.os_ext },
+                    |m: &SystemInfo| &m.os_ext,
+                    |m: &mut SystemInfo| &mut m.os_ext,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "system_information_string",
-                    |m: &SystemInfo| { &m.system_information_string },
-                    |m: &mut SystemInfo| { &mut m.system_information_string },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "device_id",
-                    |m: &SystemInfo| { &m.device_id },
-                    |m: &mut SystemInfo| { &mut m.device_id },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "system_information_string",
+                        |m: &SystemInfo| &m.system_information_string,
+                        |m: &mut SystemInfo| &mut m.system_information_string,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "device_id",
+                        |m: &SystemInfo| &m.device_id,
+                        |m: &mut SystemInfo| &mut m.device_id,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<SystemInfo>(
                     "SystemInfo",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -2677,9 +3017,7 @@ impl ::protobuf::Message for SystemInfo {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const SystemInfo,
         };
-        unsafe {
-            instance.get(SystemInfo::new)
-        }
+        unsafe { instance.get(SystemInfo::new) }
     }
 }
 
@@ -2711,7 +3049,7 @@ impl ::protobuf::reflect::ProtobufValue for SystemInfo {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct LibspotifyAppKey {
     // message fields
     version: ::std::option::Option<u32>,
@@ -2737,7 +3075,6 @@ impl LibspotifyAppKey {
 
     // required uint32 version = 1;
 
-
     pub fn get_version(&self) -> u32 {
         self.version.unwrap_or(0)
     }
@@ -2755,7 +3092,6 @@ impl LibspotifyAppKey {
     }
 
     // required bytes devkey = 2;
-
 
     pub fn get_devkey(&self) -> &[u8] {
         match self.devkey.as_ref() {
@@ -2792,7 +3128,6 @@ impl LibspotifyAppKey {
 
     // required bytes signature = 3;
 
-
     pub fn get_signature(&self) -> &[u8] {
         match self.signature.as_ref() {
             Some(v) => &v,
@@ -2823,11 +3158,12 @@ impl LibspotifyAppKey {
 
     // Take field
     pub fn take_signature(&mut self) -> ::std::vec::Vec<u8> {
-        self.signature.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.signature
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // required string useragent = 4;
-
 
     pub fn get_useragent(&self) -> &str {
         match self.useragent.as_ref() {
@@ -2859,11 +3195,12 @@ impl LibspotifyAppKey {
 
     // Take field
     pub fn take_useragent(&mut self) -> ::std::string::String {
-        self.useragent.take().unwrap_or_else(|| ::std::string::String::new())
+        self.useragent
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // required bytes callback_hash = 5;
-
 
     pub fn get_callback_hash(&self) -> &[u8] {
         match self.callback_hash.as_ref() {
@@ -2895,7 +3232,9 @@ impl LibspotifyAppKey {
 
     // Take field
     pub fn take_callback_hash(&mut self) -> ::std::vec::Vec<u8> {
-        self.callback_hash.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.callback_hash
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -2919,32 +3258,46 @@ impl ::protobuf::Message for LibspotifyAppKey {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.version = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.devkey)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.signature)?;
-                },
+                }
                 4 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.useragent)?;
-                },
+                }
                 5 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.callback_hash)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.callback_hash,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2974,7 +3327,10 @@ impl ::protobuf::Message for LibspotifyAppKey {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.version {
             os.write_uint32(1, v)?;
         }
@@ -3025,42 +3381,66 @@ impl ::protobuf::Message for LibspotifyAppKey {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "version",
-                    |m: &LibspotifyAppKey| { &m.version },
-                    |m: &mut LibspotifyAppKey| { &mut m.version },
+                    |m: &LibspotifyAppKey| &m.version,
+                    |m: &mut LibspotifyAppKey| &mut m.version,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "devkey",
-                    |m: &LibspotifyAppKey| { &m.devkey },
-                    |m: &mut LibspotifyAppKey| { &mut m.devkey },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "signature",
-                    |m: &LibspotifyAppKey| { &m.signature },
-                    |m: &mut LibspotifyAppKey| { &mut m.signature },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "useragent",
-                    |m: &LibspotifyAppKey| { &m.useragent },
-                    |m: &mut LibspotifyAppKey| { &mut m.useragent },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "callback_hash",
-                    |m: &LibspotifyAppKey| { &m.callback_hash },
-                    |m: &mut LibspotifyAppKey| { &mut m.callback_hash },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "devkey",
+                        |m: &LibspotifyAppKey| &m.devkey,
+                        |m: &mut LibspotifyAppKey| &mut m.devkey,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "signature",
+                        |m: &LibspotifyAppKey| &m.signature,
+                        |m: &mut LibspotifyAppKey| &mut m.signature,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "useragent",
+                        |m: &LibspotifyAppKey| &m.useragent,
+                        |m: &mut LibspotifyAppKey| &mut m.useragent,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "callback_hash",
+                        |m: &LibspotifyAppKey| &m.callback_hash,
+                        |m: &mut LibspotifyAppKey| &mut m.callback_hash,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<LibspotifyAppKey>(
                     "LibspotifyAppKey",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3071,9 +3451,7 @@ impl ::protobuf::Message for LibspotifyAppKey {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const LibspotifyAppKey,
         };
-        unsafe {
-            instance.get(LibspotifyAppKey::new)
-        }
+        unsafe { instance.get(LibspotifyAppKey::new) }
     }
 }
 
@@ -3100,7 +3478,7 @@ impl ::protobuf::reflect::ProtobufValue for LibspotifyAppKey {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ClientInfo {
     // message fields
     limited: ::std::option::Option<bool>,
@@ -3124,7 +3502,6 @@ impl ClientInfo {
 
     // optional bool limited = 1;
 
-
     pub fn get_limited(&self) -> bool {
         self.limited.unwrap_or(false)
     }
@@ -3143,9 +3520,10 @@ impl ClientInfo {
 
     // optional .ClientInfoFacebook fb = 2;
 
-
     pub fn get_fb(&self) -> &ClientInfoFacebook {
-        self.fb.as_ref().unwrap_or_else(|| ClientInfoFacebook::default_instance())
+        self.fb
+            .as_ref()
+            .unwrap_or_else(|| ClientInfoFacebook::default_instance())
     }
     pub fn clear_fb(&mut self) {
         self.fb.clear();
@@ -3175,7 +3553,6 @@ impl ClientInfo {
     }
 
     // optional string language = 3;
-
 
     pub fn get_language(&self) -> &str {
         match self.language.as_ref() {
@@ -3207,7 +3584,9 @@ impl ClientInfo {
 
     // Take field
     pub fn take_language(&mut self) -> ::std::string::String {
-        self.language.take().unwrap_or_else(|| ::std::string::String::new())
+        self.language
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -3217,30 +3596,40 @@ impl ::protobuf::Message for ClientInfo {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.limited = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.fb)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.language)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3265,7 +3654,10 @@ impl ::protobuf::Message for ClientInfo {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.limited {
             os.write_bool(1, v)?;
         }
@@ -3312,32 +3704,44 @@ impl ::protobuf::Message for ClientInfo {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "limited",
-                    |m: &ClientInfo| { &m.limited },
-                    |m: &mut ClientInfo| { &mut m.limited },
+                    |m: &ClientInfo| &m.limited,
+                    |m: &mut ClientInfo| &mut m.limited,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ClientInfoFacebook>>(
-                    "fb",
-                    |m: &ClientInfo| { &m.fb },
-                    |m: &mut ClientInfo| { &mut m.fb },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "language",
-                    |m: &ClientInfo| { &m.language },
-                    |m: &mut ClientInfo| { &mut m.language },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ClientInfoFacebook>,
+                    >(
+                        "fb", |m: &ClientInfo| &m.fb, |m: &mut ClientInfo| &mut m.fb
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "language",
+                        |m: &ClientInfo| &m.language,
+                        |m: &mut ClientInfo| &mut m.language,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ClientInfo>(
                     "ClientInfo",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3348,9 +3752,7 @@ impl ::protobuf::Message for ClientInfo {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ClientInfo,
         };
-        unsafe {
-            instance.get(ClientInfo::new)
-        }
+        unsafe { instance.get(ClientInfo::new) }
     }
 }
 
@@ -3375,7 +3777,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientInfo {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ClientInfoFacebook {
     // message fields
     machine_id: ::protobuf::SingularField<::std::string::String>,
@@ -3396,7 +3798,6 @@ impl ClientInfoFacebook {
     }
 
     // optional string machine_id = 1;
-
 
     pub fn get_machine_id(&self) -> &str {
         match self.machine_id.as_ref() {
@@ -3428,7 +3829,9 @@ impl ClientInfoFacebook {
 
     // Take field
     pub fn take_machine_id(&mut self) -> ::std::string::String {
-        self.machine_id.take().unwrap_or_else(|| ::std::string::String::new())
+        self.machine_id
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -3437,16 +3840,24 @@ impl ::protobuf::Message for ClientInfoFacebook {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.machine_id)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3464,7 +3875,10 @@ impl ::protobuf::Message for ClientInfoFacebook {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.machine_id.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -3503,22 +3917,28 @@ impl ::protobuf::Message for ClientInfoFacebook {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "machine_id",
-                    |m: &ClientInfoFacebook| { &m.machine_id },
-                    |m: &mut ClientInfoFacebook| { &mut m.machine_id },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "machine_id",
+                        |m: &ClientInfoFacebook| &m.machine_id,
+                        |m: &mut ClientInfoFacebook| &mut m.machine_id,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ClientInfoFacebook>(
                     "ClientInfoFacebook",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3529,9 +3949,7 @@ impl ::protobuf::Message for ClientInfoFacebook {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ClientInfoFacebook,
         };
-        unsafe {
-            instance.get(ClientInfoFacebook::new)
-        }
+        unsafe { instance.get(ClientInfoFacebook::new) }
     }
 }
 
@@ -3554,7 +3972,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientInfoFacebook {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct APWelcome {
     // message fields
     canonical_username: ::protobuf::SingularField<::std::string::String>,
@@ -3582,7 +4000,6 @@ impl APWelcome {
     }
 
     // required string canonical_username = 10;
-
 
     pub fn get_canonical_username(&self) -> &str {
         match self.canonical_username.as_ref() {
@@ -3614,11 +4031,12 @@ impl APWelcome {
 
     // Take field
     pub fn take_canonical_username(&mut self) -> ::std::string::String {
-        self.canonical_username.take().unwrap_or_else(|| ::std::string::String::new())
+        self.canonical_username
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // required .AccountType account_type_logged_in = 20;
-
 
     pub fn get_account_type_logged_in(&self) -> AccountType {
         self.account_type_logged_in.unwrap_or(AccountType::Spotify)
@@ -3638,9 +4056,9 @@ impl APWelcome {
 
     // required .AccountType credentials_type_logged_in = 25;
 
-
     pub fn get_credentials_type_logged_in(&self) -> AccountType {
-        self.credentials_type_logged_in.unwrap_or(AccountType::Spotify)
+        self.credentials_type_logged_in
+            .unwrap_or(AccountType::Spotify)
     }
     pub fn clear_credentials_type_logged_in(&mut self) {
         self.credentials_type_logged_in = ::std::option::Option::None;
@@ -3657,9 +4075,9 @@ impl APWelcome {
 
     // required .AuthenticationType reusable_auth_credentials_type = 30;
 
-
     pub fn get_reusable_auth_credentials_type(&self) -> AuthenticationType {
-        self.reusable_auth_credentials_type.unwrap_or(AuthenticationType::AUTHENTICATION_USER_PASS)
+        self.reusable_auth_credentials_type
+            .unwrap_or(AuthenticationType::AUTHENTICATION_USER_PASS)
     }
     pub fn clear_reusable_auth_credentials_type(&mut self) {
         self.reusable_auth_credentials_type = ::std::option::Option::None;
@@ -3675,7 +4093,6 @@ impl APWelcome {
     }
 
     // required bytes reusable_auth_credentials = 40;
-
 
     pub fn get_reusable_auth_credentials(&self) -> &[u8] {
         match self.reusable_auth_credentials.as_ref() {
@@ -3707,11 +4124,12 @@ impl APWelcome {
 
     // Take field
     pub fn take_reusable_auth_credentials(&mut self) -> ::std::vec::Vec<u8> {
-        self.reusable_auth_credentials.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.reusable_auth_credentials
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional bytes lfs_secret = 50;
-
 
     pub fn get_lfs_secret(&self) -> &[u8] {
         match self.lfs_secret.as_ref() {
@@ -3743,14 +4161,17 @@ impl APWelcome {
 
     // Take field
     pub fn take_lfs_secret(&mut self) -> ::std::vec::Vec<u8> {
-        self.lfs_secret.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.lfs_secret
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional .AccountInfo account_info = 60;
 
-
     pub fn get_account_info(&self) -> &AccountInfo {
-        self.account_info.as_ref().unwrap_or_else(|| AccountInfo::default_instance())
+        self.account_info
+            .as_ref()
+            .unwrap_or_else(|| AccountInfo::default_instance())
     }
     pub fn clear_account_info(&mut self) {
         self.account_info.clear();
@@ -3776,14 +4197,17 @@ impl APWelcome {
 
     // Take field
     pub fn take_account_info(&mut self) -> AccountInfo {
-        self.account_info.take().unwrap_or_else(|| AccountInfo::new())
+        self.account_info
+            .take()
+            .unwrap_or_else(|| AccountInfo::new())
     }
 
     // optional .AccountInfoFacebook fb = 70;
 
-
     pub fn get_fb(&self) -> &AccountInfoFacebook {
-        self.fb.as_ref().unwrap_or_else(|| AccountInfoFacebook::default_instance())
+        self.fb
+            .as_ref()
+            .unwrap_or_else(|| AccountInfoFacebook::default_instance())
     }
     pub fn clear_fb(&mut self) {
         self.fb.clear();
@@ -3834,46 +4258,78 @@ impl ::protobuf::Message for APWelcome {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.fb {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.canonical_username)?;
-                },
-                20 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.account_type_logged_in, 20, &mut self.unknown_fields)?
-                },
-                25 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.credentials_type_logged_in, 25, &mut self.unknown_fields)?
-                },
-                30 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.reusable_auth_credentials_type, 30, &mut self.unknown_fields)?
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.canonical_username,
+                    )?;
+                }
+                20 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.account_type_logged_in,
+                    20,
+                    &mut self.unknown_fields,
+                )?,
+                25 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.credentials_type_logged_in,
+                    25,
+                    &mut self.unknown_fields,
+                )?,
+                30 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.reusable_auth_credentials_type,
+                    30,
+                    &mut self.unknown_fields,
+                )?,
                 40 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.reusable_auth_credentials)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.reusable_auth_credentials,
+                    )?;
+                }
                 50 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.lfs_secret)?;
-                },
+                }
                 60 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.account_info)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.account_info,
+                    )?;
+                }
                 70 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.fb)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3914,7 +4370,10 @@ impl ::protobuf::Message for APWelcome {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.canonical_username.as_ref() {
             os.write_string(10, &v)?;
         }
@@ -3978,57 +4437,90 @@ impl ::protobuf::Message for APWelcome {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "canonical_username",
-                    |m: &APWelcome| { &m.canonical_username },
-                    |m: &mut APWelcome| { &mut m.canonical_username },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<AccountType>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "canonical_username",
+                        |m: &APWelcome| &m.canonical_username,
+                        |m: &mut APWelcome| &mut m.canonical_username,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<AccountType>,
+                >(
                     "account_type_logged_in",
-                    |m: &APWelcome| { &m.account_type_logged_in },
-                    |m: &mut APWelcome| { &mut m.account_type_logged_in },
+                    |m: &APWelcome| &m.account_type_logged_in,
+                    |m: &mut APWelcome| &mut m.account_type_logged_in,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<AccountType>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<AccountType>,
+                >(
                     "credentials_type_logged_in",
-                    |m: &APWelcome| { &m.credentials_type_logged_in },
-                    |m: &mut APWelcome| { &mut m.credentials_type_logged_in },
+                    |m: &APWelcome| &m.credentials_type_logged_in,
+                    |m: &mut APWelcome| &mut m.credentials_type_logged_in,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<AuthenticationType>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<AuthenticationType>,
+                >(
                     "reusable_auth_credentials_type",
-                    |m: &APWelcome| { &m.reusable_auth_credentials_type },
-                    |m: &mut APWelcome| { &mut m.reusable_auth_credentials_type },
+                    |m: &APWelcome| &m.reusable_auth_credentials_type,
+                    |m: &mut APWelcome| &mut m.reusable_auth_credentials_type,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "reusable_auth_credentials",
-                    |m: &APWelcome| { &m.reusable_auth_credentials },
-                    |m: &mut APWelcome| { &mut m.reusable_auth_credentials },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "lfs_secret",
-                    |m: &APWelcome| { &m.lfs_secret },
-                    |m: &mut APWelcome| { &mut m.lfs_secret },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AccountInfo>>(
-                    "account_info",
-                    |m: &APWelcome| { &m.account_info },
-                    |m: &mut APWelcome| { &mut m.account_info },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AccountInfoFacebook>>(
-                    "fb",
-                    |m: &APWelcome| { &m.fb },
-                    |m: &mut APWelcome| { &mut m.fb },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "reusable_auth_credentials",
+                        |m: &APWelcome| &m.reusable_auth_credentials,
+                        |m: &mut APWelcome| &mut m.reusable_auth_credentials,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "lfs_secret",
+                        |m: &APWelcome| &m.lfs_secret,
+                        |m: &mut APWelcome| &mut m.lfs_secret,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AccountInfo>,
+                    >(
+                        "account_info",
+                        |m: &APWelcome| &m.account_info,
+                        |m: &mut APWelcome| &mut m.account_info,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AccountInfoFacebook>,
+                    >(
+                        "fb", |m: &APWelcome| &m.fb, |m: &mut APWelcome| &mut m.fb
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<APWelcome>(
                     "APWelcome",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -4039,9 +4531,7 @@ impl ::protobuf::Message for APWelcome {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const APWelcome,
         };
-        unsafe {
-            instance.get(APWelcome::new)
-        }
+        unsafe { instance.get(APWelcome::new) }
     }
 }
 
@@ -4071,7 +4561,7 @@ impl ::protobuf::reflect::ProtobufValue for APWelcome {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct AccountInfo {
     // message fields
     spotify: ::protobuf::SingularPtrField<AccountInfoSpotify>,
@@ -4094,9 +4584,10 @@ impl AccountInfo {
 
     // optional .AccountInfoSpotify spotify = 1;
 
-
     pub fn get_spotify(&self) -> &AccountInfoSpotify {
-        self.spotify.as_ref().unwrap_or_else(|| AccountInfoSpotify::default_instance())
+        self.spotify
+            .as_ref()
+            .unwrap_or_else(|| AccountInfoSpotify::default_instance())
     }
     pub fn clear_spotify(&mut self) {
         self.spotify.clear();
@@ -4122,14 +4613,17 @@ impl AccountInfo {
 
     // Take field
     pub fn take_spotify(&mut self) -> AccountInfoSpotify {
-        self.spotify.take().unwrap_or_else(|| AccountInfoSpotify::new())
+        self.spotify
+            .take()
+            .unwrap_or_else(|| AccountInfoSpotify::new())
     }
 
     // optional .AccountInfoFacebook facebook = 2;
 
-
     pub fn get_facebook(&self) -> &AccountInfoFacebook {
-        self.facebook.as_ref().unwrap_or_else(|| AccountInfoFacebook::default_instance())
+        self.facebook
+            .as_ref()
+            .unwrap_or_else(|| AccountInfoFacebook::default_instance())
     }
     pub fn clear_facebook(&mut self) {
         self.facebook.clear();
@@ -4155,7 +4649,9 @@ impl AccountInfo {
 
     // Take field
     pub fn take_facebook(&mut self) -> AccountInfoFacebook {
-        self.facebook.take().unwrap_or_else(|| AccountInfoFacebook::new())
+        self.facebook
+            .take()
+            .unwrap_or_else(|| AccountInfoFacebook::new())
     }
 }
 
@@ -4165,28 +4661,36 @@ impl ::protobuf::Message for AccountInfo {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.facebook {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.spotify)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.facebook)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4209,7 +4713,10 @@ impl ::protobuf::Message for AccountInfo {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.spotify.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -4255,27 +4762,38 @@ impl ::protobuf::Message for AccountInfo {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AccountInfoSpotify>>(
-                    "spotify",
-                    |m: &AccountInfo| { &m.spotify },
-                    |m: &mut AccountInfo| { &mut m.spotify },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AccountInfoFacebook>>(
-                    "facebook",
-                    |m: &AccountInfo| { &m.facebook },
-                    |m: &mut AccountInfo| { &mut m.facebook },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AccountInfoSpotify>,
+                    >(
+                        "spotify",
+                        |m: &AccountInfo| &m.spotify,
+                        |m: &mut AccountInfo| &mut m.spotify,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AccountInfoFacebook>,
+                    >(
+                        "facebook",
+                        |m: &AccountInfo| &m.facebook,
+                        |m: &mut AccountInfo| &mut m.facebook,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<AccountInfo>(
                     "AccountInfo",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -4286,9 +4804,7 @@ impl ::protobuf::Message for AccountInfo {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const AccountInfo,
         };
-        unsafe {
-            instance.get(AccountInfo::new)
-        }
+        unsafe { instance.get(AccountInfo::new) }
     }
 }
 
@@ -4312,7 +4828,7 @@ impl ::protobuf::reflect::ProtobufValue for AccountInfo {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct AccountInfoSpotify {
     // special fields
     pub unknown_fields: ::protobuf::UnknownFields,
@@ -4336,13 +4852,21 @@ impl ::protobuf::Message for AccountInfoSpotify {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4357,7 +4881,10 @@ impl ::protobuf::Message for AccountInfoSpotify {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -4393,17 +4920,18 @@ impl ::protobuf::Message for AccountInfoSpotify {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let fields = ::std::vec::Vec::new();
                 ::protobuf::reflect::MessageDescriptor::new::<AccountInfoSpotify>(
                     "AccountInfoSpotify",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -4414,9 +4942,7 @@ impl ::protobuf::Message for AccountInfoSpotify {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const AccountInfoSpotify,
         };
-        unsafe {
-            instance.get(AccountInfoSpotify::new)
-        }
+        unsafe { instance.get(AccountInfoSpotify::new) }
     }
 }
 
@@ -4438,7 +4964,7 @@ impl ::protobuf::reflect::ProtobufValue for AccountInfoSpotify {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct AccountInfoFacebook {
     // message fields
     access_token: ::protobuf::SingularField<::std::string::String>,
@@ -4460,7 +4986,6 @@ impl AccountInfoFacebook {
     }
 
     // optional string access_token = 1;
-
 
     pub fn get_access_token(&self) -> &str {
         match self.access_token.as_ref() {
@@ -4492,11 +5017,12 @@ impl AccountInfoFacebook {
 
     // Take field
     pub fn take_access_token(&mut self) -> ::std::string::String {
-        self.access_token.take().unwrap_or_else(|| ::std::string::String::new())
+        self.access_token
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string machine_id = 2;
-
 
     pub fn get_machine_id(&self) -> &str {
         match self.machine_id.as_ref() {
@@ -4528,7 +5054,9 @@ impl AccountInfoFacebook {
 
     // Take field
     pub fn take_machine_id(&mut self) -> ::std::string::String {
-        self.machine_id.take().unwrap_or_else(|| ::std::string::String::new())
+        self.machine_id
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -4537,19 +5065,31 @@ impl ::protobuf::Message for AccountInfoFacebook {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.access_token)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.access_token,
+                    )?;
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.machine_id)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4570,7 +5110,10 @@ impl ::protobuf::Message for AccountInfoFacebook {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.access_token.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -4612,27 +5155,38 @@ impl ::protobuf::Message for AccountInfoFacebook {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "access_token",
-                    |m: &AccountInfoFacebook| { &m.access_token },
-                    |m: &mut AccountInfoFacebook| { &mut m.access_token },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "machine_id",
-                    |m: &AccountInfoFacebook| { &m.machine_id },
-                    |m: &mut AccountInfoFacebook| { &mut m.machine_id },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "access_token",
+                        |m: &AccountInfoFacebook| &m.access_token,
+                        |m: &mut AccountInfoFacebook| &mut m.access_token,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "machine_id",
+                        |m: &AccountInfoFacebook| &m.machine_id,
+                        |m: &mut AccountInfoFacebook| &mut m.machine_id,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<AccountInfoFacebook>(
                     "AccountInfoFacebook",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -4643,9 +5197,7 @@ impl ::protobuf::Message for AccountInfoFacebook {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const AccountInfoFacebook,
         };
-        unsafe {
-            instance.get(AccountInfoFacebook::new)
-        }
+        unsafe { instance.get(AccountInfoFacebook::new) }
     }
 }
 
@@ -4669,7 +5221,7 @@ impl ::protobuf::reflect::ProtobufValue for AccountInfoFacebook {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum AuthenticationType {
     AUTHENTICATION_USER_PASS = 0,
     AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS = 1,
@@ -4686,11 +5238,15 @@ impl ::protobuf::ProtobufEnum for AuthenticationType {
     fn from_i32(value: i32) -> ::std::option::Option<AuthenticationType> {
         match value {
             0 => ::std::option::Option::Some(AuthenticationType::AUTHENTICATION_USER_PASS),
-            1 => ::std::option::Option::Some(AuthenticationType::AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS),
-            2 => ::std::option::Option::Some(AuthenticationType::AUTHENTICATION_STORED_FACEBOOK_CREDENTIALS),
+            1 => ::std::option::Option::Some(
+                AuthenticationType::AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS,
+            ),
+            2 => ::std::option::Option::Some(
+                AuthenticationType::AUTHENTICATION_STORED_FACEBOOK_CREDENTIALS,
+            ),
             3 => ::std::option::Option::Some(AuthenticationType::AUTHENTICATION_SPOTIFY_TOKEN),
             4 => ::std::option::Option::Some(AuthenticationType::AUTHENTICATION_FACEBOOK_TOKEN),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -4706,20 +5262,23 @@ impl ::protobuf::ProtobufEnum for AuthenticationType {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("AuthenticationType", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "AuthenticationType",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for AuthenticationType {
-}
+impl ::std::marker::Copy for AuthenticationType {}
 
 impl ::std::default::Default for AuthenticationType {
     fn default() -> Self {
@@ -4733,7 +5292,7 @@ impl ::protobuf::reflect::ProtobufValue for AuthenticationType {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum AccountCreation {
     ACCOUNT_CREATION_ALWAYS_PROMPT = 1,
     ACCOUNT_CREATION_ALWAYS_CREATE = 3,
@@ -4748,7 +5307,7 @@ impl ::protobuf::ProtobufEnum for AccountCreation {
         match value {
             1 => ::std::option::Option::Some(AccountCreation::ACCOUNT_CREATION_ALWAYS_PROMPT),
             3 => ::std::option::Option::Some(AccountCreation::ACCOUNT_CREATION_ALWAYS_CREATE),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -4761,10 +5320,11 @@ impl ::protobuf::ProtobufEnum for AccountCreation {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("AccountCreation", file_descriptor_proto())
@@ -4773,8 +5333,7 @@ impl ::protobuf::ProtobufEnum for AccountCreation {
     }
 }
 
-impl ::std::marker::Copy for AccountCreation {
-}
+impl ::std::marker::Copy for AccountCreation {}
 
 // Note, `Default` is implemented although default value is not 0
 impl ::std::default::Default for AccountCreation {
@@ -4789,7 +5348,7 @@ impl ::protobuf::reflect::ProtobufValue for AccountCreation {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum CpuFamily {
     CPU_UNKNOWN = 0,
     CPU_X86 = 1,
@@ -4820,7 +5379,7 @@ impl ::protobuf::ProtobufEnum for CpuFamily {
             7 => ::std::option::Option::Some(CpuFamily::CPU_SH),
             8 => ::std::option::Option::Some(CpuFamily::CPU_MIPS),
             9 => ::std::option::Option::Some(CpuFamily::CPU_BLACKFIN),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -4841,10 +5400,11 @@ impl ::protobuf::ProtobufEnum for CpuFamily {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("CpuFamily", file_descriptor_proto())
@@ -4853,8 +5413,7 @@ impl ::protobuf::ProtobufEnum for CpuFamily {
     }
 }
 
-impl ::std::marker::Copy for CpuFamily {
-}
+impl ::std::marker::Copy for CpuFamily {}
 
 impl ::std::default::Default for CpuFamily {
     fn default() -> Self {
@@ -4868,7 +5427,7 @@ impl ::protobuf::reflect::ProtobufValue for CpuFamily {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Brand {
     BRAND_UNBRANDED = 0,
     BRAND_INQ = 1,
@@ -4887,7 +5446,7 @@ impl ::protobuf::ProtobufEnum for Brand {
             1 => ::std::option::Option::Some(Brand::BRAND_INQ),
             2 => ::std::option::Option::Some(Brand::BRAND_HTC),
             3 => ::std::option::Option::Some(Brand::BRAND_NOKIA),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -4902,20 +5461,19 @@ impl ::protobuf::ProtobufEnum for Brand {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
-            descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("Brand", file_descriptor_proto())
-            })
+            descriptor
+                .get(|| ::protobuf::reflect::EnumDescriptor::new("Brand", file_descriptor_proto()))
         }
     }
 }
 
-impl ::std::marker::Copy for Brand {
-}
+impl ::std::marker::Copy for Brand {}
 
 impl ::std::default::Default for Brand {
     fn default() -> Self {
@@ -4929,7 +5487,7 @@ impl ::protobuf::reflect::ProtobufValue for Brand {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Os {
     OS_UNKNOWN = 0,
     OS_WINDOWS = 1,
@@ -4986,7 +5544,7 @@ impl ::protobuf::ProtobufEnum for Os {
             20 => ::std::option::Option::Some(Os::OS_MEEGO),
             21 => ::std::option::Option::Some(Os::OS_QNXNTO),
             22 => ::std::option::Option::Some(Os::OS_BCO),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -5020,20 +5578,19 @@ impl ::protobuf::ProtobufEnum for Os {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
-            descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("Os", file_descriptor_proto())
-            })
+            descriptor
+                .get(|| ::protobuf::reflect::EnumDescriptor::new("Os", file_descriptor_proto()))
         }
     }
 }
 
-impl ::std::marker::Copy for Os {
-}
+impl ::std::marker::Copy for Os {}
 
 impl ::std::default::Default for Os {
     fn default() -> Self {
@@ -5047,7 +5604,7 @@ impl ::protobuf::reflect::ProtobufValue for Os {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum AccountType {
     Spotify = 0,
     Facebook = 1,
@@ -5062,23 +5619,21 @@ impl ::protobuf::ProtobufEnum for AccountType {
         match value {
             0 => ::std::option::Option::Some(AccountType::Spotify),
             1 => ::std::option::Option::Some(AccountType::Facebook),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
     fn values() -> &'static [Self] {
-        static values: &'static [AccountType] = &[
-            AccountType::Spotify,
-            AccountType::Facebook,
-        ];
+        static values: &'static [AccountType] = &[AccountType::Spotify, AccountType::Facebook];
         values
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("AccountType", file_descriptor_proto())
@@ -5087,8 +5642,7 @@ impl ::protobuf::ProtobufEnum for AccountType {
     }
 }
 
-impl ::std::marker::Copy for AccountType {
-}
+impl ::std::marker::Copy for AccountType {}
 
 impl ::std::default::Default for AccountType {
     fn default() -> Self {
@@ -5176,7 +5730,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x10\0\x12\x0c\n\x08Facebook\x10\x01\x1a\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -5186,9 +5742,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/keyexchange.rs
+++ b/protocol/src/keyexchange.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ClientHello {
     // message fields
     build_info: ::protobuf::SingularPtrField<BuildInfo>,
@@ -55,9 +55,10 @@ impl ClientHello {
 
     // required .BuildInfo build_info = 10;
 
-
     pub fn get_build_info(&self) -> &BuildInfo {
-        self.build_info.as_ref().unwrap_or_else(|| BuildInfo::default_instance())
+        self.build_info
+            .as_ref()
+            .unwrap_or_else(|| BuildInfo::default_instance())
     }
     pub fn clear_build_info(&mut self) {
         self.build_info.clear();
@@ -88,7 +89,6 @@ impl ClientHello {
 
     // repeated .Fingerprint fingerprints_supported = 20;
 
-
     pub fn get_fingerprints_supported(&self) -> &[Fingerprint] {
         &self.fingerprints_supported
     }
@@ -112,7 +112,6 @@ impl ClientHello {
     }
 
     // repeated .Cryptosuite cryptosuites_supported = 30;
-
 
     pub fn get_cryptosuites_supported(&self) -> &[Cryptosuite] {
         &self.cryptosuites_supported
@@ -138,7 +137,6 @@ impl ClientHello {
 
     // repeated .Powscheme powschemes_supported = 40;
 
-
     pub fn get_powschemes_supported(&self) -> &[Powscheme] {
         &self.powschemes_supported
     }
@@ -163,9 +161,10 @@ impl ClientHello {
 
     // required .LoginCryptoHelloUnion login_crypto_hello = 50;
 
-
     pub fn get_login_crypto_hello(&self) -> &LoginCryptoHelloUnion {
-        self.login_crypto_hello.as_ref().unwrap_or_else(|| LoginCryptoHelloUnion::default_instance())
+        self.login_crypto_hello
+            .as_ref()
+            .unwrap_or_else(|| LoginCryptoHelloUnion::default_instance())
     }
     pub fn clear_login_crypto_hello(&mut self) {
         self.login_crypto_hello.clear();
@@ -191,11 +190,12 @@ impl ClientHello {
 
     // Take field
     pub fn take_login_crypto_hello(&mut self) -> LoginCryptoHelloUnion {
-        self.login_crypto_hello.take().unwrap_or_else(|| LoginCryptoHelloUnion::new())
+        self.login_crypto_hello
+            .take()
+            .unwrap_or_else(|| LoginCryptoHelloUnion::new())
     }
 
     // required bytes client_nonce = 60;
-
 
     pub fn get_client_nonce(&self) -> &[u8] {
         match self.client_nonce.as_ref() {
@@ -227,11 +227,12 @@ impl ClientHello {
 
     // Take field
     pub fn take_client_nonce(&mut self) -> ::std::vec::Vec<u8> {
-        self.client_nonce.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.client_nonce
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional bytes padding = 70;
-
 
     pub fn get_padding(&self) -> &[u8] {
         match self.padding.as_ref() {
@@ -263,14 +264,17 @@ impl ClientHello {
 
     // Take field
     pub fn take_padding(&mut self) -> ::std::vec::Vec<u8> {
-        self.padding.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.padding
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional .FeatureSet feature_set = 80;
 
-
     pub fn get_feature_set(&self) -> &FeatureSet {
-        self.feature_set.as_ref().unwrap_or_else(|| FeatureSet::default_instance())
+        self.feature_set
+            .as_ref()
+            .unwrap_or_else(|| FeatureSet::default_instance())
     }
     pub fn clear_feature_set(&mut self) {
         self.feature_set.clear();
@@ -315,51 +319,87 @@ impl ::protobuf::Message for ClientHello {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.login_crypto_hello {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.feature_set {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.build_info)?;
-                },
-                20 => {
-                    ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(wire_type, is, &mut self.fingerprints_supported, 20, &mut self.unknown_fields)?
-                },
-                30 => {
-                    ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(wire_type, is, &mut self.cryptosuites_supported, 30, &mut self.unknown_fields)?
-                },
-                40 => {
-                    ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(wire_type, is, &mut self.powschemes_supported, 40, &mut self.unknown_fields)?
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.build_info,
+                    )?;
+                }
+                20 => ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.fingerprints_supported,
+                    20,
+                    &mut self.unknown_fields,
+                )?,
+                30 => ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.cryptosuites_supported,
+                    30,
+                    &mut self.unknown_fields,
+                )?,
+                40 => ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.powschemes_supported,
+                    40,
+                    &mut self.unknown_fields,
+                )?,
                 50 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.login_crypto_hello)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.login_crypto_hello,
+                    )?;
+                }
                 60 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.client_nonce)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.client_nonce,
+                    )?;
+                }
                 70 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.padding)?;
-                },
+                }
                 80 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.feature_set)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.feature_set,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -375,13 +415,13 @@ impl ::protobuf::Message for ClientHello {
         }
         for value in &self.fingerprints_supported {
             my_size += ::protobuf::rt::enum_size(20, *value);
-        };
+        }
         for value in &self.cryptosuites_supported {
             my_size += ::protobuf::rt::enum_size(30, *value);
-        };
+        }
         for value in &self.powschemes_supported {
             my_size += ::protobuf::rt::enum_size(40, *value);
-        };
+        }
         if let Some(ref v) = self.login_crypto_hello.as_ref() {
             let len = v.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -401,7 +441,10 @@ impl ::protobuf::Message for ClientHello {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.build_info.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -409,13 +452,13 @@ impl ::protobuf::Message for ClientHello {
         }
         for v in &self.fingerprints_supported {
             os.write_enum(20, v.value())?;
-        };
+        }
         for v in &self.cryptosuites_supported {
             os.write_enum(30, v.value())?;
-        };
+        }
         for v in &self.powschemes_supported {
             os.write_enum(40, v.value())?;
-        };
+        }
         if let Some(ref v) = self.login_crypto_hello.as_ref() {
             os.write_tag(50, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -467,57 +510,92 @@ impl ::protobuf::Message for ClientHello {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<BuildInfo>>(
-                    "build_info",
-                    |m: &ClientHello| { &m.build_info },
-                    |m: &mut ClientHello| { &mut m.build_info },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Fingerprint>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<BuildInfo>,
+                    >(
+                        "build_info",
+                        |m: &ClientHello| &m.build_info,
+                        |m: &mut ClientHello| &mut m.build_info,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Fingerprint>,
+                >(
                     "fingerprints_supported",
-                    |m: &ClientHello| { &m.fingerprints_supported },
-                    |m: &mut ClientHello| { &mut m.fingerprints_supported },
+                    |m: &ClientHello| &m.fingerprints_supported,
+                    |m: &mut ClientHello| &mut m.fingerprints_supported,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Cryptosuite>>(
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Cryptosuite>,
+                >(
                     "cryptosuites_supported",
-                    |m: &ClientHello| { &m.cryptosuites_supported },
-                    |m: &mut ClientHello| { &mut m.cryptosuites_supported },
+                    |m: &ClientHello| &m.cryptosuites_supported,
+                    |m: &mut ClientHello| &mut m.cryptosuites_supported,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Powscheme>>(
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Powscheme>,
+                >(
                     "powschemes_supported",
-                    |m: &ClientHello| { &m.powschemes_supported },
-                    |m: &mut ClientHello| { &mut m.powschemes_supported },
+                    |m: &ClientHello| &m.powschemes_supported,
+                    |m: &mut ClientHello| &mut m.powschemes_supported,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<LoginCryptoHelloUnion>>(
-                    "login_crypto_hello",
-                    |m: &ClientHello| { &m.login_crypto_hello },
-                    |m: &mut ClientHello| { &mut m.login_crypto_hello },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "client_nonce",
-                    |m: &ClientHello| { &m.client_nonce },
-                    |m: &mut ClientHello| { &mut m.client_nonce },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "padding",
-                    |m: &ClientHello| { &m.padding },
-                    |m: &mut ClientHello| { &mut m.padding },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<FeatureSet>>(
-                    "feature_set",
-                    |m: &ClientHello| { &m.feature_set },
-                    |m: &mut ClientHello| { &mut m.feature_set },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<LoginCryptoHelloUnion>,
+                    >(
+                        "login_crypto_hello",
+                        |m: &ClientHello| &m.login_crypto_hello,
+                        |m: &mut ClientHello| &mut m.login_crypto_hello,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "client_nonce",
+                        |m: &ClientHello| &m.client_nonce,
+                        |m: &mut ClientHello| &mut m.client_nonce,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "padding",
+                        |m: &ClientHello| &m.padding,
+                        |m: &mut ClientHello| &mut m.padding,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<FeatureSet>,
+                    >(
+                        "feature_set",
+                        |m: &ClientHello| &m.feature_set,
+                        |m: &mut ClientHello| &mut m.feature_set,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ClientHello>(
                     "ClientHello",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -528,9 +606,7 @@ impl ::protobuf::Message for ClientHello {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ClientHello,
         };
-        unsafe {
-            instance.get(ClientHello::new)
-        }
+        unsafe { instance.get(ClientHello::new) }
     }
 }
 
@@ -560,7 +636,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientHello {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct BuildInfo {
     // message fields
     product: ::std::option::Option<Product>,
@@ -585,7 +661,6 @@ impl BuildInfo {
 
     // required .Product product = 10;
 
-
     pub fn get_product(&self) -> Product {
         self.product.unwrap_or(Product::PRODUCT_CLIENT)
     }
@@ -603,7 +678,6 @@ impl BuildInfo {
     }
 
     // repeated .ProductFlags product_flags = 20;
-
 
     pub fn get_product_flags(&self) -> &[ProductFlags] {
         &self.product_flags
@@ -629,7 +703,6 @@ impl BuildInfo {
 
     // required .Platform platform = 30;
 
-
     pub fn get_platform(&self) -> Platform {
         self.platform.unwrap_or(Platform::PLATFORM_WIN32_X86)
     }
@@ -647,7 +720,6 @@ impl BuildInfo {
     }
 
     // required uint64 version = 40;
-
 
     pub fn get_version(&self) -> u64 {
         self.version.unwrap_or(0)
@@ -680,29 +752,51 @@ impl ::protobuf::Message for BuildInfo {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                10 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.product, 10, &mut self.unknown_fields)?
-                },
-                20 => {
-                    ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(wire_type, is, &mut self.product_flags, 20, &mut self.unknown_fields)?
-                },
-                30 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.platform, 30, &mut self.unknown_fields)?
-                },
+                10 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.product,
+                    10,
+                    &mut self.unknown_fields,
+                )?,
+                20 => ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.product_flags,
+                    20,
+                    &mut self.unknown_fields,
+                )?,
+                30 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.platform,
+                    30,
+                    &mut self.unknown_fields,
+                )?,
                 40 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint64()?;
                     self.version = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -717,7 +811,7 @@ impl ::protobuf::Message for BuildInfo {
         }
         for value in &self.product_flags {
             my_size += ::protobuf::rt::enum_size(20, *value);
-        };
+        }
         if let Some(v) = self.platform {
             my_size += ::protobuf::rt::enum_size(30, v);
         }
@@ -729,13 +823,16 @@ impl ::protobuf::Message for BuildInfo {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.product {
             os.write_enum(10, v.value())?;
         }
         for v in &self.product_flags {
             os.write_enum(20, v.value())?;
-        };
+        }
         if let Some(v) = self.platform {
             os.write_enum(30, v.value())?;
         }
@@ -777,37 +874,50 @@ impl ::protobuf::Message for BuildInfo {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Product>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Product>,
+                >(
                     "product",
-                    |m: &BuildInfo| { &m.product },
-                    |m: &mut BuildInfo| { &mut m.product },
+                    |m: &BuildInfo| &m.product,
+                    |m: &mut BuildInfo| &mut m.product,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ProductFlags>>(
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<ProductFlags>,
+                >(
                     "product_flags",
-                    |m: &BuildInfo| { &m.product_flags },
-                    |m: &mut BuildInfo| { &mut m.product_flags },
+                    |m: &BuildInfo| &m.product_flags,
+                    |m: &mut BuildInfo| &mut m.product_flags,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Platform>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Platform>,
+                >(
                     "platform",
-                    |m: &BuildInfo| { &m.platform },
-                    |m: &mut BuildInfo| { &mut m.platform },
+                    |m: &BuildInfo| &m.platform,
+                    |m: &mut BuildInfo| &mut m.platform,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint64,
+                >(
                     "version",
-                    |m: &BuildInfo| { &m.version },
-                    |m: &mut BuildInfo| { &mut m.version },
+                    |m: &BuildInfo| &m.version,
+                    |m: &mut BuildInfo| &mut m.version,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<BuildInfo>(
                     "BuildInfo",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -818,9 +928,7 @@ impl ::protobuf::Message for BuildInfo {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const BuildInfo,
         };
-        unsafe {
-            instance.get(BuildInfo::new)
-        }
+        unsafe { instance.get(BuildInfo::new) }
     }
 }
 
@@ -846,7 +954,7 @@ impl ::protobuf::reflect::ProtobufValue for BuildInfo {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct LoginCryptoHelloUnion {
     // message fields
     diffie_hellman: ::protobuf::SingularPtrField<LoginCryptoDiffieHellmanHello>,
@@ -868,9 +976,10 @@ impl LoginCryptoHelloUnion {
 
     // optional .LoginCryptoDiffieHellmanHello diffie_hellman = 10;
 
-
     pub fn get_diffie_hellman(&self) -> &LoginCryptoDiffieHellmanHello {
-        self.diffie_hellman.as_ref().unwrap_or_else(|| LoginCryptoDiffieHellmanHello::default_instance())
+        self.diffie_hellman
+            .as_ref()
+            .unwrap_or_else(|| LoginCryptoDiffieHellmanHello::default_instance())
     }
     pub fn clear_diffie_hellman(&mut self) {
         self.diffie_hellman.clear();
@@ -896,7 +1005,9 @@ impl LoginCryptoHelloUnion {
 
     // Take field
     pub fn take_diffie_hellman(&mut self) -> LoginCryptoDiffieHellmanHello {
-        self.diffie_hellman.take().unwrap_or_else(|| LoginCryptoDiffieHellmanHello::new())
+        self.diffie_hellman
+            .take()
+            .unwrap_or_else(|| LoginCryptoDiffieHellmanHello::new())
     }
 }
 
@@ -906,20 +1017,32 @@ impl ::protobuf::Message for LoginCryptoHelloUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.diffie_hellman)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.diffie_hellman,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -938,7 +1061,10 @@ impl ::protobuf::Message for LoginCryptoHelloUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.diffie_hellman.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -979,35 +1105,40 @@ impl ::protobuf::Message for LoginCryptoHelloUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<LoginCryptoDiffieHellmanHello>>(
-                    "diffie_hellman",
-                    |m: &LoginCryptoHelloUnion| { &m.diffie_hellman },
-                    |m: &mut LoginCryptoHelloUnion| { &mut m.diffie_hellman },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<LoginCryptoDiffieHellmanHello>,
+                    >(
+                        "diffie_hellman",
+                        |m: &LoginCryptoHelloUnion| &m.diffie_hellman,
+                        |m: &mut LoginCryptoHelloUnion| &mut m.diffie_hellman,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<LoginCryptoHelloUnion>(
                     "LoginCryptoHelloUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static LoginCryptoHelloUnion {
-        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoHelloUnion> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const LoginCryptoHelloUnion,
-        };
-        unsafe {
-            instance.get(LoginCryptoHelloUnion::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoHelloUnion> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const LoginCryptoHelloUnion,
+            };
+        unsafe { instance.get(LoginCryptoHelloUnion::new) }
     }
 }
 
@@ -1030,7 +1161,7 @@ impl ::protobuf::reflect::ProtobufValue for LoginCryptoHelloUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct LoginCryptoDiffieHellmanHello {
     // message fields
     gc: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -1052,7 +1183,6 @@ impl LoginCryptoDiffieHellmanHello {
     }
 
     // required bytes gc = 10;
-
 
     pub fn get_gc(&self) -> &[u8] {
         match self.gc.as_ref() {
@@ -1089,7 +1219,6 @@ impl LoginCryptoDiffieHellmanHello {
 
     // required uint32 server_keys_known = 20;
 
-
     pub fn get_server_keys_known(&self) -> u32 {
         self.server_keys_known.unwrap_or(0)
     }
@@ -1118,23 +1247,33 @@ impl ::protobuf::Message for LoginCryptoDiffieHellmanHello {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gc)?;
-                },
+                }
                 20 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.server_keys_known = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1155,7 +1294,10 @@ impl ::protobuf::Message for LoginCryptoDiffieHellmanHello {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.gc.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -1197,40 +1339,48 @@ impl ::protobuf::Message for LoginCryptoDiffieHellmanHello {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gc",
-                    |m: &LoginCryptoDiffieHellmanHello| { &m.gc },
-                    |m: &mut LoginCryptoDiffieHellmanHello| { &mut m.gc },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "gc",
+                        |m: &LoginCryptoDiffieHellmanHello| &m.gc,
+                        |m: &mut LoginCryptoDiffieHellmanHello| &mut m.gc,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "server_keys_known",
-                    |m: &LoginCryptoDiffieHellmanHello| { &m.server_keys_known },
-                    |m: &mut LoginCryptoDiffieHellmanHello| { &mut m.server_keys_known },
+                    |m: &LoginCryptoDiffieHellmanHello| &m.server_keys_known,
+                    |m: &mut LoginCryptoDiffieHellmanHello| &mut m.server_keys_known,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<LoginCryptoDiffieHellmanHello>(
                     "LoginCryptoDiffieHellmanHello",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static LoginCryptoDiffieHellmanHello {
-        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoDiffieHellmanHello> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const LoginCryptoDiffieHellmanHello,
-        };
-        unsafe {
-            instance.get(LoginCryptoDiffieHellmanHello::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoDiffieHellmanHello> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const LoginCryptoDiffieHellmanHello,
+            };
+        unsafe { instance.get(LoginCryptoDiffieHellmanHello::new) }
     }
 }
 
@@ -1254,7 +1404,7 @@ impl ::protobuf::reflect::ProtobufValue for LoginCryptoDiffieHellmanHello {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct FeatureSet {
     // message fields
     autoupdate2: ::std::option::Option<bool>,
@@ -1277,7 +1427,6 @@ impl FeatureSet {
 
     // optional bool autoupdate2 = 1;
 
-
     pub fn get_autoupdate2(&self) -> bool {
         self.autoupdate2.unwrap_or(false)
     }
@@ -1295,7 +1444,6 @@ impl FeatureSet {
     }
 
     // optional bool current_location = 2;
-
 
     pub fn get_current_location(&self) -> bool {
         self.current_location.unwrap_or(false)
@@ -1319,27 +1467,39 @@ impl ::protobuf::Message for FeatureSet {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.autoupdate2 = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.current_location = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1360,7 +1520,10 @@ impl ::protobuf::Message for FeatureSet {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.autoupdate2 {
             os.write_bool(1, v)?;
         }
@@ -1402,27 +1565,34 @@ impl ::protobuf::Message for FeatureSet {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "autoupdate2",
-                    |m: &FeatureSet| { &m.autoupdate2 },
-                    |m: &mut FeatureSet| { &mut m.autoupdate2 },
+                    |m: &FeatureSet| &m.autoupdate2,
+                    |m: &mut FeatureSet| &mut m.autoupdate2,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "current_location",
-                    |m: &FeatureSet| { &m.current_location },
-                    |m: &mut FeatureSet| { &mut m.current_location },
+                    |m: &FeatureSet| &m.current_location,
+                    |m: &mut FeatureSet| &mut m.current_location,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<FeatureSet>(
                     "FeatureSet",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1433,9 +1603,7 @@ impl ::protobuf::Message for FeatureSet {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const FeatureSet,
         };
-        unsafe {
-            instance.get(FeatureSet::new)
-        }
+        unsafe { instance.get(FeatureSet::new) }
     }
 }
 
@@ -1459,7 +1627,7 @@ impl ::protobuf::reflect::ProtobufValue for FeatureSet {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct APResponseMessage {
     // message fields
     challenge: ::protobuf::SingularPtrField<APChallenge>,
@@ -1483,9 +1651,10 @@ impl APResponseMessage {
 
     // optional .APChallenge challenge = 10;
 
-
     pub fn get_challenge(&self) -> &APChallenge {
-        self.challenge.as_ref().unwrap_or_else(|| APChallenge::default_instance())
+        self.challenge
+            .as_ref()
+            .unwrap_or_else(|| APChallenge::default_instance())
     }
     pub fn clear_challenge(&mut self) {
         self.challenge.clear();
@@ -1516,9 +1685,10 @@ impl APResponseMessage {
 
     // optional .UpgradeRequiredMessage upgrade = 20;
 
-
     pub fn get_upgrade(&self) -> &UpgradeRequiredMessage {
-        self.upgrade.as_ref().unwrap_or_else(|| UpgradeRequiredMessage::default_instance())
+        self.upgrade
+            .as_ref()
+            .unwrap_or_else(|| UpgradeRequiredMessage::default_instance())
     }
     pub fn clear_upgrade(&mut self) {
         self.upgrade.clear();
@@ -1544,14 +1714,17 @@ impl APResponseMessage {
 
     // Take field
     pub fn take_upgrade(&mut self) -> UpgradeRequiredMessage {
-        self.upgrade.take().unwrap_or_else(|| UpgradeRequiredMessage::new())
+        self.upgrade
+            .take()
+            .unwrap_or_else(|| UpgradeRequiredMessage::new())
     }
 
     // optional .APLoginFailed login_failed = 30;
 
-
     pub fn get_login_failed(&self) -> &APLoginFailed {
-        self.login_failed.as_ref().unwrap_or_else(|| APLoginFailed::default_instance())
+        self.login_failed
+            .as_ref()
+            .unwrap_or_else(|| APLoginFailed::default_instance())
     }
     pub fn clear_login_failed(&mut self) {
         self.login_failed.clear();
@@ -1577,7 +1750,9 @@ impl APResponseMessage {
 
     // Take field
     pub fn take_login_failed(&mut self) -> APLoginFailed {
-        self.login_failed.take().unwrap_or_else(|| APLoginFailed::new())
+        self.login_failed
+            .take()
+            .unwrap_or_else(|| APLoginFailed::new())
     }
 }
 
@@ -1587,36 +1762,48 @@ impl ::protobuf::Message for APResponseMessage {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.upgrade {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.login_failed {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.challenge)?;
-                },
+                }
                 20 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.upgrade)?;
-                },
+                }
                 30 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.login_failed)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.login_failed,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1643,7 +1830,10 @@ impl ::protobuf::Message for APResponseMessage {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.challenge.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1694,32 +1884,48 @@ impl ::protobuf::Message for APResponseMessage {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<APChallenge>>(
-                    "challenge",
-                    |m: &APResponseMessage| { &m.challenge },
-                    |m: &mut APResponseMessage| { &mut m.challenge },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<UpgradeRequiredMessage>>(
-                    "upgrade",
-                    |m: &APResponseMessage| { &m.upgrade },
-                    |m: &mut APResponseMessage| { &mut m.upgrade },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<APLoginFailed>>(
-                    "login_failed",
-                    |m: &APResponseMessage| { &m.login_failed },
-                    |m: &mut APResponseMessage| { &mut m.login_failed },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<APChallenge>,
+                    >(
+                        "challenge",
+                        |m: &APResponseMessage| &m.challenge,
+                        |m: &mut APResponseMessage| &mut m.challenge,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<UpgradeRequiredMessage>,
+                    >(
+                        "upgrade",
+                        |m: &APResponseMessage| &m.upgrade,
+                        |m: &mut APResponseMessage| &mut m.upgrade,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<APLoginFailed>,
+                    >(
+                        "login_failed",
+                        |m: &APResponseMessage| &m.login_failed,
+                        |m: &mut APResponseMessage| &mut m.login_failed,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<APResponseMessage>(
                     "APResponseMessage",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1730,9 +1936,7 @@ impl ::protobuf::Message for APResponseMessage {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const APResponseMessage,
         };
-        unsafe {
-            instance.get(APResponseMessage::new)
-        }
+        unsafe { instance.get(APResponseMessage::new) }
     }
 }
 
@@ -1757,7 +1961,7 @@ impl ::protobuf::reflect::ProtobufValue for APResponseMessage {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct APChallenge {
     // message fields
     login_crypto_challenge: ::protobuf::SingularPtrField<LoginCryptoChallengeUnion>,
@@ -1784,9 +1988,10 @@ impl APChallenge {
 
     // required .LoginCryptoChallengeUnion login_crypto_challenge = 10;
 
-
     pub fn get_login_crypto_challenge(&self) -> &LoginCryptoChallengeUnion {
-        self.login_crypto_challenge.as_ref().unwrap_or_else(|| LoginCryptoChallengeUnion::default_instance())
+        self.login_crypto_challenge
+            .as_ref()
+            .unwrap_or_else(|| LoginCryptoChallengeUnion::default_instance())
     }
     pub fn clear_login_crypto_challenge(&mut self) {
         self.login_crypto_challenge.clear();
@@ -1812,14 +2017,17 @@ impl APChallenge {
 
     // Take field
     pub fn take_login_crypto_challenge(&mut self) -> LoginCryptoChallengeUnion {
-        self.login_crypto_challenge.take().unwrap_or_else(|| LoginCryptoChallengeUnion::new())
+        self.login_crypto_challenge
+            .take()
+            .unwrap_or_else(|| LoginCryptoChallengeUnion::new())
     }
 
     // required .FingerprintChallengeUnion fingerprint_challenge = 20;
 
-
     pub fn get_fingerprint_challenge(&self) -> &FingerprintChallengeUnion {
-        self.fingerprint_challenge.as_ref().unwrap_or_else(|| FingerprintChallengeUnion::default_instance())
+        self.fingerprint_challenge
+            .as_ref()
+            .unwrap_or_else(|| FingerprintChallengeUnion::default_instance())
     }
     pub fn clear_fingerprint_challenge(&mut self) {
         self.fingerprint_challenge.clear();
@@ -1845,14 +2053,17 @@ impl APChallenge {
 
     // Take field
     pub fn take_fingerprint_challenge(&mut self) -> FingerprintChallengeUnion {
-        self.fingerprint_challenge.take().unwrap_or_else(|| FingerprintChallengeUnion::new())
+        self.fingerprint_challenge
+            .take()
+            .unwrap_or_else(|| FingerprintChallengeUnion::new())
     }
 
     // required .PoWChallengeUnion pow_challenge = 30;
 
-
     pub fn get_pow_challenge(&self) -> &PoWChallengeUnion {
-        self.pow_challenge.as_ref().unwrap_or_else(|| PoWChallengeUnion::default_instance())
+        self.pow_challenge
+            .as_ref()
+            .unwrap_or_else(|| PoWChallengeUnion::default_instance())
     }
     pub fn clear_pow_challenge(&mut self) {
         self.pow_challenge.clear();
@@ -1878,14 +2089,17 @@ impl APChallenge {
 
     // Take field
     pub fn take_pow_challenge(&mut self) -> PoWChallengeUnion {
-        self.pow_challenge.take().unwrap_or_else(|| PoWChallengeUnion::new())
+        self.pow_challenge
+            .take()
+            .unwrap_or_else(|| PoWChallengeUnion::new())
     }
 
     // required .CryptoChallengeUnion crypto_challenge = 40;
 
-
     pub fn get_crypto_challenge(&self) -> &CryptoChallengeUnion {
-        self.crypto_challenge.as_ref().unwrap_or_else(|| CryptoChallengeUnion::default_instance())
+        self.crypto_challenge
+            .as_ref()
+            .unwrap_or_else(|| CryptoChallengeUnion::default_instance())
     }
     pub fn clear_crypto_challenge(&mut self) {
         self.crypto_challenge.clear();
@@ -1911,11 +2125,12 @@ impl APChallenge {
 
     // Take field
     pub fn take_crypto_challenge(&mut self) -> CryptoChallengeUnion {
-        self.crypto_challenge.take().unwrap_or_else(|| CryptoChallengeUnion::new())
+        self.crypto_challenge
+            .take()
+            .unwrap_or_else(|| CryptoChallengeUnion::new())
     }
 
     // required bytes server_nonce = 50;
-
 
     pub fn get_server_nonce(&self) -> &[u8] {
         match self.server_nonce.as_ref() {
@@ -1947,11 +2162,12 @@ impl APChallenge {
 
     // Take field
     pub fn take_server_nonce(&mut self) -> ::std::vec::Vec<u8> {
-        self.server_nonce.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.server_nonce
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional bytes padding = 60;
-
 
     pub fn get_padding(&self) -> &[u8] {
         match self.padding.as_ref() {
@@ -1983,7 +2199,9 @@ impl APChallenge {
 
     // Take field
     pub fn take_padding(&mut self) -> ::std::vec::Vec<u8> {
-        self.padding.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.padding
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -2008,50 +2226,78 @@ impl ::protobuf::Message for APChallenge {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.fingerprint_challenge {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.pow_challenge {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.crypto_challenge {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.login_crypto_challenge)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.login_crypto_challenge,
+                    )?;
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.fingerprint_challenge)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.fingerprint_challenge,
+                    )?;
+                }
                 30 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.pow_challenge)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.pow_challenge,
+                    )?;
+                }
                 40 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.crypto_challenge)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.crypto_challenge,
+                    )?;
+                }
                 50 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.server_nonce)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.server_nonce,
+                    )?;
+                }
                 60 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.padding)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2088,7 +2334,10 @@ impl ::protobuf::Message for APChallenge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.login_crypto_challenge.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -2150,47 +2399,78 @@ impl ::protobuf::Message for APChallenge {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<LoginCryptoChallengeUnion>>(
-                    "login_crypto_challenge",
-                    |m: &APChallenge| { &m.login_crypto_challenge },
-                    |m: &mut APChallenge| { &mut m.login_crypto_challenge },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<FingerprintChallengeUnion>>(
-                    "fingerprint_challenge",
-                    |m: &APChallenge| { &m.fingerprint_challenge },
-                    |m: &mut APChallenge| { &mut m.fingerprint_challenge },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PoWChallengeUnion>>(
-                    "pow_challenge",
-                    |m: &APChallenge| { &m.pow_challenge },
-                    |m: &mut APChallenge| { &mut m.pow_challenge },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<CryptoChallengeUnion>>(
-                    "crypto_challenge",
-                    |m: &APChallenge| { &m.crypto_challenge },
-                    |m: &mut APChallenge| { &mut m.crypto_challenge },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "server_nonce",
-                    |m: &APChallenge| { &m.server_nonce },
-                    |m: &mut APChallenge| { &mut m.server_nonce },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "padding",
-                    |m: &APChallenge| { &m.padding },
-                    |m: &mut APChallenge| { &mut m.padding },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<LoginCryptoChallengeUnion>,
+                    >(
+                        "login_crypto_challenge",
+                        |m: &APChallenge| &m.login_crypto_challenge,
+                        |m: &mut APChallenge| &mut m.login_crypto_challenge,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<FingerprintChallengeUnion>,
+                    >(
+                        "fingerprint_challenge",
+                        |m: &APChallenge| &m.fingerprint_challenge,
+                        |m: &mut APChallenge| &mut m.fingerprint_challenge,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<PoWChallengeUnion>,
+                    >(
+                        "pow_challenge",
+                        |m: &APChallenge| &m.pow_challenge,
+                        |m: &mut APChallenge| &mut m.pow_challenge,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<CryptoChallengeUnion>,
+                    >(
+                        "crypto_challenge",
+                        |m: &APChallenge| &m.crypto_challenge,
+                        |m: &mut APChallenge| &mut m.crypto_challenge,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "server_nonce",
+                        |m: &APChallenge| &m.server_nonce,
+                        |m: &mut APChallenge| &mut m.server_nonce,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "padding",
+                        |m: &APChallenge| &m.padding,
+                        |m: &mut APChallenge| &mut m.padding,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<APChallenge>(
                     "APChallenge",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -2201,9 +2481,7 @@ impl ::protobuf::Message for APChallenge {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const APChallenge,
         };
-        unsafe {
-            instance.get(APChallenge::new)
-        }
+        unsafe { instance.get(APChallenge::new) }
     }
 }
 
@@ -2231,7 +2509,7 @@ impl ::protobuf::reflect::ProtobufValue for APChallenge {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct LoginCryptoChallengeUnion {
     // message fields
     diffie_hellman: ::protobuf::SingularPtrField<LoginCryptoDiffieHellmanChallenge>,
@@ -2253,9 +2531,10 @@ impl LoginCryptoChallengeUnion {
 
     // optional .LoginCryptoDiffieHellmanChallenge diffie_hellman = 10;
 
-
     pub fn get_diffie_hellman(&self) -> &LoginCryptoDiffieHellmanChallenge {
-        self.diffie_hellman.as_ref().unwrap_or_else(|| LoginCryptoDiffieHellmanChallenge::default_instance())
+        self.diffie_hellman
+            .as_ref()
+            .unwrap_or_else(|| LoginCryptoDiffieHellmanChallenge::default_instance())
     }
     pub fn clear_diffie_hellman(&mut self) {
         self.diffie_hellman.clear();
@@ -2281,7 +2560,9 @@ impl LoginCryptoChallengeUnion {
 
     // Take field
     pub fn take_diffie_hellman(&mut self) -> LoginCryptoDiffieHellmanChallenge {
-        self.diffie_hellman.take().unwrap_or_else(|| LoginCryptoDiffieHellmanChallenge::new())
+        self.diffie_hellman
+            .take()
+            .unwrap_or_else(|| LoginCryptoDiffieHellmanChallenge::new())
     }
 }
 
@@ -2291,20 +2572,32 @@ impl ::protobuf::Message for LoginCryptoChallengeUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.diffie_hellman)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.diffie_hellman,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2323,7 +2616,10 @@ impl ::protobuf::Message for LoginCryptoChallengeUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.diffie_hellman.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -2364,35 +2660,40 @@ impl ::protobuf::Message for LoginCryptoChallengeUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<LoginCryptoDiffieHellmanChallenge>>(
-                    "diffie_hellman",
-                    |m: &LoginCryptoChallengeUnion| { &m.diffie_hellman },
-                    |m: &mut LoginCryptoChallengeUnion| { &mut m.diffie_hellman },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<LoginCryptoDiffieHellmanChallenge>,
+                    >(
+                        "diffie_hellman",
+                        |m: &LoginCryptoChallengeUnion| &m.diffie_hellman,
+                        |m: &mut LoginCryptoChallengeUnion| &mut m.diffie_hellman,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<LoginCryptoChallengeUnion>(
                     "LoginCryptoChallengeUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static LoginCryptoChallengeUnion {
-        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoChallengeUnion> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const LoginCryptoChallengeUnion,
-        };
-        unsafe {
-            instance.get(LoginCryptoChallengeUnion::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoChallengeUnion> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const LoginCryptoChallengeUnion,
+            };
+        unsafe { instance.get(LoginCryptoChallengeUnion::new) }
     }
 }
 
@@ -2415,7 +2716,7 @@ impl ::protobuf::reflect::ProtobufValue for LoginCryptoChallengeUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct LoginCryptoDiffieHellmanChallenge {
     // message fields
     gs: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -2438,7 +2739,6 @@ impl LoginCryptoDiffieHellmanChallenge {
     }
 
     // required bytes gs = 10;
-
 
     pub fn get_gs(&self) -> &[u8] {
         match self.gs.as_ref() {
@@ -2475,7 +2775,6 @@ impl LoginCryptoDiffieHellmanChallenge {
 
     // required int32 server_signature_key = 20;
 
-
     pub fn get_server_signature_key(&self) -> i32 {
         self.server_signature_key.unwrap_or(0)
     }
@@ -2493,7 +2792,6 @@ impl LoginCryptoDiffieHellmanChallenge {
     }
 
     // required bytes gs_signature = 30;
-
 
     pub fn get_gs_signature(&self) -> &[u8] {
         match self.gs_signature.as_ref() {
@@ -2525,7 +2823,9 @@ impl LoginCryptoDiffieHellmanChallenge {
 
     // Take field
     pub fn take_gs_signature(&mut self) -> ::std::vec::Vec<u8> {
-        self.gs_signature.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.gs_signature
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -2543,26 +2843,40 @@ impl ::protobuf::Message for LoginCryptoDiffieHellmanChallenge {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gs)?;
-                },
+                }
                 20 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.server_signature_key = ::std::option::Option::Some(tmp);
-                },
+                }
                 30 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gs_signature)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.gs_signature,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2586,7 +2900,10 @@ impl ::protobuf::Message for LoginCryptoDiffieHellmanChallenge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.gs.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -2631,45 +2948,58 @@ impl ::protobuf::Message for LoginCryptoDiffieHellmanChallenge {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gs",
-                    |m: &LoginCryptoDiffieHellmanChallenge| { &m.gs },
-                    |m: &mut LoginCryptoDiffieHellmanChallenge| { &mut m.gs },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "gs",
+                        |m: &LoginCryptoDiffieHellmanChallenge| &m.gs,
+                        |m: &mut LoginCryptoDiffieHellmanChallenge| &mut m.gs,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "server_signature_key",
-                    |m: &LoginCryptoDiffieHellmanChallenge| { &m.server_signature_key },
-                    |m: &mut LoginCryptoDiffieHellmanChallenge| { &mut m.server_signature_key },
+                    |m: &LoginCryptoDiffieHellmanChallenge| &m.server_signature_key,
+                    |m: &mut LoginCryptoDiffieHellmanChallenge| &mut m.server_signature_key,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gs_signature",
-                    |m: &LoginCryptoDiffieHellmanChallenge| { &m.gs_signature },
-                    |m: &mut LoginCryptoDiffieHellmanChallenge| { &mut m.gs_signature },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "gs_signature",
+                        |m: &LoginCryptoDiffieHellmanChallenge| &m.gs_signature,
+                        |m: &mut LoginCryptoDiffieHellmanChallenge| &mut m.gs_signature,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<LoginCryptoDiffieHellmanChallenge>(
                     "LoginCryptoDiffieHellmanChallenge",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static LoginCryptoDiffieHellmanChallenge {
-        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoDiffieHellmanChallenge> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const LoginCryptoDiffieHellmanChallenge,
-        };
-        unsafe {
-            instance.get(LoginCryptoDiffieHellmanChallenge::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoDiffieHellmanChallenge> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const LoginCryptoDiffieHellmanChallenge,
+            };
+        unsafe { instance.get(LoginCryptoDiffieHellmanChallenge::new) }
     }
 }
 
@@ -2694,7 +3024,7 @@ impl ::protobuf::reflect::ProtobufValue for LoginCryptoDiffieHellmanChallenge {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct FingerprintChallengeUnion {
     // message fields
     grain: ::protobuf::SingularPtrField<FingerprintGrainChallenge>,
@@ -2717,9 +3047,10 @@ impl FingerprintChallengeUnion {
 
     // optional .FingerprintGrainChallenge grain = 10;
 
-
     pub fn get_grain(&self) -> &FingerprintGrainChallenge {
-        self.grain.as_ref().unwrap_or_else(|| FingerprintGrainChallenge::default_instance())
+        self.grain
+            .as_ref()
+            .unwrap_or_else(|| FingerprintGrainChallenge::default_instance())
     }
     pub fn clear_grain(&mut self) {
         self.grain.clear();
@@ -2745,14 +3076,17 @@ impl FingerprintChallengeUnion {
 
     // Take field
     pub fn take_grain(&mut self) -> FingerprintGrainChallenge {
-        self.grain.take().unwrap_or_else(|| FingerprintGrainChallenge::new())
+        self.grain
+            .take()
+            .unwrap_or_else(|| FingerprintGrainChallenge::new())
     }
 
     // optional .FingerprintHmacRipemdChallenge hmac_ripemd = 20;
 
-
     pub fn get_hmac_ripemd(&self) -> &FingerprintHmacRipemdChallenge {
-        self.hmac_ripemd.as_ref().unwrap_or_else(|| FingerprintHmacRipemdChallenge::default_instance())
+        self.hmac_ripemd
+            .as_ref()
+            .unwrap_or_else(|| FingerprintHmacRipemdChallenge::default_instance())
     }
     pub fn clear_hmac_ripemd(&mut self) {
         self.hmac_ripemd.clear();
@@ -2778,7 +3112,9 @@ impl FingerprintChallengeUnion {
 
     // Take field
     pub fn take_hmac_ripemd(&mut self) -> FingerprintHmacRipemdChallenge {
-        self.hmac_ripemd.take().unwrap_or_else(|| FingerprintHmacRipemdChallenge::new())
+        self.hmac_ripemd
+            .take()
+            .unwrap_or_else(|| FingerprintHmacRipemdChallenge::new())
     }
 }
 
@@ -2788,28 +3124,40 @@ impl ::protobuf::Message for FingerprintChallengeUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.hmac_ripemd {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.grain)?;
-                },
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.hmac_ripemd)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.hmac_ripemd,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2832,7 +3180,10 @@ impl ::protobuf::Message for FingerprintChallengeUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.grain.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -2878,40 +3229,50 @@ impl ::protobuf::Message for FingerprintChallengeUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<FingerprintGrainChallenge>>(
-                    "grain",
-                    |m: &FingerprintChallengeUnion| { &m.grain },
-                    |m: &mut FingerprintChallengeUnion| { &mut m.grain },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<FingerprintHmacRipemdChallenge>>(
-                    "hmac_ripemd",
-                    |m: &FingerprintChallengeUnion| { &m.hmac_ripemd },
-                    |m: &mut FingerprintChallengeUnion| { &mut m.hmac_ripemd },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<FingerprintGrainChallenge>,
+                    >(
+                        "grain",
+                        |m: &FingerprintChallengeUnion| &m.grain,
+                        |m: &mut FingerprintChallengeUnion| &mut m.grain,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<FingerprintHmacRipemdChallenge>,
+                    >(
+                        "hmac_ripemd",
+                        |m: &FingerprintChallengeUnion| &m.hmac_ripemd,
+                        |m: &mut FingerprintChallengeUnion| &mut m.hmac_ripemd,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<FingerprintChallengeUnion>(
                     "FingerprintChallengeUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static FingerprintChallengeUnion {
-        static mut instance: ::protobuf::lazy::Lazy<FingerprintChallengeUnion> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const FingerprintChallengeUnion,
-        };
-        unsafe {
-            instance.get(FingerprintChallengeUnion::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<FingerprintChallengeUnion> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const FingerprintChallengeUnion,
+            };
+        unsafe { instance.get(FingerprintChallengeUnion::new) }
     }
 }
 
@@ -2935,7 +3296,7 @@ impl ::protobuf::reflect::ProtobufValue for FingerprintChallengeUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct FingerprintGrainChallenge {
     // message fields
     kek: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -2956,7 +3317,6 @@ impl FingerprintGrainChallenge {
     }
 
     // required bytes kek = 10;
-
 
     pub fn get_kek(&self) -> &[u8] {
         match self.kek.as_ref() {
@@ -3000,16 +3360,24 @@ impl ::protobuf::Message for FingerprintGrainChallenge {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.kek)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3027,7 +3395,10 @@ impl ::protobuf::Message for FingerprintGrainChallenge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.kek.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -3066,35 +3437,40 @@ impl ::protobuf::Message for FingerprintGrainChallenge {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "kek",
-                    |m: &FingerprintGrainChallenge| { &m.kek },
-                    |m: &mut FingerprintGrainChallenge| { &mut m.kek },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "kek",
+                        |m: &FingerprintGrainChallenge| &m.kek,
+                        |m: &mut FingerprintGrainChallenge| &mut m.kek,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<FingerprintGrainChallenge>(
                     "FingerprintGrainChallenge",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static FingerprintGrainChallenge {
-        static mut instance: ::protobuf::lazy::Lazy<FingerprintGrainChallenge> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const FingerprintGrainChallenge,
-        };
-        unsafe {
-            instance.get(FingerprintGrainChallenge::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<FingerprintGrainChallenge> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const FingerprintGrainChallenge,
+            };
+        unsafe { instance.get(FingerprintGrainChallenge::new) }
     }
 }
 
@@ -3117,7 +3493,7 @@ impl ::protobuf::reflect::ProtobufValue for FingerprintGrainChallenge {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct FingerprintHmacRipemdChallenge {
     // message fields
     challenge: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -3138,7 +3514,6 @@ impl FingerprintHmacRipemdChallenge {
     }
 
     // required bytes challenge = 10;
-
 
     pub fn get_challenge(&self) -> &[u8] {
         match self.challenge.as_ref() {
@@ -3170,7 +3545,9 @@ impl FingerprintHmacRipemdChallenge {
 
     // Take field
     pub fn take_challenge(&mut self) -> ::std::vec::Vec<u8> {
-        self.challenge.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.challenge
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -3182,16 +3559,24 @@ impl ::protobuf::Message for FingerprintHmacRipemdChallenge {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.challenge)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3209,7 +3594,10 @@ impl ::protobuf::Message for FingerprintHmacRipemdChallenge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.challenge.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -3248,35 +3636,40 @@ impl ::protobuf::Message for FingerprintHmacRipemdChallenge {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "challenge",
-                    |m: &FingerprintHmacRipemdChallenge| { &m.challenge },
-                    |m: &mut FingerprintHmacRipemdChallenge| { &mut m.challenge },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "challenge",
+                        |m: &FingerprintHmacRipemdChallenge| &m.challenge,
+                        |m: &mut FingerprintHmacRipemdChallenge| &mut m.challenge,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<FingerprintHmacRipemdChallenge>(
                     "FingerprintHmacRipemdChallenge",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static FingerprintHmacRipemdChallenge {
-        static mut instance: ::protobuf::lazy::Lazy<FingerprintHmacRipemdChallenge> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const FingerprintHmacRipemdChallenge,
-        };
-        unsafe {
-            instance.get(FingerprintHmacRipemdChallenge::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<FingerprintHmacRipemdChallenge> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const FingerprintHmacRipemdChallenge,
+            };
+        unsafe { instance.get(FingerprintHmacRipemdChallenge::new) }
     }
 }
 
@@ -3299,7 +3692,7 @@ impl ::protobuf::reflect::ProtobufValue for FingerprintHmacRipemdChallenge {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct PoWChallengeUnion {
     // message fields
     hash_cash: ::protobuf::SingularPtrField<PoWHashCashChallenge>,
@@ -3321,9 +3714,10 @@ impl PoWChallengeUnion {
 
     // optional .PoWHashCashChallenge hash_cash = 10;
 
-
     pub fn get_hash_cash(&self) -> &PoWHashCashChallenge {
-        self.hash_cash.as_ref().unwrap_or_else(|| PoWHashCashChallenge::default_instance())
+        self.hash_cash
+            .as_ref()
+            .unwrap_or_else(|| PoWHashCashChallenge::default_instance())
     }
     pub fn clear_hash_cash(&mut self) {
         self.hash_cash.clear();
@@ -3349,7 +3743,9 @@ impl PoWChallengeUnion {
 
     // Take field
     pub fn take_hash_cash(&mut self) -> PoWHashCashChallenge {
-        self.hash_cash.take().unwrap_or_else(|| PoWHashCashChallenge::new())
+        self.hash_cash
+            .take()
+            .unwrap_or_else(|| PoWHashCashChallenge::new())
     }
 }
 
@@ -3359,20 +3755,28 @@ impl ::protobuf::Message for PoWChallengeUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.hash_cash)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3391,7 +3795,10 @@ impl ::protobuf::Message for PoWChallengeUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.hash_cash.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -3432,22 +3839,28 @@ impl ::protobuf::Message for PoWChallengeUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PoWHashCashChallenge>>(
-                    "hash_cash",
-                    |m: &PoWChallengeUnion| { &m.hash_cash },
-                    |m: &mut PoWChallengeUnion| { &mut m.hash_cash },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<PoWHashCashChallenge>,
+                    >(
+                        "hash_cash",
+                        |m: &PoWChallengeUnion| &m.hash_cash,
+                        |m: &mut PoWChallengeUnion| &mut m.hash_cash,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<PoWChallengeUnion>(
                     "PoWChallengeUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3458,9 +3871,7 @@ impl ::protobuf::Message for PoWChallengeUnion {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const PoWChallengeUnion,
         };
-        unsafe {
-            instance.get(PoWChallengeUnion::new)
-        }
+        unsafe { instance.get(PoWChallengeUnion::new) }
     }
 }
 
@@ -3483,7 +3894,7 @@ impl ::protobuf::reflect::ProtobufValue for PoWChallengeUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct PoWHashCashChallenge {
     // message fields
     prefix: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -3506,7 +3917,6 @@ impl PoWHashCashChallenge {
     }
 
     // optional bytes prefix = 10;
-
 
     pub fn get_prefix(&self) -> &[u8] {
         match self.prefix.as_ref() {
@@ -3543,7 +3953,6 @@ impl PoWHashCashChallenge {
 
     // optional int32 length = 20;
 
-
     pub fn get_length(&self) -> i32 {
         self.length.unwrap_or(0)
     }
@@ -3561,7 +3970,6 @@ impl PoWHashCashChallenge {
     }
 
     // optional int32 target = 30;
-
 
     pub fn get_target(&self) -> i32 {
         self.target.unwrap_or(0)
@@ -3585,30 +3993,42 @@ impl ::protobuf::Message for PoWHashCashChallenge {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.prefix)?;
-                },
+                }
                 20 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.length = ::std::option::Option::Some(tmp);
-                },
+                }
                 30 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.target = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3632,7 +4052,10 @@ impl ::protobuf::Message for PoWHashCashChallenge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.prefix.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -3677,45 +4100,56 @@ impl ::protobuf::Message for PoWHashCashChallenge {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "prefix",
-                    |m: &PoWHashCashChallenge| { &m.prefix },
-                    |m: &mut PoWHashCashChallenge| { &mut m.prefix },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "prefix",
+                        |m: &PoWHashCashChallenge| &m.prefix,
+                        |m: &mut PoWHashCashChallenge| &mut m.prefix,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "length",
-                    |m: &PoWHashCashChallenge| { &m.length },
-                    |m: &mut PoWHashCashChallenge| { &mut m.length },
+                    |m: &PoWHashCashChallenge| &m.length,
+                    |m: &mut PoWHashCashChallenge| &mut m.length,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "target",
-                    |m: &PoWHashCashChallenge| { &m.target },
-                    |m: &mut PoWHashCashChallenge| { &mut m.target },
+                    |m: &PoWHashCashChallenge| &m.target,
+                    |m: &mut PoWHashCashChallenge| &mut m.target,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<PoWHashCashChallenge>(
                     "PoWHashCashChallenge",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static PoWHashCashChallenge {
-        static mut instance: ::protobuf::lazy::Lazy<PoWHashCashChallenge> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const PoWHashCashChallenge,
-        };
-        unsafe {
-            instance.get(PoWHashCashChallenge::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<PoWHashCashChallenge> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const PoWHashCashChallenge,
+            };
+        unsafe { instance.get(PoWHashCashChallenge::new) }
     }
 }
 
@@ -3740,7 +4174,7 @@ impl ::protobuf::reflect::ProtobufValue for PoWHashCashChallenge {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct CryptoChallengeUnion {
     // message fields
     shannon: ::protobuf::SingularPtrField<CryptoShannonChallenge>,
@@ -3763,9 +4197,10 @@ impl CryptoChallengeUnion {
 
     // optional .CryptoShannonChallenge shannon = 10;
 
-
     pub fn get_shannon(&self) -> &CryptoShannonChallenge {
-        self.shannon.as_ref().unwrap_or_else(|| CryptoShannonChallenge::default_instance())
+        self.shannon
+            .as_ref()
+            .unwrap_or_else(|| CryptoShannonChallenge::default_instance())
     }
     pub fn clear_shannon(&mut self) {
         self.shannon.clear();
@@ -3791,14 +4226,17 @@ impl CryptoChallengeUnion {
 
     // Take field
     pub fn take_shannon(&mut self) -> CryptoShannonChallenge {
-        self.shannon.take().unwrap_or_else(|| CryptoShannonChallenge::new())
+        self.shannon
+            .take()
+            .unwrap_or_else(|| CryptoShannonChallenge::new())
     }
 
     // optional .CryptoRc4Sha1HmacChallenge rc4_sha1_hmac = 20;
 
-
     pub fn get_rc4_sha1_hmac(&self) -> &CryptoRc4Sha1HmacChallenge {
-        self.rc4_sha1_hmac.as_ref().unwrap_or_else(|| CryptoRc4Sha1HmacChallenge::default_instance())
+        self.rc4_sha1_hmac
+            .as_ref()
+            .unwrap_or_else(|| CryptoRc4Sha1HmacChallenge::default_instance())
     }
     pub fn clear_rc4_sha1_hmac(&mut self) {
         self.rc4_sha1_hmac.clear();
@@ -3824,7 +4262,9 @@ impl CryptoChallengeUnion {
 
     // Take field
     pub fn take_rc4_sha1_hmac(&mut self) -> CryptoRc4Sha1HmacChallenge {
-        self.rc4_sha1_hmac.take().unwrap_or_else(|| CryptoRc4Sha1HmacChallenge::new())
+        self.rc4_sha1_hmac
+            .take()
+            .unwrap_or_else(|| CryptoRc4Sha1HmacChallenge::new())
     }
 }
 
@@ -3834,28 +4274,40 @@ impl ::protobuf::Message for CryptoChallengeUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.rc4_sha1_hmac {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.shannon)?;
-                },
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.rc4_sha1_hmac)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.rc4_sha1_hmac,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3878,7 +4330,10 @@ impl ::protobuf::Message for CryptoChallengeUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.shannon.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -3924,40 +4379,50 @@ impl ::protobuf::Message for CryptoChallengeUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<CryptoShannonChallenge>>(
-                    "shannon",
-                    |m: &CryptoChallengeUnion| { &m.shannon },
-                    |m: &mut CryptoChallengeUnion| { &mut m.shannon },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<CryptoRc4Sha1HmacChallenge>>(
-                    "rc4_sha1_hmac",
-                    |m: &CryptoChallengeUnion| { &m.rc4_sha1_hmac },
-                    |m: &mut CryptoChallengeUnion| { &mut m.rc4_sha1_hmac },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<CryptoShannonChallenge>,
+                    >(
+                        "shannon",
+                        |m: &CryptoChallengeUnion| &m.shannon,
+                        |m: &mut CryptoChallengeUnion| &mut m.shannon,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<CryptoRc4Sha1HmacChallenge>,
+                    >(
+                        "rc4_sha1_hmac",
+                        |m: &CryptoChallengeUnion| &m.rc4_sha1_hmac,
+                        |m: &mut CryptoChallengeUnion| &mut m.rc4_sha1_hmac,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<CryptoChallengeUnion>(
                     "CryptoChallengeUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static CryptoChallengeUnion {
-        static mut instance: ::protobuf::lazy::Lazy<CryptoChallengeUnion> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const CryptoChallengeUnion,
-        };
-        unsafe {
-            instance.get(CryptoChallengeUnion::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<CryptoChallengeUnion> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const CryptoChallengeUnion,
+            };
+        unsafe { instance.get(CryptoChallengeUnion::new) }
     }
 }
 
@@ -3981,7 +4446,7 @@ impl ::protobuf::reflect::ProtobufValue for CryptoChallengeUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct CryptoShannonChallenge {
     // special fields
     pub unknown_fields: ::protobuf::UnknownFields,
@@ -4005,13 +4470,21 @@ impl ::protobuf::Message for CryptoShannonChallenge {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4026,7 +4499,10 @@ impl ::protobuf::Message for CryptoShannonChallenge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -4062,30 +4538,30 @@ impl ::protobuf::Message for CryptoShannonChallenge {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let fields = ::std::vec::Vec::new();
                 ::protobuf::reflect::MessageDescriptor::new::<CryptoShannonChallenge>(
                     "CryptoShannonChallenge",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static CryptoShannonChallenge {
-        static mut instance: ::protobuf::lazy::Lazy<CryptoShannonChallenge> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const CryptoShannonChallenge,
-        };
-        unsafe {
-            instance.get(CryptoShannonChallenge::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<CryptoShannonChallenge> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const CryptoShannonChallenge,
+            };
+        unsafe { instance.get(CryptoShannonChallenge::new) }
     }
 }
 
@@ -4107,7 +4583,7 @@ impl ::protobuf::reflect::ProtobufValue for CryptoShannonChallenge {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct CryptoRc4Sha1HmacChallenge {
     // special fields
     pub unknown_fields: ::protobuf::UnknownFields,
@@ -4131,13 +4607,21 @@ impl ::protobuf::Message for CryptoRc4Sha1HmacChallenge {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4152,7 +4636,10 @@ impl ::protobuf::Message for CryptoRc4Sha1HmacChallenge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -4188,30 +4675,30 @@ impl ::protobuf::Message for CryptoRc4Sha1HmacChallenge {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let fields = ::std::vec::Vec::new();
                 ::protobuf::reflect::MessageDescriptor::new::<CryptoRc4Sha1HmacChallenge>(
                     "CryptoRc4Sha1HmacChallenge",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static CryptoRc4Sha1HmacChallenge {
-        static mut instance: ::protobuf::lazy::Lazy<CryptoRc4Sha1HmacChallenge> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const CryptoRc4Sha1HmacChallenge,
-        };
-        unsafe {
-            instance.get(CryptoRc4Sha1HmacChallenge::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<CryptoRc4Sha1HmacChallenge> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const CryptoRc4Sha1HmacChallenge,
+            };
+        unsafe { instance.get(CryptoRc4Sha1HmacChallenge::new) }
     }
 }
 
@@ -4233,7 +4720,7 @@ impl ::protobuf::reflect::ProtobufValue for CryptoRc4Sha1HmacChallenge {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct UpgradeRequiredMessage {
     // message fields
     upgrade_signed_part: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -4256,7 +4743,6 @@ impl UpgradeRequiredMessage {
     }
 
     // required bytes upgrade_signed_part = 10;
-
 
     pub fn get_upgrade_signed_part(&self) -> &[u8] {
         match self.upgrade_signed_part.as_ref() {
@@ -4288,11 +4774,12 @@ impl UpgradeRequiredMessage {
 
     // Take field
     pub fn take_upgrade_signed_part(&mut self) -> ::std::vec::Vec<u8> {
-        self.upgrade_signed_part.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.upgrade_signed_part
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // required bytes signature = 20;
-
 
     pub fn get_signature(&self) -> &[u8] {
         match self.signature.as_ref() {
@@ -4324,11 +4811,12 @@ impl UpgradeRequiredMessage {
 
     // Take field
     pub fn take_signature(&mut self) -> ::std::vec::Vec<u8> {
-        self.signature.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.signature
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional string http_suffix = 30;
-
 
     pub fn get_http_suffix(&self) -> &str {
         match self.http_suffix.as_ref() {
@@ -4360,7 +4848,9 @@ impl UpgradeRequiredMessage {
 
     // Take field
     pub fn take_http_suffix(&mut self) -> ::std::string::String {
-        self.http_suffix.take().unwrap_or_else(|| ::std::string::String::new())
+        self.http_suffix
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -4375,22 +4865,38 @@ impl ::protobuf::Message for UpgradeRequiredMessage {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.upgrade_signed_part)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.upgrade_signed_part,
+                    )?;
+                }
                 20 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.signature)?;
-                },
+                }
                 30 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.http_suffix)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.http_suffix,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4414,7 +4920,10 @@ impl ::protobuf::Message for UpgradeRequiredMessage {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.upgrade_signed_part.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -4459,45 +4968,60 @@ impl ::protobuf::Message for UpgradeRequiredMessage {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "upgrade_signed_part",
-                    |m: &UpgradeRequiredMessage| { &m.upgrade_signed_part },
-                    |m: &mut UpgradeRequiredMessage| { &mut m.upgrade_signed_part },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "signature",
-                    |m: &UpgradeRequiredMessage| { &m.signature },
-                    |m: &mut UpgradeRequiredMessage| { &mut m.signature },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "http_suffix",
-                    |m: &UpgradeRequiredMessage| { &m.http_suffix },
-                    |m: &mut UpgradeRequiredMessage| { &mut m.http_suffix },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "upgrade_signed_part",
+                        |m: &UpgradeRequiredMessage| &m.upgrade_signed_part,
+                        |m: &mut UpgradeRequiredMessage| &mut m.upgrade_signed_part,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "signature",
+                        |m: &UpgradeRequiredMessage| &m.signature,
+                        |m: &mut UpgradeRequiredMessage| &mut m.signature,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "http_suffix",
+                        |m: &UpgradeRequiredMessage| &m.http_suffix,
+                        |m: &mut UpgradeRequiredMessage| &mut m.http_suffix,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<UpgradeRequiredMessage>(
                     "UpgradeRequiredMessage",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static UpgradeRequiredMessage {
-        static mut instance: ::protobuf::lazy::Lazy<UpgradeRequiredMessage> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const UpgradeRequiredMessage,
-        };
-        unsafe {
-            instance.get(UpgradeRequiredMessage::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<UpgradeRequiredMessage> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const UpgradeRequiredMessage,
+            };
+        unsafe { instance.get(UpgradeRequiredMessage::new) }
     }
 }
 
@@ -4522,7 +5046,7 @@ impl ::protobuf::reflect::ProtobufValue for UpgradeRequiredMessage {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct APLoginFailed {
     // message fields
     error_code: ::std::option::Option<ErrorCode>,
@@ -4547,7 +5071,6 @@ impl APLoginFailed {
 
     // required .ErrorCode error_code = 10;
 
-
     pub fn get_error_code(&self) -> ErrorCode {
         self.error_code.unwrap_or(ErrorCode::ProtocolError)
     }
@@ -4565,7 +5088,6 @@ impl APLoginFailed {
     }
 
     // optional int32 retry_delay = 20;
-
 
     pub fn get_retry_delay(&self) -> i32 {
         self.retry_delay.unwrap_or(0)
@@ -4585,7 +5107,6 @@ impl APLoginFailed {
 
     // optional int32 expiry = 30;
 
-
     pub fn get_expiry(&self) -> i32 {
         self.expiry.unwrap_or(0)
     }
@@ -4603,7 +5124,6 @@ impl APLoginFailed {
     }
 
     // optional string error_description = 40;
-
 
     pub fn get_error_description(&self) -> &str {
         match self.error_description.as_ref() {
@@ -4635,7 +5155,9 @@ impl APLoginFailed {
 
     // Take field
     pub fn take_error_description(&mut self) -> ::std::string::String {
-        self.error_description.take().unwrap_or_else(|| ::std::string::String::new())
+        self.error_description
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -4647,33 +5169,53 @@ impl ::protobuf::Message for APLoginFailed {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                10 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.error_code, 10, &mut self.unknown_fields)?
-                },
+                10 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.error_code,
+                    10,
+                    &mut self.unknown_fields,
+                )?,
                 20 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.retry_delay = ::std::option::Option::Some(tmp);
-                },
+                }
                 30 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.expiry = ::std::option::Option::Some(tmp);
-                },
+                }
                 40 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.error_description)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.error_description,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4700,7 +5242,10 @@ impl ::protobuf::Message for APLoginFailed {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.error_code {
             os.write_enum(10, v.value())?;
         }
@@ -4748,37 +5293,52 @@ impl ::protobuf::Message for APLoginFailed {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ErrorCode>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<ErrorCode>,
+                >(
                     "error_code",
-                    |m: &APLoginFailed| { &m.error_code },
-                    |m: &mut APLoginFailed| { &mut m.error_code },
+                    |m: &APLoginFailed| &m.error_code,
+                    |m: &mut APLoginFailed| &mut m.error_code,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "retry_delay",
-                    |m: &APLoginFailed| { &m.retry_delay },
-                    |m: &mut APLoginFailed| { &mut m.retry_delay },
+                    |m: &APLoginFailed| &m.retry_delay,
+                    |m: &mut APLoginFailed| &mut m.retry_delay,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "expiry",
-                    |m: &APLoginFailed| { &m.expiry },
-                    |m: &mut APLoginFailed| { &mut m.expiry },
+                    |m: &APLoginFailed| &m.expiry,
+                    |m: &mut APLoginFailed| &mut m.expiry,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "error_description",
-                    |m: &APLoginFailed| { &m.error_description },
-                    |m: &mut APLoginFailed| { &mut m.error_description },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "error_description",
+                        |m: &APLoginFailed| &m.error_description,
+                        |m: &mut APLoginFailed| &mut m.error_description,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<APLoginFailed>(
                     "APLoginFailed",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -4789,9 +5349,7 @@ impl ::protobuf::Message for APLoginFailed {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const APLoginFailed,
         };
-        unsafe {
-            instance.get(APLoginFailed::new)
-        }
+        unsafe { instance.get(APLoginFailed::new) }
     }
 }
 
@@ -4817,7 +5375,7 @@ impl ::protobuf::reflect::ProtobufValue for APLoginFailed {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ClientResponsePlaintext {
     // message fields
     login_crypto_response: ::protobuf::SingularPtrField<LoginCryptoResponseUnion>,
@@ -4841,9 +5399,10 @@ impl ClientResponsePlaintext {
 
     // required .LoginCryptoResponseUnion login_crypto_response = 10;
 
-
     pub fn get_login_crypto_response(&self) -> &LoginCryptoResponseUnion {
-        self.login_crypto_response.as_ref().unwrap_or_else(|| LoginCryptoResponseUnion::default_instance())
+        self.login_crypto_response
+            .as_ref()
+            .unwrap_or_else(|| LoginCryptoResponseUnion::default_instance())
     }
     pub fn clear_login_crypto_response(&mut self) {
         self.login_crypto_response.clear();
@@ -4869,14 +5428,17 @@ impl ClientResponsePlaintext {
 
     // Take field
     pub fn take_login_crypto_response(&mut self) -> LoginCryptoResponseUnion {
-        self.login_crypto_response.take().unwrap_or_else(|| LoginCryptoResponseUnion::new())
+        self.login_crypto_response
+            .take()
+            .unwrap_or_else(|| LoginCryptoResponseUnion::new())
     }
 
     // required .PoWResponseUnion pow_response = 20;
 
-
     pub fn get_pow_response(&self) -> &PoWResponseUnion {
-        self.pow_response.as_ref().unwrap_or_else(|| PoWResponseUnion::default_instance())
+        self.pow_response
+            .as_ref()
+            .unwrap_or_else(|| PoWResponseUnion::default_instance())
     }
     pub fn clear_pow_response(&mut self) {
         self.pow_response.clear();
@@ -4902,14 +5464,17 @@ impl ClientResponsePlaintext {
 
     // Take field
     pub fn take_pow_response(&mut self) -> PoWResponseUnion {
-        self.pow_response.take().unwrap_or_else(|| PoWResponseUnion::new())
+        self.pow_response
+            .take()
+            .unwrap_or_else(|| PoWResponseUnion::new())
     }
 
     // required .CryptoResponseUnion crypto_response = 30;
 
-
     pub fn get_crypto_response(&self) -> &CryptoResponseUnion {
-        self.crypto_response.as_ref().unwrap_or_else(|| CryptoResponseUnion::default_instance())
+        self.crypto_response
+            .as_ref()
+            .unwrap_or_else(|| CryptoResponseUnion::default_instance())
     }
     pub fn clear_crypto_response(&mut self) {
         self.crypto_response.clear();
@@ -4935,7 +5500,9 @@ impl ClientResponsePlaintext {
 
     // Take field
     pub fn take_crypto_response(&mut self) -> CryptoResponseUnion {
-        self.crypto_response.take().unwrap_or_else(|| CryptoResponseUnion::new())
+        self.crypto_response
+            .take()
+            .unwrap_or_else(|| CryptoResponseUnion::new())
     }
 }
 
@@ -4954,36 +5521,56 @@ impl ::protobuf::Message for ClientResponsePlaintext {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.pow_response {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.crypto_response {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.login_crypto_response)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.login_crypto_response,
+                    )?;
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.pow_response)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.pow_response,
+                    )?;
+                }
                 30 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.crypto_response)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.crypto_response,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -5010,7 +5597,10 @@ impl ::protobuf::Message for ClientResponsePlaintext {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.login_crypto_response.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -5061,45 +5651,60 @@ impl ::protobuf::Message for ClientResponsePlaintext {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<LoginCryptoResponseUnion>>(
-                    "login_crypto_response",
-                    |m: &ClientResponsePlaintext| { &m.login_crypto_response },
-                    |m: &mut ClientResponsePlaintext| { &mut m.login_crypto_response },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PoWResponseUnion>>(
-                    "pow_response",
-                    |m: &ClientResponsePlaintext| { &m.pow_response },
-                    |m: &mut ClientResponsePlaintext| { &mut m.pow_response },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<CryptoResponseUnion>>(
-                    "crypto_response",
-                    |m: &ClientResponsePlaintext| { &m.crypto_response },
-                    |m: &mut ClientResponsePlaintext| { &mut m.crypto_response },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<LoginCryptoResponseUnion>,
+                    >(
+                        "login_crypto_response",
+                        |m: &ClientResponsePlaintext| &m.login_crypto_response,
+                        |m: &mut ClientResponsePlaintext| &mut m.login_crypto_response,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<PoWResponseUnion>,
+                    >(
+                        "pow_response",
+                        |m: &ClientResponsePlaintext| &m.pow_response,
+                        |m: &mut ClientResponsePlaintext| &mut m.pow_response,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<CryptoResponseUnion>,
+                    >(
+                        "crypto_response",
+                        |m: &ClientResponsePlaintext| &m.crypto_response,
+                        |m: &mut ClientResponsePlaintext| &mut m.crypto_response,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ClientResponsePlaintext>(
                     "ClientResponsePlaintext",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static ClientResponsePlaintext {
-        static mut instance: ::protobuf::lazy::Lazy<ClientResponsePlaintext> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ClientResponsePlaintext,
-        };
-        unsafe {
-            instance.get(ClientResponsePlaintext::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<ClientResponsePlaintext> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ClientResponsePlaintext,
+            };
+        unsafe { instance.get(ClientResponsePlaintext::new) }
     }
 }
 
@@ -5124,7 +5729,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientResponsePlaintext {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct LoginCryptoResponseUnion {
     // message fields
     diffie_hellman: ::protobuf::SingularPtrField<LoginCryptoDiffieHellmanResponse>,
@@ -5146,9 +5751,10 @@ impl LoginCryptoResponseUnion {
 
     // optional .LoginCryptoDiffieHellmanResponse diffie_hellman = 10;
 
-
     pub fn get_diffie_hellman(&self) -> &LoginCryptoDiffieHellmanResponse {
-        self.diffie_hellman.as_ref().unwrap_or_else(|| LoginCryptoDiffieHellmanResponse::default_instance())
+        self.diffie_hellman
+            .as_ref()
+            .unwrap_or_else(|| LoginCryptoDiffieHellmanResponse::default_instance())
     }
     pub fn clear_diffie_hellman(&mut self) {
         self.diffie_hellman.clear();
@@ -5174,7 +5780,9 @@ impl LoginCryptoResponseUnion {
 
     // Take field
     pub fn take_diffie_hellman(&mut self) -> LoginCryptoDiffieHellmanResponse {
-        self.diffie_hellman.take().unwrap_or_else(|| LoginCryptoDiffieHellmanResponse::new())
+        self.diffie_hellman
+            .take()
+            .unwrap_or_else(|| LoginCryptoDiffieHellmanResponse::new())
     }
 }
 
@@ -5184,20 +5792,32 @@ impl ::protobuf::Message for LoginCryptoResponseUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.diffie_hellman)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.diffie_hellman,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -5216,7 +5836,10 @@ impl ::protobuf::Message for LoginCryptoResponseUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.diffie_hellman.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -5257,35 +5880,40 @@ impl ::protobuf::Message for LoginCryptoResponseUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<LoginCryptoDiffieHellmanResponse>>(
-                    "diffie_hellman",
-                    |m: &LoginCryptoResponseUnion| { &m.diffie_hellman },
-                    |m: &mut LoginCryptoResponseUnion| { &mut m.diffie_hellman },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<LoginCryptoDiffieHellmanResponse>,
+                    >(
+                        "diffie_hellman",
+                        |m: &LoginCryptoResponseUnion| &m.diffie_hellman,
+                        |m: &mut LoginCryptoResponseUnion| &mut m.diffie_hellman,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<LoginCryptoResponseUnion>(
                     "LoginCryptoResponseUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static LoginCryptoResponseUnion {
-        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoResponseUnion> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const LoginCryptoResponseUnion,
-        };
-        unsafe {
-            instance.get(LoginCryptoResponseUnion::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoResponseUnion> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const LoginCryptoResponseUnion,
+            };
+        unsafe { instance.get(LoginCryptoResponseUnion::new) }
     }
 }
 
@@ -5308,7 +5936,7 @@ impl ::protobuf::reflect::ProtobufValue for LoginCryptoResponseUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct LoginCryptoDiffieHellmanResponse {
     // message fields
     hmac: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -5329,7 +5957,6 @@ impl LoginCryptoDiffieHellmanResponse {
     }
 
     // required bytes hmac = 10;
-
 
     pub fn get_hmac(&self) -> &[u8] {
         match self.hmac.as_ref() {
@@ -5373,16 +6000,24 @@ impl ::protobuf::Message for LoginCryptoDiffieHellmanResponse {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.hmac)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -5400,7 +6035,10 @@ impl ::protobuf::Message for LoginCryptoDiffieHellmanResponse {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.hmac.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -5439,35 +6077,40 @@ impl ::protobuf::Message for LoginCryptoDiffieHellmanResponse {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "hmac",
-                    |m: &LoginCryptoDiffieHellmanResponse| { &m.hmac },
-                    |m: &mut LoginCryptoDiffieHellmanResponse| { &mut m.hmac },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "hmac",
+                        |m: &LoginCryptoDiffieHellmanResponse| &m.hmac,
+                        |m: &mut LoginCryptoDiffieHellmanResponse| &mut m.hmac,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<LoginCryptoDiffieHellmanResponse>(
                     "LoginCryptoDiffieHellmanResponse",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static LoginCryptoDiffieHellmanResponse {
-        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoDiffieHellmanResponse> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const LoginCryptoDiffieHellmanResponse,
-        };
-        unsafe {
-            instance.get(LoginCryptoDiffieHellmanResponse::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<LoginCryptoDiffieHellmanResponse> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const LoginCryptoDiffieHellmanResponse,
+            };
+        unsafe { instance.get(LoginCryptoDiffieHellmanResponse::new) }
     }
 }
 
@@ -5490,7 +6133,7 @@ impl ::protobuf::reflect::ProtobufValue for LoginCryptoDiffieHellmanResponse {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct PoWResponseUnion {
     // message fields
     hash_cash: ::protobuf::SingularPtrField<PoWHashCashResponse>,
@@ -5512,9 +6155,10 @@ impl PoWResponseUnion {
 
     // optional .PoWHashCashResponse hash_cash = 10;
 
-
     pub fn get_hash_cash(&self) -> &PoWHashCashResponse {
-        self.hash_cash.as_ref().unwrap_or_else(|| PoWHashCashResponse::default_instance())
+        self.hash_cash
+            .as_ref()
+            .unwrap_or_else(|| PoWHashCashResponse::default_instance())
     }
     pub fn clear_hash_cash(&mut self) {
         self.hash_cash.clear();
@@ -5540,7 +6184,9 @@ impl PoWResponseUnion {
 
     // Take field
     pub fn take_hash_cash(&mut self) -> PoWHashCashResponse {
-        self.hash_cash.take().unwrap_or_else(|| PoWHashCashResponse::new())
+        self.hash_cash
+            .take()
+            .unwrap_or_else(|| PoWHashCashResponse::new())
     }
 }
 
@@ -5550,20 +6196,28 @@ impl ::protobuf::Message for PoWResponseUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.hash_cash)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -5582,7 +6236,10 @@ impl ::protobuf::Message for PoWResponseUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.hash_cash.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -5623,22 +6280,28 @@ impl ::protobuf::Message for PoWResponseUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<PoWHashCashResponse>>(
-                    "hash_cash",
-                    |m: &PoWResponseUnion| { &m.hash_cash },
-                    |m: &mut PoWResponseUnion| { &mut m.hash_cash },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<PoWHashCashResponse>,
+                    >(
+                        "hash_cash",
+                        |m: &PoWResponseUnion| &m.hash_cash,
+                        |m: &mut PoWResponseUnion| &mut m.hash_cash,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<PoWResponseUnion>(
                     "PoWResponseUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -5649,9 +6312,7 @@ impl ::protobuf::Message for PoWResponseUnion {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const PoWResponseUnion,
         };
-        unsafe {
-            instance.get(PoWResponseUnion::new)
-        }
+        unsafe { instance.get(PoWResponseUnion::new) }
     }
 }
 
@@ -5674,7 +6335,7 @@ impl ::protobuf::reflect::ProtobufValue for PoWResponseUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct PoWHashCashResponse {
     // message fields
     hash_suffix: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -5695,7 +6356,6 @@ impl PoWHashCashResponse {
     }
 
     // required bytes hash_suffix = 10;
-
 
     pub fn get_hash_suffix(&self) -> &[u8] {
         match self.hash_suffix.as_ref() {
@@ -5727,7 +6387,9 @@ impl PoWHashCashResponse {
 
     // Take field
     pub fn take_hash_suffix(&mut self) -> ::std::vec::Vec<u8> {
-        self.hash_suffix.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.hash_suffix
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -5739,16 +6401,24 @@ impl ::protobuf::Message for PoWHashCashResponse {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.hash_suffix)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -5766,7 +6436,10 @@ impl ::protobuf::Message for PoWHashCashResponse {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.hash_suffix.as_ref() {
             os.write_bytes(10, &v)?;
         }
@@ -5805,22 +6478,28 @@ impl ::protobuf::Message for PoWHashCashResponse {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "hash_suffix",
-                    |m: &PoWHashCashResponse| { &m.hash_suffix },
-                    |m: &mut PoWHashCashResponse| { &mut m.hash_suffix },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "hash_suffix",
+                        |m: &PoWHashCashResponse| &m.hash_suffix,
+                        |m: &mut PoWHashCashResponse| &mut m.hash_suffix,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<PoWHashCashResponse>(
                     "PoWHashCashResponse",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -5831,9 +6510,7 @@ impl ::protobuf::Message for PoWHashCashResponse {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const PoWHashCashResponse,
         };
-        unsafe {
-            instance.get(PoWHashCashResponse::new)
-        }
+        unsafe { instance.get(PoWHashCashResponse::new) }
     }
 }
 
@@ -5856,7 +6533,7 @@ impl ::protobuf::reflect::ProtobufValue for PoWHashCashResponse {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct CryptoResponseUnion {
     // message fields
     shannon: ::protobuf::SingularPtrField<CryptoShannonResponse>,
@@ -5879,9 +6556,10 @@ impl CryptoResponseUnion {
 
     // optional .CryptoShannonResponse shannon = 10;
 
-
     pub fn get_shannon(&self) -> &CryptoShannonResponse {
-        self.shannon.as_ref().unwrap_or_else(|| CryptoShannonResponse::default_instance())
+        self.shannon
+            .as_ref()
+            .unwrap_or_else(|| CryptoShannonResponse::default_instance())
     }
     pub fn clear_shannon(&mut self) {
         self.shannon.clear();
@@ -5907,14 +6585,17 @@ impl CryptoResponseUnion {
 
     // Take field
     pub fn take_shannon(&mut self) -> CryptoShannonResponse {
-        self.shannon.take().unwrap_or_else(|| CryptoShannonResponse::new())
+        self.shannon
+            .take()
+            .unwrap_or_else(|| CryptoShannonResponse::new())
     }
 
     // optional .CryptoRc4Sha1HmacResponse rc4_sha1_hmac = 20;
 
-
     pub fn get_rc4_sha1_hmac(&self) -> &CryptoRc4Sha1HmacResponse {
-        self.rc4_sha1_hmac.as_ref().unwrap_or_else(|| CryptoRc4Sha1HmacResponse::default_instance())
+        self.rc4_sha1_hmac
+            .as_ref()
+            .unwrap_or_else(|| CryptoRc4Sha1HmacResponse::default_instance())
     }
     pub fn clear_rc4_sha1_hmac(&mut self) {
         self.rc4_sha1_hmac.clear();
@@ -5940,7 +6621,9 @@ impl CryptoResponseUnion {
 
     // Take field
     pub fn take_rc4_sha1_hmac(&mut self) -> CryptoRc4Sha1HmacResponse {
-        self.rc4_sha1_hmac.take().unwrap_or_else(|| CryptoRc4Sha1HmacResponse::new())
+        self.rc4_sha1_hmac
+            .take()
+            .unwrap_or_else(|| CryptoRc4Sha1HmacResponse::new())
     }
 }
 
@@ -5950,28 +6633,40 @@ impl ::protobuf::Message for CryptoResponseUnion {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.rc4_sha1_hmac {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 10 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.shannon)?;
-                },
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.rc4_sha1_hmac)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.rc4_sha1_hmac,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -5994,7 +6689,10 @@ impl ::protobuf::Message for CryptoResponseUnion {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.shannon.as_ref() {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -6040,27 +6738,38 @@ impl ::protobuf::Message for CryptoResponseUnion {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<CryptoShannonResponse>>(
-                    "shannon",
-                    |m: &CryptoResponseUnion| { &m.shannon },
-                    |m: &mut CryptoResponseUnion| { &mut m.shannon },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<CryptoRc4Sha1HmacResponse>>(
-                    "rc4_sha1_hmac",
-                    |m: &CryptoResponseUnion| { &m.rc4_sha1_hmac },
-                    |m: &mut CryptoResponseUnion| { &mut m.rc4_sha1_hmac },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<CryptoShannonResponse>,
+                    >(
+                        "shannon",
+                        |m: &CryptoResponseUnion| &m.shannon,
+                        |m: &mut CryptoResponseUnion| &mut m.shannon,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<CryptoRc4Sha1HmacResponse>,
+                    >(
+                        "rc4_sha1_hmac",
+                        |m: &CryptoResponseUnion| &m.rc4_sha1_hmac,
+                        |m: &mut CryptoResponseUnion| &mut m.rc4_sha1_hmac,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<CryptoResponseUnion>(
                     "CryptoResponseUnion",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -6071,9 +6780,7 @@ impl ::protobuf::Message for CryptoResponseUnion {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const CryptoResponseUnion,
         };
-        unsafe {
-            instance.get(CryptoResponseUnion::new)
-        }
+        unsafe { instance.get(CryptoResponseUnion::new) }
     }
 }
 
@@ -6097,7 +6804,7 @@ impl ::protobuf::reflect::ProtobufValue for CryptoResponseUnion {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct CryptoShannonResponse {
     // message fields
     dummy: ::std::option::Option<i32>,
@@ -6118,7 +6825,6 @@ impl CryptoShannonResponse {
     }
 
     // optional int32 dummy = 1;
-
 
     pub fn get_dummy(&self) -> i32 {
         self.dummy.unwrap_or(0)
@@ -6142,20 +6848,30 @@ impl ::protobuf::Message for CryptoShannonResponse {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.dummy = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -6173,7 +6889,10 @@ impl ::protobuf::Message for CryptoShannonResponse {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.dummy {
             os.write_int32(1, v)?;
         }
@@ -6212,35 +6931,38 @@ impl ::protobuf::Message for CryptoShannonResponse {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "dummy",
-                    |m: &CryptoShannonResponse| { &m.dummy },
-                    |m: &mut CryptoShannonResponse| { &mut m.dummy },
+                    |m: &CryptoShannonResponse| &m.dummy,
+                    |m: &mut CryptoShannonResponse| &mut m.dummy,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<CryptoShannonResponse>(
                     "CryptoShannonResponse",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static CryptoShannonResponse {
-        static mut instance: ::protobuf::lazy::Lazy<CryptoShannonResponse> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const CryptoShannonResponse,
-        };
-        unsafe {
-            instance.get(CryptoShannonResponse::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<CryptoShannonResponse> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const CryptoShannonResponse,
+            };
+        unsafe { instance.get(CryptoShannonResponse::new) }
     }
 }
 
@@ -6263,7 +6985,7 @@ impl ::protobuf::reflect::ProtobufValue for CryptoShannonResponse {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct CryptoRc4Sha1HmacResponse {
     // message fields
     dummy: ::std::option::Option<i32>,
@@ -6284,7 +7006,6 @@ impl CryptoRc4Sha1HmacResponse {
     }
 
     // optional int32 dummy = 1;
-
 
     pub fn get_dummy(&self) -> i32 {
         self.dummy.unwrap_or(0)
@@ -6308,20 +7029,30 @@ impl ::protobuf::Message for CryptoRc4Sha1HmacResponse {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.dummy = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -6339,7 +7070,10 @@ impl ::protobuf::Message for CryptoRc4Sha1HmacResponse {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.dummy {
             os.write_int32(1, v)?;
         }
@@ -6378,35 +7112,38 @@ impl ::protobuf::Message for CryptoRc4Sha1HmacResponse {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "dummy",
-                    |m: &CryptoRc4Sha1HmacResponse| { &m.dummy },
-                    |m: &mut CryptoRc4Sha1HmacResponse| { &mut m.dummy },
+                    |m: &CryptoRc4Sha1HmacResponse| &m.dummy,
+                    |m: &mut CryptoRc4Sha1HmacResponse| &mut m.dummy,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<CryptoRc4Sha1HmacResponse>(
                     "CryptoRc4Sha1HmacResponse",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static CryptoRc4Sha1HmacResponse {
-        static mut instance: ::protobuf::lazy::Lazy<CryptoRc4Sha1HmacResponse> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const CryptoRc4Sha1HmacResponse,
-        };
-        unsafe {
-            instance.get(CryptoRc4Sha1HmacResponse::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<CryptoRc4Sha1HmacResponse> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const CryptoRc4Sha1HmacResponse,
+            };
+        unsafe { instance.get(CryptoRc4Sha1HmacResponse::new) }
     }
 }
 
@@ -6429,7 +7166,7 @@ impl ::protobuf::reflect::ProtobufValue for CryptoRc4Sha1HmacResponse {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Product {
     PRODUCT_CLIENT = 0,
     PRODUCT_LIBSPOTIFY = 1,
@@ -6450,7 +7187,7 @@ impl ::protobuf::ProtobufEnum for Product {
             2 => ::std::option::Option::Some(Product::PRODUCT_MOBILE),
             3 => ::std::option::Option::Some(Product::PRODUCT_PARTNER),
             5 => ::std::option::Option::Some(Product::PRODUCT_LIBSPOTIFY_EMBEDDED),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -6466,10 +7203,11 @@ impl ::protobuf::ProtobufEnum for Product {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Product", file_descriptor_proto())
@@ -6478,8 +7216,7 @@ impl ::protobuf::ProtobufEnum for Product {
     }
 }
 
-impl ::std::marker::Copy for Product {
-}
+impl ::std::marker::Copy for Product {}
 
 impl ::std::default::Default for Product {
     fn default() -> Self {
@@ -6493,7 +7230,7 @@ impl ::protobuf::reflect::ProtobufValue for Product {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ProductFlags {
     PRODUCT_FLAG_NONE = 0,
     PRODUCT_FLAG_DEV_BUILD = 1,
@@ -6508,7 +7245,7 @@ impl ::protobuf::ProtobufEnum for ProductFlags {
         match value {
             0 => ::std::option::Option::Some(ProductFlags::PRODUCT_FLAG_NONE),
             1 => ::std::option::Option::Some(ProductFlags::PRODUCT_FLAG_DEV_BUILD),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -6521,10 +7258,11 @@ impl ::protobuf::ProtobufEnum for ProductFlags {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("ProductFlags", file_descriptor_proto())
@@ -6533,8 +7271,7 @@ impl ::protobuf::ProtobufEnum for ProductFlags {
     }
 }
 
-impl ::std::marker::Copy for ProductFlags {
-}
+impl ::std::marker::Copy for ProductFlags {}
 
 impl ::std::default::Default for ProductFlags {
     fn default() -> Self {
@@ -6548,7 +7285,7 @@ impl ::protobuf::reflect::ProtobufValue for ProductFlags {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Platform {
     PLATFORM_WIN32_X86 = 0,
     PLATFORM_OSX_X86 = 1,
@@ -6607,7 +7344,7 @@ impl ::protobuf::ProtobufEnum for Platform {
             21 => ::std::option::Option::Some(Platform::PLATFORM_ONKYO_ARM),
             22 => ::std::option::Option::Some(Platform::PLATFORM_QNXNTO_ARM),
             23 => ::std::option::Option::Some(Platform::PLATFORM_BCO_ARM),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -6642,10 +7379,11 @@ impl ::protobuf::ProtobufEnum for Platform {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Platform", file_descriptor_proto())
@@ -6654,8 +7392,7 @@ impl ::protobuf::ProtobufEnum for Platform {
     }
 }
 
-impl ::std::marker::Copy for Platform {
-}
+impl ::std::marker::Copy for Platform {}
 
 impl ::std::default::Default for Platform {
     fn default() -> Self {
@@ -6669,7 +7406,7 @@ impl ::protobuf::reflect::ProtobufValue for Platform {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Fingerprint {
     FINGERPRINT_GRAIN = 0,
     FINGERPRINT_HMAC_RIPEMD = 1,
@@ -6684,7 +7421,7 @@ impl ::protobuf::ProtobufEnum for Fingerprint {
         match value {
             0 => ::std::option::Option::Some(Fingerprint::FINGERPRINT_GRAIN),
             1 => ::std::option::Option::Some(Fingerprint::FINGERPRINT_HMAC_RIPEMD),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -6697,10 +7434,11 @@ impl ::protobuf::ProtobufEnum for Fingerprint {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Fingerprint", file_descriptor_proto())
@@ -6709,8 +7447,7 @@ impl ::protobuf::ProtobufEnum for Fingerprint {
     }
 }
 
-impl ::std::marker::Copy for Fingerprint {
-}
+impl ::std::marker::Copy for Fingerprint {}
 
 impl ::std::default::Default for Fingerprint {
     fn default() -> Self {
@@ -6724,7 +7461,7 @@ impl ::protobuf::reflect::ProtobufValue for Fingerprint {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Cryptosuite {
     CRYPTO_SUITE_SHANNON = 0,
     CRYPTO_SUITE_RC4_SHA1_HMAC = 1,
@@ -6739,7 +7476,7 @@ impl ::protobuf::ProtobufEnum for Cryptosuite {
         match value {
             0 => ::std::option::Option::Some(Cryptosuite::CRYPTO_SUITE_SHANNON),
             1 => ::std::option::Option::Some(Cryptosuite::CRYPTO_SUITE_RC4_SHA1_HMAC),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -6752,10 +7489,11 @@ impl ::protobuf::ProtobufEnum for Cryptosuite {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Cryptosuite", file_descriptor_proto())
@@ -6764,8 +7502,7 @@ impl ::protobuf::ProtobufEnum for Cryptosuite {
     }
 }
 
-impl ::std::marker::Copy for Cryptosuite {
-}
+impl ::std::marker::Copy for Cryptosuite {}
 
 impl ::std::default::Default for Cryptosuite {
     fn default() -> Self {
@@ -6779,7 +7516,7 @@ impl ::protobuf::reflect::ProtobufValue for Cryptosuite {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Powscheme {
     POW_HASH_CASH = 0,
 }
@@ -6792,22 +7529,21 @@ impl ::protobuf::ProtobufEnum for Powscheme {
     fn from_i32(value: i32) -> ::std::option::Option<Powscheme> {
         match value {
             0 => ::std::option::Option::Some(Powscheme::POW_HASH_CASH),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
     fn values() -> &'static [Self] {
-        static values: &'static [Powscheme] = &[
-            Powscheme::POW_HASH_CASH,
-        ];
+        static values: &'static [Powscheme] = &[Powscheme::POW_HASH_CASH];
         values
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Powscheme", file_descriptor_proto())
@@ -6816,8 +7552,7 @@ impl ::protobuf::ProtobufEnum for Powscheme {
     }
 }
 
-impl ::std::marker::Copy for Powscheme {
-}
+impl ::std::marker::Copy for Powscheme {}
 
 impl ::std::default::Default for Powscheme {
     fn default() -> Self {
@@ -6831,7 +7566,7 @@ impl ::protobuf::reflect::ProtobufValue for Powscheme {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ErrorCode {
     ProtocolError = 0,
     TryAnotherAP = 2,
@@ -6864,7 +7599,7 @@ impl ::protobuf::ProtobufEnum for ErrorCode {
             15 => ::std::option::Option::Some(ErrorCode::ExtraVerificationRequired),
             16 => ::std::option::Option::Some(ErrorCode::InvalidAppKey),
             17 => ::std::option::Option::Some(ErrorCode::ApplicationBanned),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -6886,10 +7621,11 @@ impl ::protobuf::ProtobufEnum for ErrorCode {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("ErrorCode", file_descriptor_proto())
@@ -6898,8 +7634,7 @@ impl ::protobuf::ProtobufEnum for ErrorCode {
     }
 }
 
-impl ::std::marker::Copy for ErrorCode {
-}
+impl ::std::marker::Copy for ErrorCode {}
 
 impl ::std::default::Default for ErrorCode {
     fn default() -> Self {
@@ -7007,7 +7742,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -7017,9 +7754,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,4 +1,4 @@
-extern crate protobuf;
+#![allow(rust_2018_idioms)] // because of generated code
 // This file is parsed by build.rs
 // Each included module will be compiled from the matching .proto definition.
 pub mod authentication;

--- a/protocol/src/lib.rs
+++ b/protocol/src/lib.rs
@@ -1,4 +1,5 @@
 #![allow(rust_2018_idioms)] // because of generated code
+
 // This file is parsed by build.rs
 // Each included module will be compiled from the matching .proto definition.
 pub mod authentication;

--- a/protocol/src/mercury.rs
+++ b/protocol/src/mercury.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct MercuryMultiGetRequest {
     // message fields
     request: ::protobuf::RepeatedField<MercuryRequest>,
@@ -47,7 +47,6 @@ impl MercuryMultiGetRequest {
     }
 
     // repeated .MercuryRequest request = 1;
-
 
     pub fn get_request(&self) -> &[MercuryRequest] {
         &self.request
@@ -78,20 +77,28 @@ impl ::protobuf::Message for MercuryMultiGetRequest {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.request)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -104,18 +111,21 @@ impl ::protobuf::Message for MercuryMultiGetRequest {
         for value in &self.request {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         for v in &self.request {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -151,35 +161,40 @@ impl ::protobuf::Message for MercuryMultiGetRequest {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<MercuryRequest>>(
-                    "request",
-                    |m: &MercuryMultiGetRequest| { &m.request },
-                    |m: &mut MercuryMultiGetRequest| { &mut m.request },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<MercuryRequest>,
+                    >(
+                        "request",
+                        |m: &MercuryMultiGetRequest| &m.request,
+                        |m: &mut MercuryMultiGetRequest| &mut m.request,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<MercuryMultiGetRequest>(
                     "MercuryMultiGetRequest",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static MercuryMultiGetRequest {
-        static mut instance: ::protobuf::lazy::Lazy<MercuryMultiGetRequest> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const MercuryMultiGetRequest,
-        };
-        unsafe {
-            instance.get(MercuryMultiGetRequest::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<MercuryMultiGetRequest> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const MercuryMultiGetRequest,
+            };
+        unsafe { instance.get(MercuryMultiGetRequest::new) }
     }
 }
 
@@ -202,7 +217,7 @@ impl ::protobuf::reflect::ProtobufValue for MercuryMultiGetRequest {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct MercuryMultiGetReply {
     // message fields
     reply: ::protobuf::RepeatedField<MercuryReply>,
@@ -223,7 +238,6 @@ impl MercuryMultiGetReply {
     }
 
     // repeated .MercuryReply reply = 1;
-
 
     pub fn get_reply(&self) -> &[MercuryReply] {
         &self.reply
@@ -254,20 +268,28 @@ impl ::protobuf::Message for MercuryMultiGetReply {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.reply)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -280,18 +302,21 @@ impl ::protobuf::Message for MercuryMultiGetReply {
         for value in &self.reply {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         for v in &self.reply {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -327,35 +352,40 @@ impl ::protobuf::Message for MercuryMultiGetReply {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<MercuryReply>>(
-                    "reply",
-                    |m: &MercuryMultiGetReply| { &m.reply },
-                    |m: &mut MercuryMultiGetReply| { &mut m.reply },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<MercuryReply>,
+                    >(
+                        "reply",
+                        |m: &MercuryMultiGetReply| &m.reply,
+                        |m: &mut MercuryMultiGetReply| &mut m.reply,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<MercuryMultiGetReply>(
                     "MercuryMultiGetReply",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static MercuryMultiGetReply {
-        static mut instance: ::protobuf::lazy::Lazy<MercuryMultiGetReply> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const MercuryMultiGetReply,
-        };
-        unsafe {
-            instance.get(MercuryMultiGetReply::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<MercuryMultiGetReply> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const MercuryMultiGetReply,
+            };
+        unsafe { instance.get(MercuryMultiGetReply::new) }
     }
 }
 
@@ -378,7 +408,7 @@ impl ::protobuf::reflect::ProtobufValue for MercuryMultiGetReply {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct MercuryRequest {
     // message fields
     uri: ::protobuf::SingularField<::std::string::String>,
@@ -402,7 +432,6 @@ impl MercuryRequest {
     }
 
     // optional string uri = 1;
-
 
     pub fn get_uri(&self) -> &str {
         match self.uri.as_ref() {
@@ -434,11 +463,12 @@ impl MercuryRequest {
 
     // Take field
     pub fn take_uri(&mut self) -> ::std::string::String {
-        self.uri.take().unwrap_or_else(|| ::std::string::String::new())
+        self.uri
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string content_type = 2;
-
 
     pub fn get_content_type(&self) -> &str {
         match self.content_type.as_ref() {
@@ -470,11 +500,12 @@ impl MercuryRequest {
 
     // Take field
     pub fn take_content_type(&mut self) -> ::std::string::String {
-        self.content_type.take().unwrap_or_else(|| ::std::string::String::new())
+        self.content_type
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bytes body = 3;
-
 
     pub fn get_body(&self) -> &[u8] {
         match self.body.as_ref() {
@@ -510,7 +541,6 @@ impl MercuryRequest {
     }
 
     // optional bytes etag = 4;
-
 
     pub fn get_etag(&self) -> &[u8] {
         match self.etag.as_ref() {
@@ -551,25 +581,37 @@ impl ::protobuf::Message for MercuryRequest {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.uri)?;
-                },
+                }
                 2 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.content_type)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.content_type,
+                    )?;
+                }
                 3 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.body)?;
-                },
+                }
                 4 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.etag)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -596,7 +638,10 @@ impl ::protobuf::Message for MercuryRequest {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.uri.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -644,37 +689,58 @@ impl ::protobuf::Message for MercuryRequest {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "uri",
-                    |m: &MercuryRequest| { &m.uri },
-                    |m: &mut MercuryRequest| { &mut m.uri },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "content_type",
-                    |m: &MercuryRequest| { &m.content_type },
-                    |m: &mut MercuryRequest| { &mut m.content_type },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "body",
-                    |m: &MercuryRequest| { &m.body },
-                    |m: &mut MercuryRequest| { &mut m.body },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "etag",
-                    |m: &MercuryRequest| { &m.etag },
-                    |m: &mut MercuryRequest| { &mut m.etag },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "uri",
+                        |m: &MercuryRequest| &m.uri,
+                        |m: &mut MercuryRequest| &mut m.uri,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "content_type",
+                        |m: &MercuryRequest| &m.content_type,
+                        |m: &mut MercuryRequest| &mut m.content_type,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "body",
+                        |m: &MercuryRequest| &m.body,
+                        |m: &mut MercuryRequest| &mut m.body,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "etag",
+                        |m: &MercuryRequest| &m.etag,
+                        |m: &mut MercuryRequest| &mut m.etag,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<MercuryRequest>(
                     "MercuryRequest",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -685,9 +751,7 @@ impl ::protobuf::Message for MercuryRequest {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const MercuryRequest,
         };
-        unsafe {
-            instance.get(MercuryRequest::new)
-        }
+        unsafe { instance.get(MercuryRequest::new) }
     }
 }
 
@@ -713,7 +777,7 @@ impl ::protobuf::reflect::ProtobufValue for MercuryRequest {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct MercuryReply {
     // message fields
     status_code: ::std::option::Option<i32>,
@@ -741,7 +805,6 @@ impl MercuryReply {
 
     // optional sint32 status_code = 1;
 
-
     pub fn get_status_code(&self) -> i32 {
         self.status_code.unwrap_or(0)
     }
@@ -759,7 +822,6 @@ impl MercuryReply {
     }
 
     // optional string status_message = 2;
-
 
     pub fn get_status_message(&self) -> &str {
         match self.status_message.as_ref() {
@@ -791,14 +853,16 @@ impl MercuryReply {
 
     // Take field
     pub fn take_status_message(&mut self) -> ::std::string::String {
-        self.status_message.take().unwrap_or_else(|| ::std::string::String::new())
+        self.status_message
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional .MercuryReply.CachePolicy cache_policy = 3;
 
-
     pub fn get_cache_policy(&self) -> MercuryReply_CachePolicy {
-        self.cache_policy.unwrap_or(MercuryReply_CachePolicy::CACHE_NO)
+        self.cache_policy
+            .unwrap_or(MercuryReply_CachePolicy::CACHE_NO)
     }
     pub fn clear_cache_policy(&mut self) {
         self.cache_policy = ::std::option::Option::None;
@@ -814,7 +878,6 @@ impl MercuryReply {
     }
 
     // optional sint32 ttl = 4;
-
 
     pub fn get_ttl(&self) -> i32 {
         self.ttl.unwrap_or(0)
@@ -833,7 +896,6 @@ impl MercuryReply {
     }
 
     // optional bytes etag = 5;
-
 
     pub fn get_etag(&self) -> &[u8] {
         match self.etag.as_ref() {
@@ -870,7 +932,6 @@ impl MercuryReply {
 
     // optional string content_type = 6;
 
-
     pub fn get_content_type(&self) -> &str {
         match self.content_type.as_ref() {
             Some(v) => &v,
@@ -901,11 +962,12 @@ impl MercuryReply {
 
     // Take field
     pub fn take_content_type(&mut self) -> ::std::string::String {
-        self.content_type.take().unwrap_or_else(|| ::std::string::String::new())
+        self.content_type
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bytes body = 7;
-
 
     pub fn get_body(&self) -> &[u8] {
         match self.body.as_ref() {
@@ -946,42 +1008,66 @@ impl ::protobuf::Message for MercuryReply {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.status_code = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.status_message)?;
-                },
-                3 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.cache_policy, 3, &mut self.unknown_fields)?
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.status_message,
+                    )?;
+                }
+                3 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.cache_policy,
+                    3,
+                    &mut self.unknown_fields,
+                )?,
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.ttl = ::std::option::Option::Some(tmp);
-                },
+                }
                 5 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.etag)?;
-                },
+                }
                 6 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.content_type)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.content_type,
+                    )?;
+                }
                 7 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.body)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1017,7 +1103,10 @@ impl ::protobuf::Message for MercuryReply {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.status_code {
             os.write_sint32(1, v)?;
         }
@@ -1074,52 +1163,82 @@ impl ::protobuf::Message for MercuryReply {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "status_code",
-                    |m: &MercuryReply| { &m.status_code },
-                    |m: &mut MercuryReply| { &mut m.status_code },
+                    |m: &MercuryReply| &m.status_code,
+                    |m: &mut MercuryReply| &mut m.status_code,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "status_message",
-                    |m: &MercuryReply| { &m.status_message },
-                    |m: &mut MercuryReply| { &mut m.status_message },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<MercuryReply_CachePolicy>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "status_message",
+                        |m: &MercuryReply| &m.status_message,
+                        |m: &mut MercuryReply| &mut m.status_message,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<MercuryReply_CachePolicy>,
+                >(
                     "cache_policy",
-                    |m: &MercuryReply| { &m.cache_policy },
-                    |m: &mut MercuryReply| { &mut m.cache_policy },
+                    |m: &MercuryReply| &m.cache_policy,
+                    |m: &mut MercuryReply| &mut m.cache_policy,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "ttl",
-                    |m: &MercuryReply| { &m.ttl },
-                    |m: &mut MercuryReply| { &mut m.ttl },
+                    |m: &MercuryReply| &m.ttl,
+                    |m: &mut MercuryReply| &mut m.ttl,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "etag",
-                    |m: &MercuryReply| { &m.etag },
-                    |m: &mut MercuryReply| { &mut m.etag },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "content_type",
-                    |m: &MercuryReply| { &m.content_type },
-                    |m: &mut MercuryReply| { &mut m.content_type },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "body",
-                    |m: &MercuryReply| { &m.body },
-                    |m: &mut MercuryReply| { &mut m.body },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "etag",
+                        |m: &MercuryReply| &m.etag,
+                        |m: &mut MercuryReply| &mut m.etag,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "content_type",
+                        |m: &MercuryReply| &m.content_type,
+                        |m: &mut MercuryReply| &mut m.content_type,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "body",
+                        |m: &MercuryReply| &m.body,
+                        |m: &mut MercuryReply| &mut m.body,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<MercuryReply>(
                     "MercuryReply",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1130,9 +1249,7 @@ impl ::protobuf::Message for MercuryReply {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const MercuryReply,
         };
-        unsafe {
-            instance.get(MercuryReply::new)
-        }
+        unsafe { instance.get(MercuryReply::new) }
     }
 }
 
@@ -1161,7 +1278,7 @@ impl ::protobuf::reflect::ProtobufValue for MercuryReply {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum MercuryReply_CachePolicy {
     CACHE_NO = 1,
     CACHE_PRIVATE = 2,
@@ -1178,7 +1295,7 @@ impl ::protobuf::ProtobufEnum for MercuryReply_CachePolicy {
             1 => ::std::option::Option::Some(MercuryReply_CachePolicy::CACHE_NO),
             2 => ::std::option::Option::Some(MercuryReply_CachePolicy::CACHE_PRIVATE),
             3 => ::std::option::Option::Some(MercuryReply_CachePolicy::CACHE_PUBLIC),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -1192,20 +1309,23 @@ impl ::protobuf::ProtobufEnum for MercuryReply_CachePolicy {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("MercuryReply_CachePolicy", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "MercuryReply_CachePolicy",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for MercuryReply_CachePolicy {
-}
+impl ::std::marker::Copy for MercuryReply_CachePolicy {}
 
 // Note, `Default` is implemented although default value is not 0
 impl ::std::default::Default for MercuryReply_CachePolicy {
@@ -1220,7 +1340,7 @@ impl ::protobuf::reflect::ProtobufValue for MercuryReply_CachePolicy {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Header {
     // message fields
     uri: ::protobuf::SingularField<::std::string::String>,
@@ -1245,7 +1365,6 @@ impl Header {
     }
 
     // optional string uri = 1;
-
 
     pub fn get_uri(&self) -> &str {
         match self.uri.as_ref() {
@@ -1277,11 +1396,12 @@ impl Header {
 
     // Take field
     pub fn take_uri(&mut self) -> ::std::string::String {
-        self.uri.take().unwrap_or_else(|| ::std::string::String::new())
+        self.uri
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string content_type = 2;
-
 
     pub fn get_content_type(&self) -> &str {
         match self.content_type.as_ref() {
@@ -1313,11 +1433,12 @@ impl Header {
 
     // Take field
     pub fn take_content_type(&mut self) -> ::std::string::String {
-        self.content_type.take().unwrap_or_else(|| ::std::string::String::new())
+        self.content_type
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string method = 3;
-
 
     pub fn get_method(&self) -> &str {
         match self.method.as_ref() {
@@ -1349,11 +1470,12 @@ impl Header {
 
     // Take field
     pub fn take_method(&mut self) -> ::std::string::String {
-        self.method.take().unwrap_or_else(|| ::std::string::String::new())
+        self.method
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional sint32 status_code = 4;
-
 
     pub fn get_status_code(&self) -> i32 {
         self.status_code.unwrap_or(0)
@@ -1372,7 +1494,6 @@ impl Header {
     }
 
     // repeated .UserField user_fields = 6;
-
 
     pub fn get_user_fields(&self) -> &[UserField] {
         &self.user_fields
@@ -1403,36 +1524,54 @@ impl ::protobuf::Message for Header {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.uri)?;
-                },
+                }
                 2 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.content_type)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.content_type,
+                    )?;
+                }
                 3 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.method)?;
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.status_code = ::std::option::Option::Some(tmp);
-                },
+                }
                 6 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.user_fields)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.user_fields,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1457,13 +1596,16 @@ impl ::protobuf::Message for Header {
         for value in &self.user_fields {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.uri.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -1480,7 +1622,7 @@ impl ::protobuf::Message for Header {
             os.write_tag(6, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -1516,42 +1658,62 @@ impl ::protobuf::Message for Header {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "uri",
-                    |m: &Header| { &m.uri },
-                    |m: &mut Header| { &mut m.uri },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "content_type",
-                    |m: &Header| { &m.content_type },
-                    |m: &mut Header| { &mut m.content_type },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "method",
-                    |m: &Header| { &m.method },
-                    |m: &mut Header| { &mut m.method },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >("uri", |m: &Header| &m.uri, |m: &mut Header| &mut m.uri),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "content_type",
+                        |m: &Header| &m.content_type,
+                        |m: &mut Header| &mut m.content_type,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "method",
+                        |m: &Header| &m.method,
+                        |m: &mut Header| &mut m.method,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "status_code",
-                    |m: &Header| { &m.status_code },
-                    |m: &mut Header| { &mut m.status_code },
+                    |m: &Header| &m.status_code,
+                    |m: &mut Header| &mut m.status_code,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<UserField>>(
-                    "user_fields",
-                    |m: &Header| { &m.user_fields },
-                    |m: &mut Header| { &mut m.user_fields },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<UserField>,
+                    >(
+                        "user_fields",
+                        |m: &Header| &m.user_fields,
+                        |m: &mut Header| &mut m.user_fields,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Header>(
                     "Header",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1562,9 +1724,7 @@ impl ::protobuf::Message for Header {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Header,
         };
-        unsafe {
-            instance.get(Header::new)
-        }
+        unsafe { instance.get(Header::new) }
     }
 }
 
@@ -1591,7 +1751,7 @@ impl ::protobuf::reflect::ProtobufValue for Header {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct UserField {
     // message fields
     key: ::protobuf::SingularField<::std::string::String>,
@@ -1613,7 +1773,6 @@ impl UserField {
     }
 
     // optional string key = 1;
-
 
     pub fn get_key(&self) -> &str {
         match self.key.as_ref() {
@@ -1645,11 +1804,12 @@ impl UserField {
 
     // Take field
     pub fn take_key(&mut self) -> ::std::string::String {
-        self.key.take().unwrap_or_else(|| ::std::string::String::new())
+        self.key
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bytes value = 2;
-
 
     pub fn get_value(&self) -> &[u8] {
         match self.value.as_ref() {
@@ -1690,19 +1850,27 @@ impl ::protobuf::Message for UserField {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.key)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.value)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1723,7 +1891,10 @@ impl ::protobuf::Message for UserField {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.key.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -1765,27 +1936,38 @@ impl ::protobuf::Message for UserField {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "key",
-                    |m: &UserField| { &m.key },
-                    |m: &mut UserField| { &mut m.key },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "value",
-                    |m: &UserField| { &m.value },
-                    |m: &mut UserField| { &mut m.value },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "key",
+                        |m: &UserField| &m.key,
+                        |m: &mut UserField| &mut m.key,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "value",
+                        |m: &UserField| &m.value,
+                        |m: &mut UserField| &mut m.value,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<UserField>(
                     "UserField",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1796,9 +1978,7 @@ impl ::protobuf::Message for UserField {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const UserField,
         };
-        unsafe {
-            instance.get(UserField::new)
-        }
+        unsafe { instance.get(UserField::new) }
     }
 }
 
@@ -1843,7 +2023,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x12\x0f\n\x05value\x18\x02\x20\x01(\x0cB\0:\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -1853,9 +2035,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/metadata.rs
+++ b/protocol/src/metadata.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct TopTracks {
     // message fields
     country: ::protobuf::SingularField<::std::string::String>,
@@ -48,7 +48,6 @@ impl TopTracks {
     }
 
     // optional string country = 1;
-
 
     pub fn get_country(&self) -> &str {
         match self.country.as_ref() {
@@ -80,11 +79,12 @@ impl TopTracks {
 
     // Take field
     pub fn take_country(&mut self) -> ::std::string::String {
-        self.country.take().unwrap_or_else(|| ::std::string::String::new())
+        self.country
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // repeated .Track track = 2;
-
 
     pub fn get_track(&self) -> &[Track] {
         &self.track
@@ -115,23 +115,31 @@ impl ::protobuf::Message for TopTracks {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.country)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.track)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -147,13 +155,16 @@ impl ::protobuf::Message for TopTracks {
         for value in &self.track {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.country.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -161,7 +172,7 @@ impl ::protobuf::Message for TopTracks {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -197,27 +208,38 @@ impl ::protobuf::Message for TopTracks {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "country",
-                    |m: &TopTracks| { &m.country },
-                    |m: &mut TopTracks| { &mut m.country },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Track>>(
-                    "track",
-                    |m: &TopTracks| { &m.track },
-                    |m: &mut TopTracks| { &mut m.track },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "country",
+                        |m: &TopTracks| &m.country,
+                        |m: &mut TopTracks| &mut m.country,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Track>,
+                    >(
+                        "track",
+                        |m: &TopTracks| &m.track,
+                        |m: &mut TopTracks| &mut m.track,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<TopTracks>(
                     "TopTracks",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -228,9 +250,7 @@ impl ::protobuf::Message for TopTracks {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TopTracks,
         };
-        unsafe {
-            instance.get(TopTracks::new)
-        }
+        unsafe { instance.get(TopTracks::new) }
     }
 }
 
@@ -254,7 +274,7 @@ impl ::protobuf::reflect::ProtobufValue for TopTracks {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ActivityPeriod {
     // message fields
     start_year: ::std::option::Option<i32>,
@@ -278,7 +298,6 @@ impl ActivityPeriod {
 
     // optional sint32 start_year = 1;
 
-
     pub fn get_start_year(&self) -> i32 {
         self.start_year.unwrap_or(0)
     }
@@ -297,7 +316,6 @@ impl ActivityPeriod {
 
     // optional sint32 end_year = 2;
 
-
     pub fn get_end_year(&self) -> i32 {
         self.end_year.unwrap_or(0)
     }
@@ -315,7 +333,6 @@ impl ActivityPeriod {
     }
 
     // optional sint32 decade = 3;
-
 
     pub fn get_decade(&self) -> i32 {
         self.decade.unwrap_or(0)
@@ -339,34 +356,48 @@ impl ::protobuf::Message for ActivityPeriod {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.start_year = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.end_year = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.decade = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -390,7 +421,10 @@ impl ::protobuf::Message for ActivityPeriod {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.start_year {
             os.write_sint32(1, v)?;
         }
@@ -435,32 +469,42 @@ impl ::protobuf::Message for ActivityPeriod {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "start_year",
-                    |m: &ActivityPeriod| { &m.start_year },
-                    |m: &mut ActivityPeriod| { &mut m.start_year },
+                    |m: &ActivityPeriod| &m.start_year,
+                    |m: &mut ActivityPeriod| &mut m.start_year,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "end_year",
-                    |m: &ActivityPeriod| { &m.end_year },
-                    |m: &mut ActivityPeriod| { &mut m.end_year },
+                    |m: &ActivityPeriod| &m.end_year,
+                    |m: &mut ActivityPeriod| &mut m.end_year,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "decade",
-                    |m: &ActivityPeriod| { &m.decade },
-                    |m: &mut ActivityPeriod| { &mut m.decade },
+                    |m: &ActivityPeriod| &m.decade,
+                    |m: &mut ActivityPeriod| &mut m.decade,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ActivityPeriod>(
                     "ActivityPeriod",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -471,9 +515,7 @@ impl ::protobuf::Message for ActivityPeriod {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ActivityPeriod,
         };
-        unsafe {
-            instance.get(ActivityPeriod::new)
-        }
+        unsafe { instance.get(ActivityPeriod::new) }
     }
 }
 
@@ -498,7 +540,7 @@ impl ::protobuf::reflect::ProtobufValue for ActivityPeriod {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Artist {
     // message fields
     gid: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -536,7 +578,6 @@ impl Artist {
 
     // optional bytes gid = 1;
 
-
     pub fn get_gid(&self) -> &[u8] {
         match self.gid.as_ref() {
             Some(v) => &v,
@@ -572,7 +613,6 @@ impl Artist {
 
     // optional string name = 2;
 
-
     pub fn get_name(&self) -> &str {
         match self.name.as_ref() {
             Some(v) => &v,
@@ -603,11 +643,12 @@ impl Artist {
 
     // Take field
     pub fn take_name(&mut self) -> ::std::string::String {
-        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional sint32 popularity = 3;
-
 
     pub fn get_popularity(&self) -> i32 {
         self.popularity.unwrap_or(0)
@@ -626,7 +667,6 @@ impl Artist {
     }
 
     // repeated .TopTracks top_track = 4;
-
 
     pub fn get_top_track(&self) -> &[TopTracks] {
         &self.top_track
@@ -652,7 +692,6 @@ impl Artist {
 
     // repeated .AlbumGroup album_group = 5;
 
-
     pub fn get_album_group(&self) -> &[AlbumGroup] {
         &self.album_group
     }
@@ -676,7 +715,6 @@ impl Artist {
     }
 
     // repeated .AlbumGroup single_group = 6;
-
 
     pub fn get_single_group(&self) -> &[AlbumGroup] {
         &self.single_group
@@ -702,7 +740,6 @@ impl Artist {
 
     // repeated .AlbumGroup compilation_group = 7;
 
-
     pub fn get_compilation_group(&self) -> &[AlbumGroup] {
         &self.compilation_group
     }
@@ -722,11 +759,13 @@ impl Artist {
 
     // Take field
     pub fn take_compilation_group(&mut self) -> ::protobuf::RepeatedField<AlbumGroup> {
-        ::std::mem::replace(&mut self.compilation_group, ::protobuf::RepeatedField::new())
+        ::std::mem::replace(
+            &mut self.compilation_group,
+            ::protobuf::RepeatedField::new(),
+        )
     }
 
     // repeated .AlbumGroup appears_on_group = 8;
-
 
     pub fn get_appears_on_group(&self) -> &[AlbumGroup] {
         &self.appears_on_group
@@ -752,7 +791,6 @@ impl Artist {
 
     // repeated string genre = 9;
 
-
     pub fn get_genre(&self) -> &[::std::string::String] {
         &self.genre
     }
@@ -776,7 +814,6 @@ impl Artist {
     }
 
     // repeated .ExternalId external_id = 10;
-
 
     pub fn get_external_id(&self) -> &[ExternalId] {
         &self.external_id
@@ -802,7 +839,6 @@ impl Artist {
 
     // repeated .Image portrait = 11;
 
-
     pub fn get_portrait(&self) -> &[Image] {
         &self.portrait
     }
@@ -826,7 +862,6 @@ impl Artist {
     }
 
     // repeated .Biography biography = 12;
-
 
     pub fn get_biography(&self) -> &[Biography] {
         &self.biography
@@ -852,7 +887,6 @@ impl Artist {
 
     // repeated .ActivityPeriod activity_period = 13;
 
-
     pub fn get_activity_period(&self) -> &[ActivityPeriod] {
         &self.activity_period
     }
@@ -876,7 +910,6 @@ impl Artist {
     }
 
     // repeated .Restriction restriction = 14;
-
 
     pub fn get_restriction(&self) -> &[Restriction] {
         &self.restriction
@@ -902,7 +935,6 @@ impl Artist {
 
     // repeated .Artist related = 15;
 
-
     pub fn get_related(&self) -> &[Artist] {
         &self.related
     }
@@ -927,7 +959,6 @@ impl Artist {
 
     // optional bool is_portrait_album_cover = 16;
 
-
     pub fn get_is_portrait_album_cover(&self) -> bool {
         self.is_portrait_album_cover.unwrap_or(false)
     }
@@ -946,9 +977,10 @@ impl Artist {
 
     // optional .ImageGroup portrait_group = 17;
 
-
     pub fn get_portrait_group(&self) -> &ImageGroup {
-        self.portrait_group.as_ref().unwrap_or_else(|| ImageGroup::default_instance())
+        self.portrait_group
+            .as_ref()
+            .unwrap_or_else(|| ImageGroup::default_instance())
     }
     pub fn clear_portrait_group(&mut self) {
         self.portrait_group.clear();
@@ -974,7 +1006,9 @@ impl Artist {
 
     // Take field
     pub fn take_portrait_group(&mut self) -> ImageGroup {
-        self.portrait_group.take().unwrap_or_else(|| ImageGroup::new())
+        self.portrait_group
+            .take()
+            .unwrap_or_else(|| ImageGroup::new())
     }
 }
 
@@ -984,131 +1018,175 @@ impl ::protobuf::Message for Artist {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.album_group {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.single_group {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.compilation_group {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.appears_on_group {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.external_id {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.portrait {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.biography {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.activity_period {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.restriction {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.related {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.portrait_group {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gid)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
-                },
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.popularity = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.top_track)?;
-                },
+                }
                 5 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.album_group)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.album_group,
+                    )?;
+                }
                 6 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.single_group)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.single_group,
+                    )?;
+                }
                 7 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.compilation_group)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.compilation_group,
+                    )?;
+                }
                 8 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.appears_on_group)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.appears_on_group,
+                    )?;
+                }
                 9 => {
                     ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.genre)?;
-                },
+                }
                 10 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.external_id)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.external_id,
+                    )?;
+                }
                 11 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.portrait)?;
-                },
+                }
                 12 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.biography)?;
-                },
+                }
                 13 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.activity_period)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.activity_period,
+                    )?;
+                }
                 14 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.restriction)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.restriction,
+                    )?;
+                }
                 15 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.related)?;
-                },
+                }
                 16 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.is_portrait_album_cover = ::std::option::Option::Some(tmp);
-                },
+                }
                 17 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.portrait_group)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.portrait_group,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1130,50 +1208,50 @@ impl ::protobuf::Message for Artist {
         for value in &self.top_track {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.album_group {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.single_group {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.compilation_group {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.appears_on_group {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.genre {
             my_size += ::protobuf::rt::string_size(9, &value);
-        };
+        }
         for value in &self.external_id {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.portrait {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.biography {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.activity_period {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.restriction {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.related {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(v) = self.is_portrait_album_cover {
             my_size += 3;
         }
@@ -1186,7 +1264,10 @@ impl ::protobuf::Message for Artist {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.gid.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -1200,60 +1281,60 @@ impl ::protobuf::Message for Artist {
             os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.album_group {
             os.write_tag(5, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.single_group {
             os.write_tag(6, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.compilation_group {
             os.write_tag(7, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.appears_on_group {
             os.write_tag(8, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.genre {
             os.write_string(9, &v)?;
-        };
+        }
         for v in &self.external_id {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.portrait {
             os.write_tag(11, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.biography {
             os.write_tag(12, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.activity_period {
             os.write_tag(13, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.restriction {
             os.write_tag(14, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.related {
             os.write_tag(15, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(v) = self.is_portrait_album_cover {
             os.write_bool(16, v)?;
         }
@@ -1297,102 +1378,178 @@ impl ::protobuf::Message for Artist {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gid",
-                    |m: &Artist| { &m.gid },
-                    |m: &mut Artist| { &mut m.gid },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "name",
-                    |m: &Artist| { &m.name },
-                    |m: &mut Artist| { &mut m.name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >("gid", |m: &Artist| &m.gid, |m: &mut Artist| &mut m.gid),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "name", |m: &Artist| &m.name, |m: &mut Artist| &mut m.name
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "popularity",
-                    |m: &Artist| { &m.popularity },
-                    |m: &mut Artist| { &mut m.popularity },
+                    |m: &Artist| &m.popularity,
+                    |m: &mut Artist| &mut m.popularity,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<TopTracks>>(
-                    "top_track",
-                    |m: &Artist| { &m.top_track },
-                    |m: &mut Artist| { &mut m.top_track },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AlbumGroup>>(
-                    "album_group",
-                    |m: &Artist| { &m.album_group },
-                    |m: &mut Artist| { &mut m.album_group },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AlbumGroup>>(
-                    "single_group",
-                    |m: &Artist| { &m.single_group },
-                    |m: &mut Artist| { &mut m.single_group },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AlbumGroup>>(
-                    "compilation_group",
-                    |m: &Artist| { &m.compilation_group },
-                    |m: &mut Artist| { &mut m.compilation_group },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AlbumGroup>>(
-                    "appears_on_group",
-                    |m: &Artist| { &m.appears_on_group },
-                    |m: &mut Artist| { &mut m.appears_on_group },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "genre",
-                    |m: &Artist| { &m.genre },
-                    |m: &mut Artist| { &mut m.genre },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ExternalId>>(
-                    "external_id",
-                    |m: &Artist| { &m.external_id },
-                    |m: &mut Artist| { &mut m.external_id },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Image>>(
-                    "portrait",
-                    |m: &Artist| { &m.portrait },
-                    |m: &mut Artist| { &mut m.portrait },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Biography>>(
-                    "biography",
-                    |m: &Artist| { &m.biography },
-                    |m: &mut Artist| { &mut m.biography },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ActivityPeriod>>(
-                    "activity_period",
-                    |m: &Artist| { &m.activity_period },
-                    |m: &mut Artist| { &mut m.activity_period },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Restriction>>(
-                    "restriction",
-                    |m: &Artist| { &m.restriction },
-                    |m: &mut Artist| { &mut m.restriction },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Artist>>(
-                    "related",
-                    |m: &Artist| { &m.related },
-                    |m: &mut Artist| { &mut m.related },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<TopTracks>,
+                    >(
+                        "top_track",
+                        |m: &Artist| &m.top_track,
+                        |m: &mut Artist| &mut m.top_track,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AlbumGroup>,
+                    >(
+                        "album_group",
+                        |m: &Artist| &m.album_group,
+                        |m: &mut Artist| &mut m.album_group,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AlbumGroup>,
+                    >(
+                        "single_group",
+                        |m: &Artist| &m.single_group,
+                        |m: &mut Artist| &mut m.single_group,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AlbumGroup>,
+                    >(
+                        "compilation_group",
+                        |m: &Artist| &m.compilation_group,
+                        |m: &mut Artist| &mut m.compilation_group,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AlbumGroup>,
+                    >(
+                        "appears_on_group",
+                        |m: &Artist| &m.appears_on_group,
+                        |m: &mut Artist| &mut m.appears_on_group,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "genre",
+                        |m: &Artist| &m.genre,
+                        |m: &mut Artist| &mut m.genre,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ExternalId>,
+                    >(
+                        "external_id",
+                        |m: &Artist| &m.external_id,
+                        |m: &mut Artist| &mut m.external_id,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Image>,
+                    >(
+                        "portrait",
+                        |m: &Artist| &m.portrait,
+                        |m: &mut Artist| &mut m.portrait,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Biography>,
+                    >(
+                        "biography",
+                        |m: &Artist| &m.biography,
+                        |m: &mut Artist| &mut m.biography,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ActivityPeriod>,
+                    >(
+                        "activity_period",
+                        |m: &Artist| &m.activity_period,
+                        |m: &mut Artist| &mut m.activity_period,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Restriction>,
+                    >(
+                        "restriction",
+                        |m: &Artist| &m.restriction,
+                        |m: &mut Artist| &mut m.restriction,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Artist>,
+                    >(
+                        "related",
+                        |m: &Artist| &m.related,
+                        |m: &mut Artist| &mut m.related,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "is_portrait_album_cover",
-                    |m: &Artist| { &m.is_portrait_album_cover },
-                    |m: &mut Artist| { &mut m.is_portrait_album_cover },
+                    |m: &Artist| &m.is_portrait_album_cover,
+                    |m: &mut Artist| &mut m.is_portrait_album_cover,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ImageGroup>>(
-                    "portrait_group",
-                    |m: &Artist| { &m.portrait_group },
-                    |m: &mut Artist| { &mut m.portrait_group },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ImageGroup>,
+                    >(
+                        "portrait_group",
+                        |m: &Artist| &m.portrait_group,
+                        |m: &mut Artist| &mut m.portrait_group,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Artist>(
                     "Artist",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1403,9 +1560,7 @@ impl ::protobuf::Message for Artist {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Artist,
         };
-        unsafe {
-            instance.get(Artist::new)
-        }
+        unsafe { instance.get(Artist::new) }
     }
 }
 
@@ -1444,7 +1599,7 @@ impl ::protobuf::reflect::ProtobufValue for Artist {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct AlbumGroup {
     // message fields
     album: ::protobuf::RepeatedField<Album>,
@@ -1465,7 +1620,6 @@ impl AlbumGroup {
     }
 
     // repeated .Album album = 1;
-
 
     pub fn get_album(&self) -> &[Album] {
         &self.album
@@ -1496,20 +1650,28 @@ impl ::protobuf::Message for AlbumGroup {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.album)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1522,18 +1684,21 @@ impl ::protobuf::Message for AlbumGroup {
         for value in &self.album {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         for v in &self.album {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -1569,22 +1734,28 @@ impl ::protobuf::Message for AlbumGroup {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Album>>(
-                    "album",
-                    |m: &AlbumGroup| { &m.album },
-                    |m: &mut AlbumGroup| { &mut m.album },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Album>,
+                    >(
+                        "album",
+                        |m: &AlbumGroup| &m.album,
+                        |m: &mut AlbumGroup| &mut m.album,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<AlbumGroup>(
                     "AlbumGroup",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1595,9 +1766,7 @@ impl ::protobuf::Message for AlbumGroup {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const AlbumGroup,
         };
-        unsafe {
-            instance.get(AlbumGroup::new)
-        }
+        unsafe { instance.get(AlbumGroup::new) }
     }
 }
 
@@ -1620,7 +1789,7 @@ impl ::protobuf::reflect::ProtobufValue for AlbumGroup {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Date {
     // message fields
     year: ::std::option::Option<i32>,
@@ -1646,7 +1815,6 @@ impl Date {
 
     // optional sint32 year = 1;
 
-
     pub fn get_year(&self) -> i32 {
         self.year.unwrap_or(0)
     }
@@ -1664,7 +1832,6 @@ impl Date {
     }
 
     // optional sint32 month = 2;
-
 
     pub fn get_month(&self) -> i32 {
         self.month.unwrap_or(0)
@@ -1684,7 +1851,6 @@ impl Date {
 
     // optional sint32 day = 3;
 
-
     pub fn get_day(&self) -> i32 {
         self.day.unwrap_or(0)
     }
@@ -1703,7 +1869,6 @@ impl Date {
 
     // optional sint32 hour = 4;
 
-
     pub fn get_hour(&self) -> i32 {
         self.hour.unwrap_or(0)
     }
@@ -1721,7 +1886,6 @@ impl Date {
     }
 
     // optional sint32 minute = 5;
-
 
     pub fn get_minute(&self) -> i32 {
         self.minute.unwrap_or(0)
@@ -1745,48 +1909,66 @@ impl ::protobuf::Message for Date {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.year = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.month = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.day = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.hour = ::std::option::Option::Some(tmp);
-                },
+                }
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.minute = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1816,7 +1998,10 @@ impl ::protobuf::Message for Date {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.year {
             os.write_sint32(1, v)?;
         }
@@ -1867,42 +2052,50 @@ impl ::protobuf::Message for Date {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
-                    "year",
-                    |m: &Date| { &m.year },
-                    |m: &mut Date| { &mut m.year },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
+                    "year", |m: &Date| &m.year, |m: &mut Date| &mut m.year
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
-                    "month",
-                    |m: &Date| { &m.month },
-                    |m: &mut Date| { &mut m.month },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
+                    "month", |m: &Date| &m.month, |m: &mut Date| &mut m.month
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
-                    "day",
-                    |m: &Date| { &m.day },
-                    |m: &mut Date| { &mut m.day },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
+                    "day", |m: &Date| &m.day, |m: &mut Date| &mut m.day
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
-                    "hour",
-                    |m: &Date| { &m.hour },
-                    |m: &mut Date| { &mut m.hour },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
+                    "hour", |m: &Date| &m.hour, |m: &mut Date| &mut m.hour
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "minute",
-                    |m: &Date| { &m.minute },
-                    |m: &mut Date| { &mut m.minute },
+                    |m: &Date| &m.minute,
+                    |m: &mut Date| &mut m.minute,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Date>(
                     "Date",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1913,9 +2106,7 @@ impl ::protobuf::Message for Date {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Date,
         };
-        unsafe {
-            instance.get(Date::new)
-        }
+        unsafe { instance.get(Date::new) }
     }
 }
 
@@ -1942,7 +2133,7 @@ impl ::protobuf::reflect::ProtobufValue for Date {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Album {
     // message fields
     gid: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -1980,7 +2171,6 @@ impl Album {
 
     // optional bytes gid = 1;
 
-
     pub fn get_gid(&self) -> &[u8] {
         match self.gid.as_ref() {
             Some(v) => &v,
@@ -2016,7 +2206,6 @@ impl Album {
 
     // optional string name = 2;
 
-
     pub fn get_name(&self) -> &str {
         match self.name.as_ref() {
             Some(v) => &v,
@@ -2047,11 +2236,12 @@ impl Album {
 
     // Take field
     pub fn take_name(&mut self) -> ::std::string::String {
-        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // repeated .Artist artist = 3;
-
 
     pub fn get_artist(&self) -> &[Artist] {
         &self.artist
@@ -2077,7 +2267,6 @@ impl Album {
 
     // optional .Album.Type typ = 4;
 
-
     pub fn get_typ(&self) -> Album_Type {
         self.typ.unwrap_or(Album_Type::ALBUM)
     }
@@ -2095,7 +2284,6 @@ impl Album {
     }
 
     // optional string label = 5;
-
 
     pub fn get_label(&self) -> &str {
         match self.label.as_ref() {
@@ -2127,14 +2315,17 @@ impl Album {
 
     // Take field
     pub fn take_label(&mut self) -> ::std::string::String {
-        self.label.take().unwrap_or_else(|| ::std::string::String::new())
+        self.label
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional .Date date = 6;
 
-
     pub fn get_date(&self) -> &Date {
-        self.date.as_ref().unwrap_or_else(|| Date::default_instance())
+        self.date
+            .as_ref()
+            .unwrap_or_else(|| Date::default_instance())
     }
     pub fn clear_date(&mut self) {
         self.date.clear();
@@ -2165,7 +2356,6 @@ impl Album {
 
     // optional sint32 popularity = 7;
 
-
     pub fn get_popularity(&self) -> i32 {
         self.popularity.unwrap_or(0)
     }
@@ -2183,7 +2373,6 @@ impl Album {
     }
 
     // repeated string genre = 8;
-
 
     pub fn get_genre(&self) -> &[::std::string::String] {
         &self.genre
@@ -2209,7 +2398,6 @@ impl Album {
 
     // repeated .Image cover = 9;
 
-
     pub fn get_cover(&self) -> &[Image] {
         &self.cover
     }
@@ -2233,7 +2421,6 @@ impl Album {
     }
 
     // repeated .ExternalId external_id = 10;
-
 
     pub fn get_external_id(&self) -> &[ExternalId] {
         &self.external_id
@@ -2259,7 +2446,6 @@ impl Album {
 
     // repeated .Disc disc = 11;
 
-
     pub fn get_disc(&self) -> &[Disc] {
         &self.disc
     }
@@ -2283,7 +2469,6 @@ impl Album {
     }
 
     // repeated string review = 12;
-
 
     pub fn get_review(&self) -> &[::std::string::String] {
         &self.review
@@ -2309,7 +2494,6 @@ impl Album {
 
     // repeated .Copyright copyright = 13;
 
-
     pub fn get_copyright(&self) -> &[Copyright] {
         &self.copyright
     }
@@ -2333,7 +2517,6 @@ impl Album {
     }
 
     // repeated .Restriction restriction = 14;
-
 
     pub fn get_restriction(&self) -> &[Restriction] {
         &self.restriction
@@ -2359,7 +2542,6 @@ impl Album {
 
     // repeated .Album related = 15;
 
-
     pub fn get_related(&self) -> &[Album] {
         &self.related
     }
@@ -2383,7 +2565,6 @@ impl Album {
     }
 
     // repeated .SalePeriod sale_period = 16;
-
 
     pub fn get_sale_period(&self) -> &[SalePeriod] {
         &self.sale_period
@@ -2409,9 +2590,10 @@ impl Album {
 
     // optional .ImageGroup cover_group = 17;
 
-
     pub fn get_cover_group(&self) -> &ImageGroup {
-        self.cover_group.as_ref().unwrap_or_else(|| ImageGroup::default_instance())
+        self.cover_group
+            .as_ref()
+            .unwrap_or_else(|| ImageGroup::default_instance())
     }
     pub fn clear_cover_group(&mut self) {
         self.cover_group.clear();
@@ -2447,117 +2629,147 @@ impl ::protobuf::Message for Album {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.date {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.cover {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.external_id {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.disc {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.copyright {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.restriction {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.related {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.sale_period {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.cover_group {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gid)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.artist)?;
-                },
-                4 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.typ, 4, &mut self.unknown_fields)?
-                },
+                }
+                4 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.typ,
+                    4,
+                    &mut self.unknown_fields,
+                )?,
                 5 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.label)?;
-                },
+                }
                 6 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.date)?;
-                },
+                }
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.popularity = ::std::option::Option::Some(tmp);
-                },
+                }
                 8 => {
                     ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.genre)?;
-                },
+                }
                 9 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.cover)?;
-                },
+                }
                 10 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.external_id)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.external_id,
+                    )?;
+                }
                 11 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.disc)?;
-                },
+                }
                 12 => {
                     ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.review)?;
-                },
+                }
                 13 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.copyright)?;
-                },
+                }
                 14 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.restriction)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.restriction,
+                    )?;
+                }
                 15 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.related)?;
-                },
+                }
                 16 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.sale_period)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.sale_period,
+                    )?;
+                }
                 17 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.cover_group)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.cover_group,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2576,7 +2788,7 @@ impl ::protobuf::Message for Album {
         for value in &self.artist {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(v) = self.typ {
             my_size += ::protobuf::rt::enum_size(4, v);
         }
@@ -2592,38 +2804,38 @@ impl ::protobuf::Message for Album {
         }
         for value in &self.genre {
             my_size += ::protobuf::rt::string_size(8, &value);
-        };
+        }
         for value in &self.cover {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.external_id {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.disc {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.review {
             my_size += ::protobuf::rt::string_size(12, &value);
-        };
+        }
         for value in &self.copyright {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.restriction {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.related {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.sale_period {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.cover_group.as_ref() {
             let len = v.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -2633,7 +2845,10 @@ impl ::protobuf::Message for Album {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.gid.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -2644,7 +2859,7 @@ impl ::protobuf::Message for Album {
             os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(v) = self.typ {
             os.write_enum(4, v.value())?;
         }
@@ -2661,45 +2876,45 @@ impl ::protobuf::Message for Album {
         }
         for v in &self.genre {
             os.write_string(8, &v)?;
-        };
+        }
         for v in &self.cover {
             os.write_tag(9, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.external_id {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.disc {
             os.write_tag(11, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.review {
             os.write_string(12, &v)?;
-        };
+        }
         for v in &self.copyright {
             os.write_tag(13, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.restriction {
             os.write_tag(14, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.related {
             os.write_tag(15, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.sale_period {
             os.write_tag(16, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.cover_group.as_ref() {
             os.write_tag(17, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -2740,102 +2955,160 @@ impl ::protobuf::Message for Album {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gid",
-                    |m: &Album| { &m.gid },
-                    |m: &mut Album| { &mut m.gid },
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >("gid", |m: &Album| &m.gid, |m: &mut Album| &mut m.gid),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >("name", |m: &Album| &m.name, |m: &mut Album| &mut m.name),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Artist>,
+                    >(
+                        "artist",
+                        |m: &Album| &m.artist,
+                        |m: &mut Album| &mut m.artist,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Album_Type>,
+                >(
+                    "typ", |m: &Album| &m.typ, |m: &mut Album| &mut m.typ
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "name",
-                    |m: &Album| { &m.name },
-                    |m: &mut Album| { &mut m.name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Artist>>(
-                    "artist",
-                    |m: &Album| { &m.artist },
-                    |m: &mut Album| { &mut m.artist },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Album_Type>>(
-                    "typ",
-                    |m: &Album| { &m.typ },
-                    |m: &mut Album| { &mut m.typ },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "label",
-                    |m: &Album| { &m.label },
-                    |m: &mut Album| { &mut m.label },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Date>>(
-                    "date",
-                    |m: &Album| { &m.date },
-                    |m: &mut Album| { &mut m.date },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "label", |m: &Album| &m.label, |m: &mut Album| &mut m.label
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Date>,
+                    >("date", |m: &Album| &m.date, |m: &mut Album| &mut m.date),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "popularity",
-                    |m: &Album| { &m.popularity },
-                    |m: &mut Album| { &mut m.popularity },
+                    |m: &Album| &m.popularity,
+                    |m: &mut Album| &mut m.popularity,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "genre",
-                    |m: &Album| { &m.genre },
-                    |m: &mut Album| { &mut m.genre },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Image>>(
-                    "cover",
-                    |m: &Album| { &m.cover },
-                    |m: &mut Album| { &mut m.cover },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ExternalId>>(
-                    "external_id",
-                    |m: &Album| { &m.external_id },
-                    |m: &mut Album| { &mut m.external_id },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Disc>>(
-                    "disc",
-                    |m: &Album| { &m.disc },
-                    |m: &mut Album| { &mut m.disc },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "review",
-                    |m: &Album| { &m.review },
-                    |m: &mut Album| { &mut m.review },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Copyright>>(
-                    "copyright",
-                    |m: &Album| { &m.copyright },
-                    |m: &mut Album| { &mut m.copyright },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Restriction>>(
-                    "restriction",
-                    |m: &Album| { &m.restriction },
-                    |m: &mut Album| { &mut m.restriction },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Album>>(
-                    "related",
-                    |m: &Album| { &m.related },
-                    |m: &mut Album| { &mut m.related },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<SalePeriod>>(
-                    "sale_period",
-                    |m: &Album| { &m.sale_period },
-                    |m: &mut Album| { &mut m.sale_period },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ImageGroup>>(
-                    "cover_group",
-                    |m: &Album| { &m.cover_group },
-                    |m: &mut Album| { &mut m.cover_group },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "genre", |m: &Album| &m.genre, |m: &mut Album| &mut m.genre
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Image>,
+                    >(
+                        "cover", |m: &Album| &m.cover, |m: &mut Album| &mut m.cover
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ExternalId>,
+                    >(
+                        "external_id",
+                        |m: &Album| &m.external_id,
+                        |m: &mut Album| &mut m.external_id,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Disc>,
+                    >("disc", |m: &Album| &m.disc, |m: &mut Album| &mut m.disc),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "review",
+                        |m: &Album| &m.review,
+                        |m: &mut Album| &mut m.review,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Copyright>,
+                    >(
+                        "copyright",
+                        |m: &Album| &m.copyright,
+                        |m: &mut Album| &mut m.copyright,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Restriction>,
+                    >(
+                        "restriction",
+                        |m: &Album| &m.restriction,
+                        |m: &mut Album| &mut m.restriction,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Album>,
+                    >(
+                        "related",
+                        |m: &Album| &m.related,
+                        |m: &mut Album| &mut m.related,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<SalePeriod>,
+                    >(
+                        "sale_period",
+                        |m: &Album| &m.sale_period,
+                        |m: &mut Album| &mut m.sale_period,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ImageGroup>,
+                    >(
+                        "cover_group",
+                        |m: &Album| &m.cover_group,
+                        |m: &mut Album| &mut m.cover_group,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Album>(
                     "Album",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -2846,9 +3119,7 @@ impl ::protobuf::Message for Album {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Album,
         };
-        unsafe {
-            instance.get(Album::new)
-        }
+        unsafe { instance.get(Album::new) }
     }
 }
 
@@ -2887,7 +3158,7 @@ impl ::protobuf::reflect::ProtobufValue for Album {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Album_Type {
     ALBUM = 1,
     SINGLE = 2,
@@ -2906,7 +3177,7 @@ impl ::protobuf::ProtobufEnum for Album_Type {
             2 => ::std::option::Option::Some(Album_Type::SINGLE),
             3 => ::std::option::Option::Some(Album_Type::COMPILATION),
             4 => ::std::option::Option::Some(Album_Type::EP),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -2921,10 +3192,11 @@ impl ::protobuf::ProtobufEnum for Album_Type {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Album_Type", file_descriptor_proto())
@@ -2933,8 +3205,7 @@ impl ::protobuf::ProtobufEnum for Album_Type {
     }
 }
 
-impl ::std::marker::Copy for Album_Type {
-}
+impl ::std::marker::Copy for Album_Type {}
 
 // Note, `Default` is implemented although default value is not 0
 impl ::std::default::Default for Album_Type {
@@ -2949,7 +3220,7 @@ impl ::protobuf::reflect::ProtobufValue for Album_Type {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Track {
     // message fields
     gid: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -2984,7 +3255,6 @@ impl Track {
     }
 
     // optional bytes gid = 1;
-
 
     pub fn get_gid(&self) -> &[u8] {
         match self.gid.as_ref() {
@@ -3021,7 +3291,6 @@ impl Track {
 
     // optional string name = 2;
 
-
     pub fn get_name(&self) -> &str {
         match self.name.as_ref() {
             Some(v) => &v,
@@ -3052,14 +3321,17 @@ impl Track {
 
     // Take field
     pub fn take_name(&mut self) -> ::std::string::String {
-        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional .Album album = 3;
 
-
     pub fn get_album(&self) -> &Album {
-        self.album.as_ref().unwrap_or_else(|| Album::default_instance())
+        self.album
+            .as_ref()
+            .unwrap_or_else(|| Album::default_instance())
     }
     pub fn clear_album(&mut self) {
         self.album.clear();
@@ -3090,7 +3362,6 @@ impl Track {
 
     // repeated .Artist artist = 4;
 
-
     pub fn get_artist(&self) -> &[Artist] {
         &self.artist
     }
@@ -3115,7 +3386,6 @@ impl Track {
 
     // optional sint32 number = 5;
 
-
     pub fn get_number(&self) -> i32 {
         self.number.unwrap_or(0)
     }
@@ -3133,7 +3403,6 @@ impl Track {
     }
 
     // optional sint32 disc_number = 6;
-
 
     pub fn get_disc_number(&self) -> i32 {
         self.disc_number.unwrap_or(0)
@@ -3153,7 +3422,6 @@ impl Track {
 
     // optional sint32 duration = 7;
 
-
     pub fn get_duration(&self) -> i32 {
         self.duration.unwrap_or(0)
     }
@@ -3171,7 +3439,6 @@ impl Track {
     }
 
     // optional sint32 popularity = 8;
-
 
     pub fn get_popularity(&self) -> i32 {
         self.popularity.unwrap_or(0)
@@ -3191,7 +3458,6 @@ impl Track {
 
     // optional bool explicit = 9;
 
-
     pub fn get_explicit(&self) -> bool {
         self.explicit.unwrap_or(false)
     }
@@ -3209,7 +3475,6 @@ impl Track {
     }
 
     // repeated .ExternalId external_id = 10;
-
 
     pub fn get_external_id(&self) -> &[ExternalId] {
         &self.external_id
@@ -3235,7 +3500,6 @@ impl Track {
 
     // repeated .Restriction restriction = 11;
 
-
     pub fn get_restriction(&self) -> &[Restriction] {
         &self.restriction
     }
@@ -3259,7 +3523,6 @@ impl Track {
     }
 
     // repeated .AudioFile file = 12;
-
 
     pub fn get_file(&self) -> &[AudioFile] {
         &self.file
@@ -3285,7 +3548,6 @@ impl Track {
 
     // repeated .Track alternative = 13;
 
-
     pub fn get_alternative(&self) -> &[Track] {
         &self.alternative
     }
@@ -3310,7 +3572,6 @@ impl Track {
 
     // repeated .SalePeriod sale_period = 14;
 
-
     pub fn get_sale_period(&self) -> &[SalePeriod] {
         &self.sale_period
     }
@@ -3334,7 +3595,6 @@ impl Track {
     }
 
     // repeated .AudioFile preview = 15;
-
 
     pub fn get_preview(&self) -> &[AudioFile] {
         &self.preview
@@ -3365,117 +3625,151 @@ impl ::protobuf::Message for Track {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.artist {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.external_id {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.restriction {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.file {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.alternative {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.sale_period {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.preview {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gid)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.album)?;
-                },
+                }
                 4 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.artist)?;
-                },
+                }
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.number = ::std::option::Option::Some(tmp);
-                },
+                }
                 6 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.disc_number = ::std::option::Option::Some(tmp);
-                },
+                }
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.duration = ::std::option::Option::Some(tmp);
-                },
+                }
                 8 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.popularity = ::std::option::Option::Some(tmp);
-                },
+                }
                 9 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.explicit = ::std::option::Option::Some(tmp);
-                },
+                }
                 10 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.external_id)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.external_id,
+                    )?;
+                }
                 11 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.restriction)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.restriction,
+                    )?;
+                }
                 12 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.file)?;
-                },
+                }
                 13 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.alternative)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.alternative,
+                    )?;
+                }
                 14 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.sale_period)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.sale_period,
+                    )?;
+                }
                 15 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.preview)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3498,7 +3792,7 @@ impl ::protobuf::Message for Track {
         for value in &self.artist {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(v) = self.number {
             my_size += ::protobuf::rt::value_varint_zigzag_size(5, v);
         }
@@ -3517,33 +3811,36 @@ impl ::protobuf::Message for Track {
         for value in &self.external_id {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.restriction {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.file {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.alternative {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.sale_period {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.preview {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.gid.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -3559,7 +3856,7 @@ impl ::protobuf::Message for Track {
             os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(v) = self.number {
             os.write_sint32(5, v)?;
         }
@@ -3579,32 +3876,32 @@ impl ::protobuf::Message for Track {
             os.write_tag(10, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.restriction {
             os.write_tag(11, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.file {
             os.write_tag(12, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.alternative {
             os.write_tag(13, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.sale_period {
             os.write_tag(14, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.preview {
             os.write_tag(15, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -3640,92 +3937,144 @@ impl ::protobuf::Message for Track {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gid",
-                    |m: &Track| { &m.gid },
-                    |m: &mut Track| { &mut m.gid },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "name",
-                    |m: &Track| { &m.name },
-                    |m: &mut Track| { &mut m.name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Album>>(
-                    "album",
-                    |m: &Track| { &m.album },
-                    |m: &mut Track| { &mut m.album },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Artist>>(
-                    "artist",
-                    |m: &Track| { &m.artist },
-                    |m: &mut Track| { &mut m.artist },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >("gid", |m: &Track| &m.gid, |m: &mut Track| &mut m.gid),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >("name", |m: &Track| &m.name, |m: &mut Track| &mut m.name),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Album>,
+                    >(
+                        "album", |m: &Track| &m.album, |m: &mut Track| &mut m.album
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Artist>,
+                    >(
+                        "artist",
+                        |m: &Track| &m.artist,
+                        |m: &mut Track| &mut m.artist,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "number",
-                    |m: &Track| { &m.number },
-                    |m: &mut Track| { &mut m.number },
+                    |m: &Track| &m.number,
+                    |m: &mut Track| &mut m.number,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "disc_number",
-                    |m: &Track| { &m.disc_number },
-                    |m: &mut Track| { &mut m.disc_number },
+                    |m: &Track| &m.disc_number,
+                    |m: &mut Track| &mut m.disc_number,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "duration",
-                    |m: &Track| { &m.duration },
-                    |m: &mut Track| { &mut m.duration },
+                    |m: &Track| &m.duration,
+                    |m: &mut Track| &mut m.duration,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "popularity",
-                    |m: &Track| { &m.popularity },
-                    |m: &mut Track| { &mut m.popularity },
+                    |m: &Track| &m.popularity,
+                    |m: &mut Track| &mut m.popularity,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "explicit",
-                    |m: &Track| { &m.explicit },
-                    |m: &mut Track| { &mut m.explicit },
+                    |m: &Track| &m.explicit,
+                    |m: &mut Track| &mut m.explicit,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ExternalId>>(
-                    "external_id",
-                    |m: &Track| { &m.external_id },
-                    |m: &mut Track| { &mut m.external_id },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Restriction>>(
-                    "restriction",
-                    |m: &Track| { &m.restriction },
-                    |m: &mut Track| { &mut m.restriction },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AudioFile>>(
-                    "file",
-                    |m: &Track| { &m.file },
-                    |m: &mut Track| { &mut m.file },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Track>>(
-                    "alternative",
-                    |m: &Track| { &m.alternative },
-                    |m: &mut Track| { &mut m.alternative },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<SalePeriod>>(
-                    "sale_period",
-                    |m: &Track| { &m.sale_period },
-                    |m: &mut Track| { &mut m.sale_period },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AudioFile>>(
-                    "preview",
-                    |m: &Track| { &m.preview },
-                    |m: &mut Track| { &mut m.preview },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ExternalId>,
+                    >(
+                        "external_id",
+                        |m: &Track| &m.external_id,
+                        |m: &mut Track| &mut m.external_id,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Restriction>,
+                    >(
+                        "restriction",
+                        |m: &Track| &m.restriction,
+                        |m: &mut Track| &mut m.restriction,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AudioFile>,
+                    >("file", |m: &Track| &m.file, |m: &mut Track| &mut m.file),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Track>,
+                    >(
+                        "alternative",
+                        |m: &Track| &m.alternative,
+                        |m: &mut Track| &mut m.alternative,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<SalePeriod>,
+                    >(
+                        "sale_period",
+                        |m: &Track| &m.sale_period,
+                        |m: &mut Track| &mut m.sale_period,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AudioFile>,
+                    >(
+                        "preview",
+                        |m: &Track| &m.preview,
+                        |m: &mut Track| &mut m.preview,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Track>(
                     "Track",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3736,9 +4085,7 @@ impl ::protobuf::Message for Track {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Track,
         };
-        unsafe {
-            instance.get(Track::new)
-        }
+        unsafe { instance.get(Track::new) }
     }
 }
 
@@ -3775,7 +4122,7 @@ impl ::protobuf::reflect::ProtobufValue for Track {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Image {
     // message fields
     file_id: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -3799,7 +4146,6 @@ impl Image {
     }
 
     // optional bytes file_id = 1;
-
 
     pub fn get_file_id(&self) -> &[u8] {
         match self.file_id.as_ref() {
@@ -3831,11 +4177,12 @@ impl Image {
 
     // Take field
     pub fn take_file_id(&mut self) -> ::std::vec::Vec<u8> {
-        self.file_id.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.file_id
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional .Image.Size size = 2;
-
 
     pub fn get_size(&self) -> Image_Size {
         self.size.unwrap_or(Image_Size::DEFAULT)
@@ -3855,7 +4202,6 @@ impl Image {
 
     // optional sint32 width = 3;
 
-
     pub fn get_width(&self) -> i32 {
         self.width.unwrap_or(0)
     }
@@ -3873,7 +4219,6 @@ impl Image {
     }
 
     // optional sint32 height = 4;
-
 
     pub fn get_height(&self) -> i32 {
         self.height.unwrap_or(0)
@@ -3897,33 +4242,49 @@ impl ::protobuf::Message for Image {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.file_id)?;
-                },
-                2 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.size, 2, &mut self.unknown_fields)?
-                },
+                }
+                2 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.size,
+                    2,
+                    &mut self.unknown_fields,
+                )?,
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.width = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.height = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3950,7 +4311,10 @@ impl ::protobuf::Message for Image {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.file_id.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -3998,37 +4362,50 @@ impl ::protobuf::Message for Image {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "file_id",
-                    |m: &Image| { &m.file_id },
-                    |m: &mut Image| { &mut m.file_id },
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "file_id",
+                        |m: &Image| &m.file_id,
+                        |m: &mut Image| &mut m.file_id,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Image_Size>,
+                >(
+                    "size", |m: &Image| &m.size, |m: &mut Image| &mut m.size
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Image_Size>>(
-                    "size",
-                    |m: &Image| { &m.size },
-                    |m: &mut Image| { &mut m.size },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "width",
-                    |m: &Image| { &m.width },
-                    |m: &mut Image| { &mut m.width },
+                    |m: &Image| &m.width,
+                    |m: &mut Image| &mut m.width,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "height",
-                    |m: &Image| { &m.height },
-                    |m: &mut Image| { &mut m.height },
+                    |m: &Image| &m.height,
+                    |m: &mut Image| &mut m.height,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Image>(
                     "Image",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -4039,9 +4416,7 @@ impl ::protobuf::Message for Image {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Image,
         };
-        unsafe {
-            instance.get(Image::new)
-        }
+        unsafe { instance.get(Image::new) }
     }
 }
 
@@ -4067,7 +4442,7 @@ impl ::protobuf::reflect::ProtobufValue for Image {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Image_Size {
     DEFAULT = 0,
     SMALL = 1,
@@ -4086,7 +4461,7 @@ impl ::protobuf::ProtobufEnum for Image_Size {
             1 => ::std::option::Option::Some(Image_Size::SMALL),
             2 => ::std::option::Option::Some(Image_Size::LARGE),
             3 => ::std::option::Option::Some(Image_Size::XLARGE),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -4101,10 +4476,11 @@ impl ::protobuf::ProtobufEnum for Image_Size {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Image_Size", file_descriptor_proto())
@@ -4113,8 +4489,7 @@ impl ::protobuf::ProtobufEnum for Image_Size {
     }
 }
 
-impl ::std::marker::Copy for Image_Size {
-}
+impl ::std::marker::Copy for Image_Size {}
 
 impl ::std::default::Default for Image_Size {
     fn default() -> Self {
@@ -4128,7 +4503,7 @@ impl ::protobuf::reflect::ProtobufValue for Image_Size {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ImageGroup {
     // message fields
     image: ::protobuf::RepeatedField<Image>,
@@ -4149,7 +4524,6 @@ impl ImageGroup {
     }
 
     // repeated .Image image = 1;
-
 
     pub fn get_image(&self) -> &[Image] {
         &self.image
@@ -4180,20 +4554,28 @@ impl ::protobuf::Message for ImageGroup {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.image)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4206,18 +4588,21 @@ impl ::protobuf::Message for ImageGroup {
         for value in &self.image {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         for v in &self.image {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -4253,22 +4638,28 @@ impl ::protobuf::Message for ImageGroup {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Image>>(
-                    "image",
-                    |m: &ImageGroup| { &m.image },
-                    |m: &mut ImageGroup| { &mut m.image },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Image>,
+                    >(
+                        "image",
+                        |m: &ImageGroup| &m.image,
+                        |m: &mut ImageGroup| &mut m.image,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ImageGroup>(
                     "ImageGroup",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -4279,9 +4670,7 @@ impl ::protobuf::Message for ImageGroup {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ImageGroup,
         };
-        unsafe {
-            instance.get(ImageGroup::new)
-        }
+        unsafe { instance.get(ImageGroup::new) }
     }
 }
 
@@ -4304,7 +4693,7 @@ impl ::protobuf::reflect::ProtobufValue for ImageGroup {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Biography {
     // message fields
     text: ::protobuf::SingularField<::std::string::String>,
@@ -4327,7 +4716,6 @@ impl Biography {
     }
 
     // optional string text = 1;
-
 
     pub fn get_text(&self) -> &str {
         match self.text.as_ref() {
@@ -4359,11 +4747,12 @@ impl Biography {
 
     // Take field
     pub fn take_text(&mut self) -> ::std::string::String {
-        self.text.take().unwrap_or_else(|| ::std::string::String::new())
+        self.text
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // repeated .Image portrait = 2;
-
 
     pub fn get_portrait(&self) -> &[Image] {
         &self.portrait
@@ -4388,7 +4777,6 @@ impl Biography {
     }
 
     // repeated .ImageGroup portrait_group = 3;
-
 
     pub fn get_portrait_group(&self) -> &[ImageGroup] {
         &self.portrait_group
@@ -4419,31 +4807,43 @@ impl ::protobuf::Message for Biography {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.portrait_group {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.text)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.portrait)?;
-                },
+                }
                 3 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.portrait_group)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.portrait_group,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4459,17 +4859,20 @@ impl ::protobuf::Message for Biography {
         for value in &self.portrait {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.portrait_group {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.text.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -4477,12 +4880,12 @@ impl ::protobuf::Message for Biography {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.portrait_group {
             os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -4518,32 +4921,48 @@ impl ::protobuf::Message for Biography {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "text",
-                    |m: &Biography| { &m.text },
-                    |m: &mut Biography| { &mut m.text },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Image>>(
-                    "portrait",
-                    |m: &Biography| { &m.portrait },
-                    |m: &mut Biography| { &mut m.portrait },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ImageGroup>>(
-                    "portrait_group",
-                    |m: &Biography| { &m.portrait_group },
-                    |m: &mut Biography| { &mut m.portrait_group },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "text",
+                        |m: &Biography| &m.text,
+                        |m: &mut Biography| &mut m.text,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Image>,
+                    >(
+                        "portrait",
+                        |m: &Biography| &m.portrait,
+                        |m: &mut Biography| &mut m.portrait,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ImageGroup>,
+                    >(
+                        "portrait_group",
+                        |m: &Biography| &m.portrait_group,
+                        |m: &mut Biography| &mut m.portrait_group,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Biography>(
                     "Biography",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -4554,9 +4973,7 @@ impl ::protobuf::Message for Biography {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Biography,
         };
-        unsafe {
-            instance.get(Biography::new)
-        }
+        unsafe { instance.get(Biography::new) }
     }
 }
 
@@ -4581,7 +4998,7 @@ impl ::protobuf::reflect::ProtobufValue for Biography {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Disc {
     // message fields
     number: ::std::option::Option<i32>,
@@ -4605,7 +5022,6 @@ impl Disc {
 
     // optional sint32 number = 1;
 
-
     pub fn get_number(&self) -> i32 {
         self.number.unwrap_or(0)
     }
@@ -4623,7 +5039,6 @@ impl Disc {
     }
 
     // optional string name = 2;
-
 
     pub fn get_name(&self) -> &str {
         match self.name.as_ref() {
@@ -4655,11 +5070,12 @@ impl Disc {
 
     // Take field
     pub fn take_name(&mut self) -> ::std::string::String {
-        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // repeated .Track track = 3;
-
 
     pub fn get_track(&self) -> &[Track] {
         &self.track
@@ -4690,30 +5106,40 @@ impl ::protobuf::Message for Disc {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.number = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.track)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4732,13 +5158,16 @@ impl ::protobuf::Message for Disc {
         for value in &self.track {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.number {
             os.write_sint32(1, v)?;
         }
@@ -4749,7 +5178,7 @@ impl ::protobuf::Message for Disc {
             os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -4785,32 +5214,38 @@ impl ::protobuf::Message for Disc {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "number",
-                    |m: &Disc| { &m.number },
-                    |m: &mut Disc| { &mut m.number },
+                    |m: &Disc| &m.number,
+                    |m: &mut Disc| &mut m.number,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "name",
-                    |m: &Disc| { &m.name },
-                    |m: &mut Disc| { &mut m.name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Track>>(
-                    "track",
-                    |m: &Disc| { &m.track },
-                    |m: &mut Disc| { &mut m.track },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >("name", |m: &Disc| &m.name, |m: &mut Disc| &mut m.name),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Track>,
+                    >("track", |m: &Disc| &m.track, |m: &mut Disc| &mut m.track),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Disc>(
                     "Disc",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -4821,9 +5256,7 @@ impl ::protobuf::Message for Disc {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Disc,
         };
-        unsafe {
-            instance.get(Disc::new)
-        }
+        unsafe { instance.get(Disc::new) }
     }
 }
 
@@ -4848,7 +5281,7 @@ impl ::protobuf::reflect::ProtobufValue for Disc {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Copyright {
     // message fields
     typ: ::std::option::Option<Copyright_Type>,
@@ -4871,7 +5304,6 @@ impl Copyright {
 
     // optional .Copyright.Type typ = 1;
 
-
     pub fn get_typ(&self) -> Copyright_Type {
         self.typ.unwrap_or(Copyright_Type::P)
     }
@@ -4889,7 +5321,6 @@ impl Copyright {
     }
 
     // optional string text = 2;
-
 
     pub fn get_text(&self) -> &str {
         match self.text.as_ref() {
@@ -4921,7 +5352,9 @@ impl Copyright {
 
     // Take field
     pub fn take_text(&mut self) -> ::std::string::String {
-        self.text.take().unwrap_or_else(|| ::std::string::String::new())
+        self.text
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -4930,19 +5363,31 @@ impl ::protobuf::Message for Copyright {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                1 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.typ, 1, &mut self.unknown_fields)?
-                },
+                1 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.typ,
+                    1,
+                    &mut self.unknown_fields,
+                )?,
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.text)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -4963,7 +5408,10 @@ impl ::protobuf::Message for Copyright {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.typ {
             os.write_enum(1, v.value())?;
         }
@@ -5005,27 +5453,36 @@ impl ::protobuf::Message for Copyright {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Copyright_Type>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Copyright_Type>,
+                >(
                     "typ",
-                    |m: &Copyright| { &m.typ },
-                    |m: &mut Copyright| { &mut m.typ },
+                    |m: &Copyright| &m.typ,
+                    |m: &mut Copyright| &mut m.typ,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "text",
-                    |m: &Copyright| { &m.text },
-                    |m: &mut Copyright| { &mut m.text },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "text",
+                        |m: &Copyright| &m.text,
+                        |m: &mut Copyright| &mut m.text,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Copyright>(
                     "Copyright",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -5036,9 +5493,7 @@ impl ::protobuf::Message for Copyright {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Copyright,
         };
-        unsafe {
-            instance.get(Copyright::new)
-        }
+        unsafe { instance.get(Copyright::new) }
     }
 }
 
@@ -5062,7 +5517,7 @@ impl ::protobuf::reflect::ProtobufValue for Copyright {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Copyright_Type {
     P = 0,
     C = 1,
@@ -5077,23 +5532,21 @@ impl ::protobuf::ProtobufEnum for Copyright_Type {
         match value {
             0 => ::std::option::Option::Some(Copyright_Type::P),
             1 => ::std::option::Option::Some(Copyright_Type::C),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
     fn values() -> &'static [Self] {
-        static values: &'static [Copyright_Type] = &[
-            Copyright_Type::P,
-            Copyright_Type::C,
-        ];
+        static values: &'static [Copyright_Type] = &[Copyright_Type::P, Copyright_Type::C];
         values
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Copyright_Type", file_descriptor_proto())
@@ -5102,8 +5555,7 @@ impl ::protobuf::ProtobufEnum for Copyright_Type {
     }
 }
 
-impl ::std::marker::Copy for Copyright_Type {
-}
+impl ::std::marker::Copy for Copyright_Type {}
 
 impl ::std::default::Default for Copyright_Type {
     fn default() -> Self {
@@ -5117,7 +5569,7 @@ impl ::protobuf::reflect::ProtobufValue for Copyright_Type {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Restriction {
     // message fields
     catalogue: ::std::vec::Vec<Restriction_Catalogue>,
@@ -5143,7 +5595,6 @@ impl Restriction {
 
     // repeated .Restriction.Catalogue catalogue = 1;
 
-
     pub fn get_catalogue(&self) -> &[Restriction_Catalogue] {
         &self.catalogue
     }
@@ -5167,7 +5618,6 @@ impl Restriction {
     }
 
     // optional string countries_allowed = 2;
-
 
     pub fn get_countries_allowed(&self) -> &str {
         match self.countries_allowed.as_ref() {
@@ -5199,11 +5649,12 @@ impl Restriction {
 
     // Take field
     pub fn take_countries_allowed(&mut self) -> ::std::string::String {
-        self.countries_allowed.take().unwrap_or_else(|| ::std::string::String::new())
+        self.countries_allowed
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string countries_forbidden = 3;
-
 
     pub fn get_countries_forbidden(&self) -> &str {
         match self.countries_forbidden.as_ref() {
@@ -5235,11 +5686,12 @@ impl Restriction {
 
     // Take field
     pub fn take_countries_forbidden(&mut self) -> ::std::string::String {
-        self.countries_forbidden.take().unwrap_or_else(|| ::std::string::String::new())
+        self.countries_forbidden
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional .Restriction.Type typ = 4;
-
 
     pub fn get_typ(&self) -> Restriction_Type {
         self.typ.unwrap_or(Restriction_Type::STREAMING)
@@ -5258,7 +5710,6 @@ impl Restriction {
     }
 
     // repeated string catalogue_str = 5;
-
 
     pub fn get_catalogue_str(&self) -> &[::std::string::String] {
         &self.catalogue_str
@@ -5288,28 +5739,56 @@ impl ::protobuf::Message for Restriction {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                1 => {
-                    ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(wire_type, is, &mut self.catalogue, 1, &mut self.unknown_fields)?
-                },
+                1 => ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.catalogue,
+                    1,
+                    &mut self.unknown_fields,
+                )?,
                 2 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.countries_allowed)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.countries_allowed,
+                    )?;
+                }
                 3 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.countries_forbidden)?;
-                },
-                4 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.typ, 4, &mut self.unknown_fields)?
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.countries_forbidden,
+                    )?;
+                }
+                4 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.typ,
+                    4,
+                    &mut self.unknown_fields,
+                )?,
                 5 => {
-                    ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.catalogue_str)?;
-                },
+                    ::protobuf::rt::read_repeated_string_into(
+                        wire_type,
+                        is,
+                        &mut self.catalogue_str,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -5321,7 +5800,7 @@ impl ::protobuf::Message for Restriction {
         let mut my_size = 0;
         for value in &self.catalogue {
             my_size += ::protobuf::rt::enum_size(1, *value);
-        };
+        }
         if let Some(ref v) = self.countries_allowed.as_ref() {
             my_size += ::protobuf::rt::string_size(2, &v);
         }
@@ -5333,16 +5812,19 @@ impl ::protobuf::Message for Restriction {
         }
         for value in &self.catalogue_str {
             my_size += ::protobuf::rt::string_size(5, &value);
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         for v in &self.catalogue {
             os.write_enum(1, v.value())?;
-        };
+        }
         if let Some(ref v) = self.countries_allowed.as_ref() {
             os.write_string(2, &v)?;
         }
@@ -5354,7 +5836,7 @@ impl ::protobuf::Message for Restriction {
         }
         for v in &self.catalogue_str {
             os.write_string(5, &v)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -5390,42 +5872,64 @@ impl ::protobuf::Message for Restriction {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Restriction_Catalogue>>(
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Restriction_Catalogue>,
+                >(
                     "catalogue",
-                    |m: &Restriction| { &m.catalogue },
-                    |m: &mut Restriction| { &mut m.catalogue },
+                    |m: &Restriction| &m.catalogue,
+                    |m: &mut Restriction| &mut m.catalogue,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "countries_allowed",
-                    |m: &Restriction| { &m.countries_allowed },
-                    |m: &mut Restriction| { &mut m.countries_allowed },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "countries_forbidden",
-                    |m: &Restriction| { &m.countries_forbidden },
-                    |m: &mut Restriction| { &mut m.countries_forbidden },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Restriction_Type>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "countries_allowed",
+                        |m: &Restriction| &m.countries_allowed,
+                        |m: &mut Restriction| &mut m.countries_allowed,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "countries_forbidden",
+                        |m: &Restriction| &m.countries_forbidden,
+                        |m: &mut Restriction| &mut m.countries_forbidden,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Restriction_Type>,
+                >(
                     "typ",
-                    |m: &Restriction| { &m.typ },
-                    |m: &mut Restriction| { &mut m.typ },
+                    |m: &Restriction| &m.typ,
+                    |m: &mut Restriction| &mut m.typ,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "catalogue_str",
-                    |m: &Restriction| { &m.catalogue_str },
-                    |m: &mut Restriction| { &mut m.catalogue_str },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "catalogue_str",
+                        |m: &Restriction| &m.catalogue_str,
+                        |m: &mut Restriction| &mut m.catalogue_str,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Restriction>(
                     "Restriction",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -5436,9 +5940,7 @@ impl ::protobuf::Message for Restriction {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Restriction,
         };
-        unsafe {
-            instance.get(Restriction::new)
-        }
+        unsafe { instance.get(Restriction::new) }
     }
 }
 
@@ -5465,7 +5967,7 @@ impl ::protobuf::reflect::ProtobufValue for Restriction {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Restriction_Catalogue {
     AD = 0,
     SUBSCRIPTION = 1,
@@ -5486,7 +5988,7 @@ impl ::protobuf::ProtobufEnum for Restriction_Catalogue {
             2 => ::std::option::Option::Some(Restriction_Catalogue::CATALOGUE_ALL),
             3 => ::std::option::Option::Some(Restriction_Catalogue::SHUFFLE),
             4 => ::std::option::Option::Some(Restriction_Catalogue::COMMERCIAL),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -5502,20 +6004,23 @@ impl ::protobuf::ProtobufEnum for Restriction_Catalogue {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("Restriction_Catalogue", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "Restriction_Catalogue",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for Restriction_Catalogue {
-}
+impl ::std::marker::Copy for Restriction_Catalogue {}
 
 impl ::std::default::Default for Restriction_Catalogue {
     fn default() -> Self {
@@ -5529,7 +6034,7 @@ impl ::protobuf::reflect::ProtobufValue for Restriction_Catalogue {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Restriction_Type {
     STREAMING = 0,
 }
@@ -5542,32 +6047,33 @@ impl ::protobuf::ProtobufEnum for Restriction_Type {
     fn from_i32(value: i32) -> ::std::option::Option<Restriction_Type> {
         match value {
             0 => ::std::option::Option::Some(Restriction_Type::STREAMING),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
     fn values() -> &'static [Self] {
-        static values: &'static [Restriction_Type] = &[
-            Restriction_Type::STREAMING,
-        ];
+        static values: &'static [Restriction_Type] = &[Restriction_Type::STREAMING];
         values
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("Restriction_Type", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "Restriction_Type",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for Restriction_Type {
-}
+impl ::std::marker::Copy for Restriction_Type {}
 
 impl ::std::default::Default for Restriction_Type {
     fn default() -> Self {
@@ -5581,7 +6087,7 @@ impl ::protobuf::reflect::ProtobufValue for Restriction_Type {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Availability {
     // message fields
     catalogue_str: ::protobuf::RepeatedField<::std::string::String>,
@@ -5603,7 +6109,6 @@ impl Availability {
     }
 
     // repeated string catalogue_str = 1;
-
 
     pub fn get_catalogue_str(&self) -> &[::std::string::String] {
         &self.catalogue_str
@@ -5629,9 +6134,10 @@ impl Availability {
 
     // optional .Date start = 2;
 
-
     pub fn get_start(&self) -> &Date {
-        self.start.as_ref().unwrap_or_else(|| Date::default_instance())
+        self.start
+            .as_ref()
+            .unwrap_or_else(|| Date::default_instance())
     }
     pub fn clear_start(&mut self) {
         self.start.clear();
@@ -5667,23 +6173,35 @@ impl ::protobuf::Message for Availability {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.catalogue_str)?;
-                },
+                    ::protobuf::rt::read_repeated_string_into(
+                        wire_type,
+                        is,
+                        &mut self.catalogue_str,
+                    )?;
+                }
                 2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.start)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -5695,7 +6213,7 @@ impl ::protobuf::Message for Availability {
         let mut my_size = 0;
         for value in &self.catalogue_str {
             my_size += ::protobuf::rt::string_size(1, &value);
-        };
+        }
         if let Some(ref v) = self.start.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -5705,10 +6223,13 @@ impl ::protobuf::Message for Availability {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         for v in &self.catalogue_str {
             os.write_string(1, &v)?;
-        };
+        }
         if let Some(ref v) = self.start.as_ref() {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -5749,27 +6270,38 @@ impl ::protobuf::Message for Availability {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "catalogue_str",
-                    |m: &Availability| { &m.catalogue_str },
-                    |m: &mut Availability| { &mut m.catalogue_str },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Date>>(
-                    "start",
-                    |m: &Availability| { &m.start },
-                    |m: &mut Availability| { &mut m.start },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "catalogue_str",
+                        |m: &Availability| &m.catalogue_str,
+                        |m: &mut Availability| &mut m.catalogue_str,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Date>,
+                    >(
+                        "start",
+                        |m: &Availability| &m.start,
+                        |m: &mut Availability| &mut m.start,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Availability>(
                     "Availability",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -5780,9 +6312,7 @@ impl ::protobuf::Message for Availability {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Availability,
         };
-        unsafe {
-            instance.get(Availability::new)
-        }
+        unsafe { instance.get(Availability::new) }
     }
 }
 
@@ -5806,7 +6336,7 @@ impl ::protobuf::reflect::ProtobufValue for Availability {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct SalePeriod {
     // message fields
     restriction: ::protobuf::RepeatedField<Restriction>,
@@ -5829,7 +6359,6 @@ impl SalePeriod {
     }
 
     // repeated .Restriction restriction = 1;
-
 
     pub fn get_restriction(&self) -> &[Restriction] {
         &self.restriction
@@ -5855,9 +6384,10 @@ impl SalePeriod {
 
     // optional .Date start = 2;
 
-
     pub fn get_start(&self) -> &Date {
-        self.start.as_ref().unwrap_or_else(|| Date::default_instance())
+        self.start
+            .as_ref()
+            .unwrap_or_else(|| Date::default_instance())
     }
     pub fn clear_start(&mut self) {
         self.start.clear();
@@ -5888,9 +6418,10 @@ impl SalePeriod {
 
     // optional .Date end = 3;
 
-
     pub fn get_end(&self) -> &Date {
-        self.end.as_ref().unwrap_or_else(|| Date::default_instance())
+        self.end
+            .as_ref()
+            .unwrap_or_else(|| Date::default_instance())
     }
     pub fn clear_end(&mut self) {
         self.end.clear();
@@ -5926,36 +6457,48 @@ impl ::protobuf::Message for SalePeriod {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.start {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.end {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.restriction)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.restriction,
+                    )?;
+                }
                 2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.start)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.end)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -5968,7 +6511,7 @@ impl ::protobuf::Message for SalePeriod {
         for value in &self.restriction {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.start.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -5982,12 +6525,15 @@ impl ::protobuf::Message for SalePeriod {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         for v in &self.restriction {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.start.as_ref() {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -6033,32 +6579,48 @@ impl ::protobuf::Message for SalePeriod {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Restriction>>(
-                    "restriction",
-                    |m: &SalePeriod| { &m.restriction },
-                    |m: &mut SalePeriod| { &mut m.restriction },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Date>>(
-                    "start",
-                    |m: &SalePeriod| { &m.start },
-                    |m: &mut SalePeriod| { &mut m.start },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Date>>(
-                    "end",
-                    |m: &SalePeriod| { &m.end },
-                    |m: &mut SalePeriod| { &mut m.end },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Restriction>,
+                    >(
+                        "restriction",
+                        |m: &SalePeriod| &m.restriction,
+                        |m: &mut SalePeriod| &mut m.restriction,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Date>,
+                    >(
+                        "start",
+                        |m: &SalePeriod| &m.start,
+                        |m: &mut SalePeriod| &mut m.start,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Date>,
+                    >(
+                        "end",
+                        |m: &SalePeriod| &m.end,
+                        |m: &mut SalePeriod| &mut m.end,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<SalePeriod>(
                     "SalePeriod",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -6069,9 +6631,7 @@ impl ::protobuf::Message for SalePeriod {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const SalePeriod,
         };
-        unsafe {
-            instance.get(SalePeriod::new)
-        }
+        unsafe { instance.get(SalePeriod::new) }
     }
 }
 
@@ -6096,7 +6656,7 @@ impl ::protobuf::reflect::ProtobufValue for SalePeriod {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ExternalId {
     // message fields
     typ: ::protobuf::SingularField<::std::string::String>,
@@ -6118,7 +6678,6 @@ impl ExternalId {
     }
 
     // optional string typ = 1;
-
 
     pub fn get_typ(&self) -> &str {
         match self.typ.as_ref() {
@@ -6150,11 +6709,12 @@ impl ExternalId {
 
     // Take field
     pub fn take_typ(&mut self) -> ::std::string::String {
-        self.typ.take().unwrap_or_else(|| ::std::string::String::new())
+        self.typ
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string id = 2;
-
 
     pub fn get_id(&self) -> &str {
         match self.id.as_ref() {
@@ -6186,7 +6746,9 @@ impl ExternalId {
 
     // Take field
     pub fn take_id(&mut self) -> ::std::string::String {
-        self.id.take().unwrap_or_else(|| ::std::string::String::new())
+        self.id
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -6195,19 +6757,27 @@ impl ::protobuf::Message for ExternalId {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.typ)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.id)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -6228,7 +6798,10 @@ impl ::protobuf::Message for ExternalId {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.typ.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -6270,27 +6843,36 @@ impl ::protobuf::Message for ExternalId {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "typ",
-                    |m: &ExternalId| { &m.typ },
-                    |m: &mut ExternalId| { &mut m.typ },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "id",
-                    |m: &ExternalId| { &m.id },
-                    |m: &mut ExternalId| { &mut m.id },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "typ",
+                        |m: &ExternalId| &m.typ,
+                        |m: &mut ExternalId| &mut m.typ,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "id", |m: &ExternalId| &m.id, |m: &mut ExternalId| &mut m.id
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ExternalId>(
                     "ExternalId",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -6301,9 +6883,7 @@ impl ::protobuf::Message for ExternalId {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ExternalId,
         };
-        unsafe {
-            instance.get(ExternalId::new)
-        }
+        unsafe { instance.get(ExternalId::new) }
     }
 }
 
@@ -6327,7 +6907,7 @@ impl ::protobuf::reflect::ProtobufValue for ExternalId {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct AudioFile {
     // message fields
     file_id: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -6349,7 +6929,6 @@ impl AudioFile {
     }
 
     // optional bytes file_id = 1;
-
 
     pub fn get_file_id(&self) -> &[u8] {
         match self.file_id.as_ref() {
@@ -6381,11 +6960,12 @@ impl AudioFile {
 
     // Take field
     pub fn take_file_id(&mut self) -> ::std::vec::Vec<u8> {
-        self.file_id.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.file_id
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional .AudioFile.Format format = 2;
-
 
     pub fn get_format(&self) -> AudioFile_Format {
         self.format.unwrap_or(AudioFile_Format::OGG_VORBIS_96)
@@ -6409,19 +6989,31 @@ impl ::protobuf::Message for AudioFile {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.file_id)?;
-                },
-                2 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.format, 2, &mut self.unknown_fields)?
-                },
+                }
+                2 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.format,
+                    2,
+                    &mut self.unknown_fields,
+                )?,
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -6442,7 +7034,10 @@ impl ::protobuf::Message for AudioFile {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.file_id.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -6484,27 +7079,36 @@ impl ::protobuf::Message for AudioFile {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "file_id",
-                    |m: &AudioFile| { &m.file_id },
-                    |m: &mut AudioFile| { &mut m.file_id },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<AudioFile_Format>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "file_id",
+                        |m: &AudioFile| &m.file_id,
+                        |m: &mut AudioFile| &mut m.file_id,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<AudioFile_Format>,
+                >(
                     "format",
-                    |m: &AudioFile| { &m.format },
-                    |m: &mut AudioFile| { &mut m.format },
+                    |m: &AudioFile| &m.format,
+                    |m: &mut AudioFile| &mut m.format,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<AudioFile>(
                     "AudioFile",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -6515,9 +7119,7 @@ impl ::protobuf::Message for AudioFile {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const AudioFile,
         };
-        unsafe {
-            instance.get(AudioFile::new)
-        }
+        unsafe { instance.get(AudioFile::new) }
     }
 }
 
@@ -6541,7 +7143,7 @@ impl ::protobuf::reflect::ProtobufValue for AudioFile {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum AudioFile_Format {
     OGG_VORBIS_96 = 0,
     OGG_VORBIS_160 = 1,
@@ -6580,7 +7182,7 @@ impl ::protobuf::ProtobufEnum for AudioFile_Format {
             11 => ::std::option::Option::Some(AudioFile_Format::AAC_320),
             12 => ::std::option::Option::Some(AudioFile_Format::MP4_128),
             13 => ::std::option::Option::Some(AudioFile_Format::OTHER5),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -6605,20 +7207,23 @@ impl ::protobuf::ProtobufEnum for AudioFile_Format {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("AudioFile_Format", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "AudioFile_Format",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for AudioFile_Format {
-}
+impl ::std::marker::Copy for AudioFile_Format {}
 
 impl ::std::default::Default for AudioFile_Format {
     fn default() -> Self {
@@ -6632,7 +7237,7 @@ impl ::protobuf::reflect::ProtobufValue for AudioFile_Format {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct VideoFile {
     // message fields
     file_id: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -6653,7 +7258,6 @@ impl VideoFile {
     }
 
     // optional bytes file_id = 1;
-
 
     pub fn get_file_id(&self) -> &[u8] {
         match self.file_id.as_ref() {
@@ -6685,7 +7289,9 @@ impl VideoFile {
 
     // Take field
     pub fn take_file_id(&mut self) -> ::std::vec::Vec<u8> {
-        self.file_id.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.file_id
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -6694,16 +7300,24 @@ impl ::protobuf::Message for VideoFile {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.file_id)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -6721,7 +7335,10 @@ impl ::protobuf::Message for VideoFile {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.file_id.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -6760,22 +7377,28 @@ impl ::protobuf::Message for VideoFile {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "file_id",
-                    |m: &VideoFile| { &m.file_id },
-                    |m: &mut VideoFile| { &mut m.file_id },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "file_id",
+                        |m: &VideoFile| &m.file_id,
+                        |m: &mut VideoFile| &mut m.file_id,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<VideoFile>(
                     "VideoFile",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -6786,9 +7409,7 @@ impl ::protobuf::Message for VideoFile {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const VideoFile,
         };
-        unsafe {
-            instance.get(VideoFile::new)
-        }
+        unsafe { instance.get(VideoFile::new) }
     }
 }
 
@@ -6811,7 +7432,7 @@ impl ::protobuf::reflect::ProtobufValue for VideoFile {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Show {
     // message fields
     gid: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -6851,7 +7472,6 @@ impl Show {
 
     // optional bytes gid = 1;
 
-
     pub fn get_gid(&self) -> &[u8] {
         match self.gid.as_ref() {
             Some(v) => &v,
@@ -6887,7 +7507,6 @@ impl Show {
 
     // optional string name = 2;
 
-
     pub fn get_name(&self) -> &str {
         match self.name.as_ref() {
             Some(v) => &v,
@@ -6918,11 +7537,12 @@ impl Show {
 
     // Take field
     pub fn take_name(&mut self) -> ::std::string::String {
-        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string description = 64;
-
 
     pub fn get_description(&self) -> &str {
         match self.description.as_ref() {
@@ -6954,11 +7574,12 @@ impl Show {
 
     // Take field
     pub fn take_description(&mut self) -> ::std::string::String {
-        self.description.take().unwrap_or_else(|| ::std::string::String::new())
+        self.description
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional sint32 deprecated_popularity = 65;
-
 
     pub fn get_deprecated_popularity(&self) -> i32 {
         self.deprecated_popularity.unwrap_or(0)
@@ -6977,7 +7598,6 @@ impl Show {
     }
 
     // optional string publisher = 66;
-
 
     pub fn get_publisher(&self) -> &str {
         match self.publisher.as_ref() {
@@ -7009,11 +7629,12 @@ impl Show {
 
     // Take field
     pub fn take_publisher(&mut self) -> ::std::string::String {
-        self.publisher.take().unwrap_or_else(|| ::std::string::String::new())
+        self.publisher
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string language = 67;
-
 
     pub fn get_language(&self) -> &str {
         match self.language.as_ref() {
@@ -7045,11 +7666,12 @@ impl Show {
 
     // Take field
     pub fn take_language(&mut self) -> ::std::string::String {
-        self.language.take().unwrap_or_else(|| ::std::string::String::new())
+        self.language
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bool explicit = 68;
-
 
     pub fn get_explicit(&self) -> bool {
         self.explicit.unwrap_or(false)
@@ -7069,9 +7691,10 @@ impl Show {
 
     // optional .ImageGroup covers = 69;
 
-
     pub fn get_covers(&self) -> &ImageGroup {
-        self.covers.as_ref().unwrap_or_else(|| ImageGroup::default_instance())
+        self.covers
+            .as_ref()
+            .unwrap_or_else(|| ImageGroup::default_instance())
     }
     pub fn clear_covers(&mut self) {
         self.covers.clear();
@@ -7102,7 +7725,6 @@ impl Show {
 
     // repeated .Episode episode = 70;
 
-
     pub fn get_episode(&self) -> &[Episode] {
         &self.episode
     }
@@ -7126,7 +7748,6 @@ impl Show {
     }
 
     // repeated .Copyright copyright = 71;
-
 
     pub fn get_copyright(&self) -> &[Copyright] {
         &self.copyright
@@ -7152,7 +7773,6 @@ impl Show {
 
     // repeated .Restriction restriction = 72;
 
-
     pub fn get_restriction(&self) -> &[Restriction] {
         &self.restriction
     }
@@ -7176,7 +7796,6 @@ impl Show {
     }
 
     // repeated string keyword = 73;
-
 
     pub fn get_keyword(&self) -> &[::std::string::String] {
         &self.keyword
@@ -7202,7 +7821,6 @@ impl Show {
 
     // optional .Show.MediaType media_type = 74;
 
-
     pub fn get_media_type(&self) -> Show_MediaType {
         self.media_type.unwrap_or(Show_MediaType::MIXED)
     }
@@ -7221,9 +7839,9 @@ impl Show {
 
     // optional .Show.ConsumptionOrder consumption_order = 75;
 
-
     pub fn get_consumption_order(&self) -> Show_ConsumptionOrder {
-        self.consumption_order.unwrap_or(Show_ConsumptionOrder::SEQUENTIAL)
+        self.consumption_order
+            .unwrap_or(Show_ConsumptionOrder::SEQUENTIAL)
     }
     pub fn clear_consumption_order(&mut self) {
         self.consumption_order = ::std::option::Option::None;
@@ -7239,7 +7857,6 @@ impl Show {
     }
 
     // optional bool interpret_restriction_using_geoip = 76;
-
 
     pub fn get_interpret_restriction_using_geoip(&self) -> bool {
         self.interpret_restriction_using_geoip.unwrap_or(false)
@@ -7258,7 +7875,6 @@ impl Show {
     }
 
     // repeated .Availability availability = 78;
-
 
     pub fn get_availability(&self) -> &[Availability] {
         &self.availability
@@ -7283,7 +7899,6 @@ impl Show {
     }
 
     // optional string country_of_origin = 79;
-
 
     pub fn get_country_of_origin(&self) -> &str {
         match self.country_of_origin.as_ref() {
@@ -7315,11 +7930,12 @@ impl Show {
 
     // Take field
     pub fn take_country_of_origin(&mut self) -> ::std::string::String {
-        self.country_of_origin.take().unwrap_or_else(|| ::std::string::String::new())
+        self.country_of_origin
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // repeated .Category categories = 80;
-
 
     pub fn get_categories(&self) -> &[Category] {
         &self.categories
@@ -7345,7 +7961,6 @@ impl Show {
 
     // optional .Show.PassthroughEnum passthrough = 81;
 
-
     pub fn get_passthrough(&self) -> Show_PassthroughEnum {
         self.passthrough.unwrap_or(Show_PassthroughEnum::UNKNOWN)
     }
@@ -7369,111 +7984,157 @@ impl ::protobuf::Message for Show {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.episode {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.copyright {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.restriction {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.availability {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.categories {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gid)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
-                },
+                }
                 64 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.description)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.description,
+                    )?;
+                }
                 65 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.deprecated_popularity = ::std::option::Option::Some(tmp);
-                },
+                }
                 66 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.publisher)?;
-                },
+                }
                 67 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.language)?;
-                },
+                }
                 68 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.explicit = ::std::option::Option::Some(tmp);
-                },
+                }
                 69 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.covers)?;
-                },
+                }
                 70 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.episode)?;
-                },
+                }
                 71 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.copyright)?;
-                },
+                }
                 72 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.restriction)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.restriction,
+                    )?;
+                }
                 73 => {
                     ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.keyword)?;
-                },
-                74 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.media_type, 74, &mut self.unknown_fields)?
-                },
-                75 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.consumption_order, 75, &mut self.unknown_fields)?
-                },
+                }
+                74 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.media_type,
+                    74,
+                    &mut self.unknown_fields,
+                )?,
+                75 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.consumption_order,
+                    75,
+                    &mut self.unknown_fields,
+                )?,
                 76 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.interpret_restriction_using_geoip = ::std::option::Option::Some(tmp);
-                },
+                }
                 78 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.availability)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.availability,
+                    )?;
+                }
                 79 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.country_of_origin)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.country_of_origin,
+                    )?;
+                }
                 80 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.categories)?;
-                },
-                81 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.passthrough, 81, &mut self.unknown_fields)?
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.categories,
+                    )?;
+                }
+                81 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.passthrough,
+                    81,
+                    &mut self.unknown_fields,
+                )?,
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -7511,18 +8172,18 @@ impl ::protobuf::Message for Show {
         for value in &self.episode {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.copyright {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.restriction {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.keyword {
             my_size += ::protobuf::rt::string_size(73, &value);
-        };
+        }
         if let Some(v) = self.media_type {
             my_size += ::protobuf::rt::enum_size(74, v);
         }
@@ -7535,14 +8196,14 @@ impl ::protobuf::Message for Show {
         for value in &self.availability {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.country_of_origin.as_ref() {
             my_size += ::protobuf::rt::string_size(79, &v);
         }
         for value in &self.categories {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(v) = self.passthrough {
             my_size += ::protobuf::rt::enum_size(81, v);
         }
@@ -7551,7 +8212,10 @@ impl ::protobuf::Message for Show {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.gid.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -7582,20 +8246,20 @@ impl ::protobuf::Message for Show {
             os.write_tag(70, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.copyright {
             os.write_tag(71, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.restriction {
             os.write_tag(72, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.keyword {
             os.write_string(73, &v)?;
-        };
+        }
         if let Some(v) = self.media_type {
             os.write_enum(74, v.value())?;
         }
@@ -7609,7 +8273,7 @@ impl ::protobuf::Message for Show {
             os.write_tag(78, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.country_of_origin.as_ref() {
             os.write_string(79, &v)?;
         }
@@ -7617,7 +8281,7 @@ impl ::protobuf::Message for Show {
             os.write_tag(80, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(v) = self.passthrough {
             os.write_enum(81, v.value())?;
         }
@@ -7656,112 +8320,186 @@ impl ::protobuf::Message for Show {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gid",
-                    |m: &Show| { &m.gid },
-                    |m: &mut Show| { &mut m.gid },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "name",
-                    |m: &Show| { &m.name },
-                    |m: &mut Show| { &mut m.name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "description",
-                    |m: &Show| { &m.description },
-                    |m: &mut Show| { &mut m.description },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >("gid", |m: &Show| &m.gid, |m: &mut Show| &mut m.gid),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >("name", |m: &Show| &m.name, |m: &mut Show| &mut m.name),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "description",
+                        |m: &Show| &m.description,
+                        |m: &mut Show| &mut m.description,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "deprecated_popularity",
-                    |m: &Show| { &m.deprecated_popularity },
-                    |m: &mut Show| { &mut m.deprecated_popularity },
+                    |m: &Show| &m.deprecated_popularity,
+                    |m: &mut Show| &mut m.deprecated_popularity,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "publisher",
-                    |m: &Show| { &m.publisher },
-                    |m: &mut Show| { &mut m.publisher },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "language",
-                    |m: &Show| { &m.language },
-                    |m: &mut Show| { &mut m.language },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "publisher",
+                        |m: &Show| &m.publisher,
+                        |m: &mut Show| &mut m.publisher,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "language",
+                        |m: &Show| &m.language,
+                        |m: &mut Show| &mut m.language,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "explicit",
-                    |m: &Show| { &m.explicit },
-                    |m: &mut Show| { &mut m.explicit },
+                    |m: &Show| &m.explicit,
+                    |m: &mut Show| &mut m.explicit,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ImageGroup>>(
-                    "covers",
-                    |m: &Show| { &m.covers },
-                    |m: &mut Show| { &mut m.covers },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Episode>>(
-                    "episode",
-                    |m: &Show| { &m.episode },
-                    |m: &mut Show| { &mut m.episode },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Copyright>>(
-                    "copyright",
-                    |m: &Show| { &m.copyright },
-                    |m: &mut Show| { &mut m.copyright },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Restriction>>(
-                    "restriction",
-                    |m: &Show| { &m.restriction },
-                    |m: &mut Show| { &mut m.restriction },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "keyword",
-                    |m: &Show| { &m.keyword },
-                    |m: &mut Show| { &mut m.keyword },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Show_MediaType>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ImageGroup>,
+                    >(
+                        "covers", |m: &Show| &m.covers, |m: &mut Show| &mut m.covers
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Episode>,
+                    >(
+                        "episode",
+                        |m: &Show| &m.episode,
+                        |m: &mut Show| &mut m.episode,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Copyright>,
+                    >(
+                        "copyright",
+                        |m: &Show| &m.copyright,
+                        |m: &mut Show| &mut m.copyright,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Restriction>,
+                    >(
+                        "restriction",
+                        |m: &Show| &m.restriction,
+                        |m: &mut Show| &mut m.restriction,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "keyword",
+                        |m: &Show| &m.keyword,
+                        |m: &mut Show| &mut m.keyword,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Show_MediaType>,
+                >(
                     "media_type",
-                    |m: &Show| { &m.media_type },
-                    |m: &mut Show| { &mut m.media_type },
+                    |m: &Show| &m.media_type,
+                    |m: &mut Show| &mut m.media_type,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Show_ConsumptionOrder>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Show_ConsumptionOrder>,
+                >(
                     "consumption_order",
-                    |m: &Show| { &m.consumption_order },
-                    |m: &mut Show| { &mut m.consumption_order },
+                    |m: &Show| &m.consumption_order,
+                    |m: &mut Show| &mut m.consumption_order,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "interpret_restriction_using_geoip",
-                    |m: &Show| { &m.interpret_restriction_using_geoip },
-                    |m: &mut Show| { &mut m.interpret_restriction_using_geoip },
+                    |m: &Show| &m.interpret_restriction_using_geoip,
+                    |m: &mut Show| &mut m.interpret_restriction_using_geoip,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Availability>>(
-                    "availability",
-                    |m: &Show| { &m.availability },
-                    |m: &mut Show| { &mut m.availability },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "country_of_origin",
-                    |m: &Show| { &m.country_of_origin },
-                    |m: &mut Show| { &mut m.country_of_origin },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Category>>(
-                    "categories",
-                    |m: &Show| { &m.categories },
-                    |m: &mut Show| { &mut m.categories },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Show_PassthroughEnum>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Availability>,
+                    >(
+                        "availability",
+                        |m: &Show| &m.availability,
+                        |m: &mut Show| &mut m.availability,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "country_of_origin",
+                        |m: &Show| &m.country_of_origin,
+                        |m: &mut Show| &mut m.country_of_origin,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Category>,
+                    >(
+                        "categories",
+                        |m: &Show| &m.categories,
+                        |m: &mut Show| &mut m.categories,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Show_PassthroughEnum>,
+                >(
                     "passthrough",
-                    |m: &Show| { &m.passthrough },
-                    |m: &mut Show| { &mut m.passthrough },
+                    |m: &Show| &m.passthrough,
+                    |m: &mut Show| &mut m.passthrough,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Show>(
                     "Show",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -7772,9 +8510,7 @@ impl ::protobuf::Message for Show {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Show,
         };
-        unsafe {
-            instance.get(Show::new)
-        }
+        unsafe { instance.get(Show::new) }
     }
 }
 
@@ -7815,7 +8551,7 @@ impl ::protobuf::reflect::ProtobufValue for Show {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Show_MediaType {
     MIXED = 0,
     AUDIO = 1,
@@ -7832,7 +8568,7 @@ impl ::protobuf::ProtobufEnum for Show_MediaType {
             0 => ::std::option::Option::Some(Show_MediaType::MIXED),
             1 => ::std::option::Option::Some(Show_MediaType::AUDIO),
             2 => ::std::option::Option::Some(Show_MediaType::VIDEO),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -7846,10 +8582,11 @@ impl ::protobuf::ProtobufEnum for Show_MediaType {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Show_MediaType", file_descriptor_proto())
@@ -7858,8 +8595,7 @@ impl ::protobuf::ProtobufEnum for Show_MediaType {
     }
 }
 
-impl ::std::marker::Copy for Show_MediaType {
-}
+impl ::std::marker::Copy for Show_MediaType {}
 
 impl ::std::default::Default for Show_MediaType {
     fn default() -> Self {
@@ -7873,7 +8609,7 @@ impl ::protobuf::reflect::ProtobufValue for Show_MediaType {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Show_ConsumptionOrder {
     SEQUENTIAL = 1,
     EPISODIC = 2,
@@ -7890,7 +8626,7 @@ impl ::protobuf::ProtobufEnum for Show_ConsumptionOrder {
             1 => ::std::option::Option::Some(Show_ConsumptionOrder::SEQUENTIAL),
             2 => ::std::option::Option::Some(Show_ConsumptionOrder::EPISODIC),
             3 => ::std::option::Option::Some(Show_ConsumptionOrder::RECENT),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -7904,20 +8640,23 @@ impl ::protobuf::ProtobufEnum for Show_ConsumptionOrder {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("Show_ConsumptionOrder", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "Show_ConsumptionOrder",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for Show_ConsumptionOrder {
-}
+impl ::std::marker::Copy for Show_ConsumptionOrder {}
 
 // Note, `Default` is implemented although default value is not 0
 impl ::std::default::Default for Show_ConsumptionOrder {
@@ -7932,7 +8671,7 @@ impl ::protobuf::reflect::ProtobufValue for Show_ConsumptionOrder {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Show_PassthroughEnum {
     UNKNOWN = 0,
     NONE = 1,
@@ -7949,7 +8688,7 @@ impl ::protobuf::ProtobufEnum for Show_PassthroughEnum {
             0 => ::std::option::Option::Some(Show_PassthroughEnum::UNKNOWN),
             1 => ::std::option::Option::Some(Show_PassthroughEnum::NONE),
             2 => ::std::option::Option::Some(Show_PassthroughEnum::ALLOWED),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -7963,20 +8702,23 @@ impl ::protobuf::ProtobufEnum for Show_PassthroughEnum {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("Show_PassthroughEnum", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "Show_PassthroughEnum",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for Show_PassthroughEnum {
-}
+impl ::std::marker::Copy for Show_PassthroughEnum {}
 
 impl ::std::default::Default for Show_PassthroughEnum {
     fn default() -> Self {
@@ -7990,7 +8732,7 @@ impl ::protobuf::reflect::ProtobufValue for Show_PassthroughEnum {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Episode {
     // message fields
     gid: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -8036,7 +8778,6 @@ impl Episode {
 
     // optional bytes gid = 1;
 
-
     pub fn get_gid(&self) -> &[u8] {
         match self.gid.as_ref() {
             Some(v) => &v,
@@ -8072,7 +8813,6 @@ impl Episode {
 
     // optional string name = 2;
 
-
     pub fn get_name(&self) -> &str {
         match self.name.as_ref() {
             Some(v) => &v,
@@ -8103,11 +8843,12 @@ impl Episode {
 
     // Take field
     pub fn take_name(&mut self) -> ::std::string::String {
-        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional sint32 duration = 7;
-
 
     pub fn get_duration(&self) -> i32 {
         self.duration.unwrap_or(0)
@@ -8127,7 +8868,6 @@ impl Episode {
 
     // optional sint32 popularity = 8;
 
-
     pub fn get_popularity(&self) -> i32 {
         self.popularity.unwrap_or(0)
     }
@@ -8145,7 +8885,6 @@ impl Episode {
     }
 
     // repeated .AudioFile file = 12;
-
 
     pub fn get_file(&self) -> &[AudioFile] {
         &self.file
@@ -8170,7 +8909,6 @@ impl Episode {
     }
 
     // optional string description = 64;
-
 
     pub fn get_description(&self) -> &str {
         match self.description.as_ref() {
@@ -8202,11 +8940,12 @@ impl Episode {
 
     // Take field
     pub fn take_description(&mut self) -> ::std::string::String {
-        self.description.take().unwrap_or_else(|| ::std::string::String::new())
+        self.description
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional sint32 number = 65;
-
 
     pub fn get_number(&self) -> i32 {
         self.number.unwrap_or(0)
@@ -8226,9 +8965,10 @@ impl Episode {
 
     // optional .Date publish_time = 66;
 
-
     pub fn get_publish_time(&self) -> &Date {
-        self.publish_time.as_ref().unwrap_or_else(|| Date::default_instance())
+        self.publish_time
+            .as_ref()
+            .unwrap_or_else(|| Date::default_instance())
     }
     pub fn clear_publish_time(&mut self) {
         self.publish_time.clear();
@@ -8259,7 +8999,6 @@ impl Episode {
 
     // optional sint32 deprecated_popularity = 67;
 
-
     pub fn get_deprecated_popularity(&self) -> i32 {
         self.deprecated_popularity.unwrap_or(0)
     }
@@ -8278,9 +9017,10 @@ impl Episode {
 
     // optional .ImageGroup covers = 68;
 
-
     pub fn get_covers(&self) -> &ImageGroup {
-        self.covers.as_ref().unwrap_or_else(|| ImageGroup::default_instance())
+        self.covers
+            .as_ref()
+            .unwrap_or_else(|| ImageGroup::default_instance())
     }
     pub fn clear_covers(&mut self) {
         self.covers.clear();
@@ -8310,7 +9050,6 @@ impl Episode {
     }
 
     // optional string language = 69;
-
 
     pub fn get_language(&self) -> &str {
         match self.language.as_ref() {
@@ -8342,11 +9081,12 @@ impl Episode {
 
     // Take field
     pub fn take_language(&mut self) -> ::std::string::String {
-        self.language.take().unwrap_or_else(|| ::std::string::String::new())
+        self.language
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bool explicit = 70;
-
 
     pub fn get_explicit(&self) -> bool {
         self.explicit.unwrap_or(false)
@@ -8366,9 +9106,10 @@ impl Episode {
 
     // optional .Show show = 71;
 
-
     pub fn get_show(&self) -> &Show {
-        self.show.as_ref().unwrap_or_else(|| Show::default_instance())
+        self.show
+            .as_ref()
+            .unwrap_or_else(|| Show::default_instance())
     }
     pub fn clear_show(&mut self) {
         self.show.clear();
@@ -8399,7 +9140,6 @@ impl Episode {
 
     // repeated .VideoFile video = 72;
 
-
     pub fn get_video(&self) -> &[VideoFile] {
         &self.video
     }
@@ -8423,7 +9163,6 @@ impl Episode {
     }
 
     // repeated .VideoFile video_preview = 73;
-
 
     pub fn get_video_preview(&self) -> &[VideoFile] {
         &self.video_preview
@@ -8449,7 +9188,6 @@ impl Episode {
 
     // repeated .AudioFile audio_preview = 74;
 
-
     pub fn get_audio_preview(&self) -> &[AudioFile] {
         &self.audio_preview
     }
@@ -8473,7 +9211,6 @@ impl Episode {
     }
 
     // repeated .Restriction restriction = 75;
-
 
     pub fn get_restriction(&self) -> &[Restriction] {
         &self.restriction
@@ -8499,9 +9236,10 @@ impl Episode {
 
     // optional .ImageGroup freeze_frame = 76;
 
-
     pub fn get_freeze_frame(&self) -> &ImageGroup {
-        self.freeze_frame.as_ref().unwrap_or_else(|| ImageGroup::default_instance())
+        self.freeze_frame
+            .as_ref()
+            .unwrap_or_else(|| ImageGroup::default_instance())
     }
     pub fn clear_freeze_frame(&mut self) {
         self.freeze_frame.clear();
@@ -8527,11 +9265,12 @@ impl Episode {
 
     // Take field
     pub fn take_freeze_frame(&mut self) -> ImageGroup {
-        self.freeze_frame.take().unwrap_or_else(|| ImageGroup::new())
+        self.freeze_frame
+            .take()
+            .unwrap_or_else(|| ImageGroup::new())
     }
 
     // repeated string keyword = 77;
-
 
     pub fn get_keyword(&self) -> &[::std::string::String] {
         &self.keyword
@@ -8557,7 +9296,6 @@ impl Episode {
 
     // optional bool suppress_monetization = 78;
 
-
     pub fn get_suppress_monetization(&self) -> bool {
         self.suppress_monetization.unwrap_or(false)
     }
@@ -8575,7 +9313,6 @@ impl Episode {
     }
 
     // optional bool interpret_restriction_using_geoip = 79;
-
 
     pub fn get_interpret_restriction_using_geoip(&self) -> bool {
         self.interpret_restriction_using_geoip.unwrap_or(false)
@@ -8595,7 +9332,6 @@ impl Episode {
 
     // optional bool allow_background_playback = 81;
 
-
     pub fn get_allow_background_playback(&self) -> bool {
         self.allow_background_playback.unwrap_or(false)
     }
@@ -8613,7 +9349,6 @@ impl Episode {
     }
 
     // repeated .Availability availability = 82;
-
 
     pub fn get_availability(&self) -> &[Availability] {
         &self.availability
@@ -8638,7 +9373,6 @@ impl Episode {
     }
 
     // optional string external_url = 83;
-
 
     pub fn get_external_url(&self) -> &str {
         match self.external_url.as_ref() {
@@ -8670,14 +9404,17 @@ impl Episode {
 
     // Take field
     pub fn take_external_url(&mut self) -> ::std::string::String {
-        self.external_url.take().unwrap_or_else(|| ::std::string::String::new())
+        self.external_url
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional .OriginalAudio original_audio = 84;
 
-
     pub fn get_original_audio(&self) -> &OriginalAudio {
-        self.original_audio.as_ref().unwrap_or_else(|| OriginalAudio::default_instance())
+        self.original_audio
+            .as_ref()
+            .unwrap_or_else(|| OriginalAudio::default_instance())
     }
     pub fn clear_original_audio(&mut self) {
         self.original_audio.clear();
@@ -8703,7 +9440,9 @@ impl Episode {
 
     // Take field
     pub fn take_original_audio(&mut self) -> OriginalAudio {
-        self.original_audio.take().unwrap_or_else(|| OriginalAudio::new())
+        self.original_audio
+            .take()
+            .unwrap_or_else(|| OriginalAudio::new())
     }
 }
 
@@ -8713,174 +9452,234 @@ impl ::protobuf::Message for Episode {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.publish_time {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.covers {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.show {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.video {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.video_preview {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.audio_preview {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.restriction {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.freeze_frame {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.availability {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.original_audio {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gid)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
-                },
+                }
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.duration = ::std::option::Option::Some(tmp);
-                },
+                }
                 8 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.popularity = ::std::option::Option::Some(tmp);
-                },
+                }
                 12 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.file)?;
-                },
+                }
                 64 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.description)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.description,
+                    )?;
+                }
                 65 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.number = ::std::option::Option::Some(tmp);
-                },
+                }
                 66 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.publish_time)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.publish_time,
+                    )?;
+                }
                 67 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_sint32()?;
                     self.deprecated_popularity = ::std::option::Option::Some(tmp);
-                },
+                }
                 68 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.covers)?;
-                },
+                }
                 69 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.language)?;
-                },
+                }
                 70 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.explicit = ::std::option::Option::Some(tmp);
-                },
+                }
                 71 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.show)?;
-                },
+                }
                 72 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.video)?;
-                },
+                }
                 73 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.video_preview)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.video_preview,
+                    )?;
+                }
                 74 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.audio_preview)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.audio_preview,
+                    )?;
+                }
                 75 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.restriction)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.restriction,
+                    )?;
+                }
                 76 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.freeze_frame)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.freeze_frame,
+                    )?;
+                }
                 77 => {
                     ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.keyword)?;
-                },
+                }
                 78 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.suppress_monetization = ::std::option::Option::Some(tmp);
-                },
+                }
                 79 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.interpret_restriction_using_geoip = ::std::option::Option::Some(tmp);
-                },
+                }
                 81 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.allow_background_playback = ::std::option::Option::Some(tmp);
-                },
+                }
                 82 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.availability)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.availability,
+                    )?;
+                }
                 83 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.external_url)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.external_url,
+                    )?;
+                }
                 84 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.original_audio)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.original_audio,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -8905,7 +9704,7 @@ impl ::protobuf::Message for Episode {
         for value in &self.file {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.description.as_ref() {
             my_size += ::protobuf::rt::string_size(64, &v);
         }
@@ -8936,26 +9735,26 @@ impl ::protobuf::Message for Episode {
         for value in &self.video {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.video_preview {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.audio_preview {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.restriction {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.freeze_frame.as_ref() {
             let len = v.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         }
         for value in &self.keyword {
             my_size += ::protobuf::rt::string_size(77, &value);
-        };
+        }
         if let Some(v) = self.suppress_monetization {
             my_size += 3;
         }
@@ -8968,7 +9767,7 @@ impl ::protobuf::Message for Episode {
         for value in &self.availability {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.external_url.as_ref() {
             my_size += ::protobuf::rt::string_size(83, &v);
         }
@@ -8981,7 +9780,10 @@ impl ::protobuf::Message for Episode {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.gid.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -8998,7 +9800,7 @@ impl ::protobuf::Message for Episode {
             os.write_tag(12, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.description.as_ref() {
             os.write_string(64, &v)?;
         }
@@ -9033,22 +9835,22 @@ impl ::protobuf::Message for Episode {
             os.write_tag(72, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.video_preview {
             os.write_tag(73, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.audio_preview {
             os.write_tag(74, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.restriction {
             os.write_tag(75, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.freeze_frame.as_ref() {
             os.write_tag(76, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -9056,7 +9858,7 @@ impl ::protobuf::Message for Episode {
         }
         for v in &self.keyword {
             os.write_string(77, &v)?;
-        };
+        }
         if let Some(v) = self.suppress_monetization {
             os.write_bool(78, v)?;
         }
@@ -9070,7 +9872,7 @@ impl ::protobuf::Message for Episode {
             os.write_tag(82, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.external_url.as_ref() {
             os.write_string(83, &v)?;
         }
@@ -9114,142 +9916,242 @@ impl ::protobuf::Message for Episode {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gid",
-                    |m: &Episode| { &m.gid },
-                    |m: &mut Episode| { &mut m.gid },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "name",
-                    |m: &Episode| { &m.name },
-                    |m: &mut Episode| { &mut m.name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >("gid", |m: &Episode| &m.gid, |m: &mut Episode| &mut m.gid),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "name", |m: &Episode| &m.name, |m: &mut Episode| &mut m.name
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "duration",
-                    |m: &Episode| { &m.duration },
-                    |m: &mut Episode| { &mut m.duration },
+                    |m: &Episode| &m.duration,
+                    |m: &mut Episode| &mut m.duration,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "popularity",
-                    |m: &Episode| { &m.popularity },
-                    |m: &mut Episode| { &mut m.popularity },
+                    |m: &Episode| &m.popularity,
+                    |m: &mut Episode| &mut m.popularity,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AudioFile>>(
-                    "file",
-                    |m: &Episode| { &m.file },
-                    |m: &mut Episode| { &mut m.file },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "description",
-                    |m: &Episode| { &m.description },
-                    |m: &mut Episode| { &mut m.description },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AudioFile>,
+                    >(
+                        "file", |m: &Episode| &m.file, |m: &mut Episode| &mut m.file
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "description",
+                        |m: &Episode| &m.description,
+                        |m: &mut Episode| &mut m.description,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "number",
-                    |m: &Episode| { &m.number },
-                    |m: &mut Episode| { &mut m.number },
+                    |m: &Episode| &m.number,
+                    |m: &mut Episode| &mut m.number,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Date>>(
-                    "publish_time",
-                    |m: &Episode| { &m.publish_time },
-                    |m: &mut Episode| { &mut m.publish_time },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeSint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Date>,
+                    >(
+                        "publish_time",
+                        |m: &Episode| &m.publish_time,
+                        |m: &mut Episode| &mut m.publish_time,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeSint32,
+                >(
                     "deprecated_popularity",
-                    |m: &Episode| { &m.deprecated_popularity },
-                    |m: &mut Episode| { &mut m.deprecated_popularity },
+                    |m: &Episode| &m.deprecated_popularity,
+                    |m: &mut Episode| &mut m.deprecated_popularity,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ImageGroup>>(
-                    "covers",
-                    |m: &Episode| { &m.covers },
-                    |m: &mut Episode| { &mut m.covers },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "language",
-                    |m: &Episode| { &m.language },
-                    |m: &mut Episode| { &mut m.language },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ImageGroup>,
+                    >(
+                        "covers",
+                        |m: &Episode| &m.covers,
+                        |m: &mut Episode| &mut m.covers,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "language",
+                        |m: &Episode| &m.language,
+                        |m: &mut Episode| &mut m.language,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "explicit",
-                    |m: &Episode| { &m.explicit },
-                    |m: &mut Episode| { &mut m.explicit },
+                    |m: &Episode| &m.explicit,
+                    |m: &mut Episode| &mut m.explicit,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Show>>(
-                    "show",
-                    |m: &Episode| { &m.show },
-                    |m: &mut Episode| { &mut m.show },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<VideoFile>>(
-                    "video",
-                    |m: &Episode| { &m.video },
-                    |m: &mut Episode| { &mut m.video },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<VideoFile>>(
-                    "video_preview",
-                    |m: &Episode| { &m.video_preview },
-                    |m: &mut Episode| { &mut m.video_preview },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<AudioFile>>(
-                    "audio_preview",
-                    |m: &Episode| { &m.audio_preview },
-                    |m: &mut Episode| { &mut m.audio_preview },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Restriction>>(
-                    "restriction",
-                    |m: &Episode| { &m.restriction },
-                    |m: &mut Episode| { &mut m.restriction },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ImageGroup>>(
-                    "freeze_frame",
-                    |m: &Episode| { &m.freeze_frame },
-                    |m: &mut Episode| { &mut m.freeze_frame },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "keyword",
-                    |m: &Episode| { &m.keyword },
-                    |m: &mut Episode| { &mut m.keyword },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Show>,
+                    >(
+                        "show", |m: &Episode| &m.show, |m: &mut Episode| &mut m.show
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<VideoFile>,
+                    >(
+                        "video",
+                        |m: &Episode| &m.video,
+                        |m: &mut Episode| &mut m.video,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<VideoFile>,
+                    >(
+                        "video_preview",
+                        |m: &Episode| &m.video_preview,
+                        |m: &mut Episode| &mut m.video_preview,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<AudioFile>,
+                    >(
+                        "audio_preview",
+                        |m: &Episode| &m.audio_preview,
+                        |m: &mut Episode| &mut m.audio_preview,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Restriction>,
+                    >(
+                        "restriction",
+                        |m: &Episode| &m.restriction,
+                        |m: &mut Episode| &mut m.restriction,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ImageGroup>,
+                    >(
+                        "freeze_frame",
+                        |m: &Episode| &m.freeze_frame,
+                        |m: &mut Episode| &mut m.freeze_frame,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "keyword",
+                        |m: &Episode| &m.keyword,
+                        |m: &mut Episode| &mut m.keyword,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "suppress_monetization",
-                    |m: &Episode| { &m.suppress_monetization },
-                    |m: &mut Episode| { &mut m.suppress_monetization },
+                    |m: &Episode| &m.suppress_monetization,
+                    |m: &mut Episode| &mut m.suppress_monetization,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "interpret_restriction_using_geoip",
-                    |m: &Episode| { &m.interpret_restriction_using_geoip },
-                    |m: &mut Episode| { &mut m.interpret_restriction_using_geoip },
+                    |m: &Episode| &m.interpret_restriction_using_geoip,
+                    |m: &mut Episode| &mut m.interpret_restriction_using_geoip,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "allow_background_playback",
-                    |m: &Episode| { &m.allow_background_playback },
-                    |m: &mut Episode| { &mut m.allow_background_playback },
+                    |m: &Episode| &m.allow_background_playback,
+                    |m: &mut Episode| &mut m.allow_background_playback,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Availability>>(
-                    "availability",
-                    |m: &Episode| { &m.availability },
-                    |m: &mut Episode| { &mut m.availability },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "external_url",
-                    |m: &Episode| { &m.external_url },
-                    |m: &mut Episode| { &mut m.external_url },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<OriginalAudio>>(
-                    "original_audio",
-                    |m: &Episode| { &m.original_audio },
-                    |m: &mut Episode| { &mut m.original_audio },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Availability>,
+                    >(
+                        "availability",
+                        |m: &Episode| &m.availability,
+                        |m: &mut Episode| &mut m.availability,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "external_url",
+                        |m: &Episode| &m.external_url,
+                        |m: &mut Episode| &mut m.external_url,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<OriginalAudio>,
+                    >(
+                        "original_audio",
+                        |m: &Episode| &m.original_audio,
+                        |m: &mut Episode| &mut m.original_audio,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Episode>(
                     "Episode",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -9260,9 +10162,7 @@ impl ::protobuf::Message for Episode {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Episode,
         };
-        unsafe {
-            instance.get(Episode::new)
-        }
+        unsafe { instance.get(Episode::new) }
     }
 }
 
@@ -9309,7 +10209,7 @@ impl ::protobuf::reflect::ProtobufValue for Episode {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Category {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
@@ -9331,7 +10231,6 @@ impl Category {
     }
 
     // optional string name = 1;
-
 
     pub fn get_name(&self) -> &str {
         match self.name.as_ref() {
@@ -9363,11 +10262,12 @@ impl Category {
 
     // Take field
     pub fn take_name(&mut self) -> ::std::string::String {
-        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // repeated .Category subcategories = 2;
-
 
     pub fn get_subcategories(&self) -> &[Category] {
         &self.subcategories
@@ -9398,23 +10298,35 @@ impl ::protobuf::Message for Category {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
-                },
+                }
                 2 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.subcategories)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.subcategories,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -9430,13 +10342,16 @@ impl ::protobuf::Message for Category {
         for value in &self.subcategories {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.name.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -9444,7 +10359,7 @@ impl ::protobuf::Message for Category {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -9480,27 +10395,38 @@ impl ::protobuf::Message for Category {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "name",
-                    |m: &Category| { &m.name },
-                    |m: &mut Category| { &mut m.name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Category>>(
-                    "subcategories",
-                    |m: &Category| { &m.subcategories },
-                    |m: &mut Category| { &mut m.subcategories },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "name",
+                        |m: &Category| &m.name,
+                        |m: &mut Category| &mut m.name,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Category>,
+                    >(
+                        "subcategories",
+                        |m: &Category| &m.subcategories,
+                        |m: &mut Category| &mut m.subcategories,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Category>(
                     "Category",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -9511,9 +10437,7 @@ impl ::protobuf::Message for Category {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Category,
         };
-        unsafe {
-            instance.get(Category::new)
-        }
+        unsafe { instance.get(Category::new) }
     }
 }
 
@@ -9537,7 +10461,7 @@ impl ::protobuf::reflect::ProtobufValue for Category {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct OriginalAudio {
     // message fields
     uuid: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -9558,7 +10482,6 @@ impl OriginalAudio {
     }
 
     // optional bytes uuid = 1;
-
 
     pub fn get_uuid(&self) -> &[u8] {
         match self.uuid.as_ref() {
@@ -9599,16 +10522,24 @@ impl ::protobuf::Message for OriginalAudio {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.uuid)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -9626,7 +10557,10 @@ impl ::protobuf::Message for OriginalAudio {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.uuid.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -9665,22 +10599,28 @@ impl ::protobuf::Message for OriginalAudio {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "uuid",
-                    |m: &OriginalAudio| { &m.uuid },
-                    |m: &mut OriginalAudio| { &mut m.uuid },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "uuid",
+                        |m: &OriginalAudio| &m.uuid,
+                        |m: &mut OriginalAudio| &mut m.uuid,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<OriginalAudio>(
                     "OriginalAudio",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -9691,9 +10631,7 @@ impl ::protobuf::Message for OriginalAudio {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const OriginalAudio,
         };
-        unsafe {
-            instance.get(OriginalAudio::new)
-        }
+        unsafe { instance.get(OriginalAudio::new) }
     }
 }
 
@@ -9843,7 +10781,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x18\x01\x20\x01(\x0cB\0:\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -9853,9 +10793,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/playlist4changes.rs
+++ b/protocol/src/playlist4changes.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ChangeInfo {
     // message fields
     user: ::protobuf::SingularField<::std::string::String>,
@@ -54,7 +54,6 @@ impl ChangeInfo {
     }
 
     // optional string user = 1;
-
 
     pub fn get_user(&self) -> &str {
         match self.user.as_ref() {
@@ -86,11 +85,12 @@ impl ChangeInfo {
 
     // Take field
     pub fn take_user(&mut self) -> ::std::string::String {
-        self.user.take().unwrap_or_else(|| ::std::string::String::new())
+        self.user
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional int32 timestamp = 2;
-
 
     pub fn get_timestamp(&self) -> i32 {
         self.timestamp.unwrap_or(0)
@@ -110,7 +110,6 @@ impl ChangeInfo {
 
     // optional bool admin = 3;
 
-
     pub fn get_admin(&self) -> bool {
         self.admin.unwrap_or(false)
     }
@@ -128,7 +127,6 @@ impl ChangeInfo {
     }
 
     // optional bool undo = 4;
-
 
     pub fn get_undo(&self) -> bool {
         self.undo.unwrap_or(false)
@@ -148,7 +146,6 @@ impl ChangeInfo {
 
     // optional bool redo = 5;
 
-
     pub fn get_redo(&self) -> bool {
         self.redo.unwrap_or(false)
     }
@@ -166,7 +163,6 @@ impl ChangeInfo {
     }
 
     // optional bool merge = 6;
-
 
     pub fn get_merge(&self) -> bool {
         self.merge.unwrap_or(false)
@@ -186,7 +182,6 @@ impl ChangeInfo {
 
     // optional bool compressed = 7;
 
-
     pub fn get_compressed(&self) -> bool {
         self.compressed.unwrap_or(false)
     }
@@ -204,7 +199,6 @@ impl ChangeInfo {
     }
 
     // optional bool migration = 8;
-
 
     pub fn get_migration(&self) -> bool {
         self.migration.unwrap_or(false)
@@ -228,65 +222,87 @@ impl ::protobuf::Message for ChangeInfo {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.user)?;
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.timestamp = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.admin = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.undo = ::std::option::Option::Some(tmp);
-                },
+                }
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.redo = ::std::option::Option::Some(tmp);
-                },
+                }
                 6 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.merge = ::std::option::Option::Some(tmp);
-                },
+                }
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.compressed = ::std::option::Option::Some(tmp);
-                },
+                }
                 8 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.migration = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -325,7 +341,10 @@ impl ::protobuf::Message for ChangeInfo {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.user.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -385,57 +404,84 @@ impl ::protobuf::Message for ChangeInfo {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "user",
-                    |m: &ChangeInfo| { &m.user },
-                    |m: &mut ChangeInfo| { &mut m.user },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "user",
+                        |m: &ChangeInfo| &m.user,
+                        |m: &mut ChangeInfo| &mut m.user,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "timestamp",
-                    |m: &ChangeInfo| { &m.timestamp },
-                    |m: &mut ChangeInfo| { &mut m.timestamp },
+                    |m: &ChangeInfo| &m.timestamp,
+                    |m: &mut ChangeInfo| &mut m.timestamp,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "admin",
-                    |m: &ChangeInfo| { &m.admin },
-                    |m: &mut ChangeInfo| { &mut m.admin },
+                    |m: &ChangeInfo| &m.admin,
+                    |m: &mut ChangeInfo| &mut m.admin,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "undo",
-                    |m: &ChangeInfo| { &m.undo },
-                    |m: &mut ChangeInfo| { &mut m.undo },
+                    |m: &ChangeInfo| &m.undo,
+                    |m: &mut ChangeInfo| &mut m.undo,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "redo",
-                    |m: &ChangeInfo| { &m.redo },
-                    |m: &mut ChangeInfo| { &mut m.redo },
+                    |m: &ChangeInfo| &m.redo,
+                    |m: &mut ChangeInfo| &mut m.redo,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "merge",
-                    |m: &ChangeInfo| { &m.merge },
-                    |m: &mut ChangeInfo| { &mut m.merge },
+                    |m: &ChangeInfo| &m.merge,
+                    |m: &mut ChangeInfo| &mut m.merge,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "compressed",
-                    |m: &ChangeInfo| { &m.compressed },
-                    |m: &mut ChangeInfo| { &mut m.compressed },
+                    |m: &ChangeInfo| &m.compressed,
+                    |m: &mut ChangeInfo| &mut m.compressed,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "migration",
-                    |m: &ChangeInfo| { &m.migration },
-                    |m: &mut ChangeInfo| { &mut m.migration },
+                    |m: &ChangeInfo| &m.migration,
+                    |m: &mut ChangeInfo| &mut m.migration,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ChangeInfo>(
                     "ChangeInfo",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -446,9 +492,7 @@ impl ::protobuf::Message for ChangeInfo {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ChangeInfo,
         };
-        unsafe {
-            instance.get(ChangeInfo::new)
-        }
+        unsafe { instance.get(ChangeInfo::new) }
     }
 }
 
@@ -478,7 +522,7 @@ impl ::protobuf::reflect::ProtobufValue for ChangeInfo {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Delta {
     // message fields
     base_version: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -501,7 +545,6 @@ impl Delta {
     }
 
     // optional bytes base_version = 1;
-
 
     pub fn get_base_version(&self) -> &[u8] {
         match self.base_version.as_ref() {
@@ -533,11 +576,12 @@ impl Delta {
 
     // Take field
     pub fn take_base_version(&mut self) -> ::std::vec::Vec<u8> {
-        self.base_version.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.base_version
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // repeated .Op ops = 2;
-
 
     pub fn get_ops(&self) -> &[super::playlist4ops::Op] {
         &self.ops
@@ -563,9 +607,10 @@ impl Delta {
 
     // optional .ChangeInfo info = 4;
 
-
     pub fn get_info(&self) -> &ChangeInfo {
-        self.info.as_ref().unwrap_or_else(|| ChangeInfo::default_instance())
+        self.info
+            .as_ref()
+            .unwrap_or_else(|| ChangeInfo::default_instance())
     }
     pub fn clear_info(&mut self) {
         self.info.clear();
@@ -601,31 +646,43 @@ impl ::protobuf::Message for Delta {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.info {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.base_version)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.base_version,
+                    )?;
+                }
                 2 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.ops)?;
-                },
+                }
                 4 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.info)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -641,7 +698,7 @@ impl ::protobuf::Message for Delta {
         for value in &self.ops {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.info.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -651,7 +708,10 @@ impl ::protobuf::Message for Delta {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.base_version.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -659,7 +719,7 @@ impl ::protobuf::Message for Delta {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.info.as_ref() {
             os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -700,32 +760,40 @@ impl ::protobuf::Message for Delta {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "base_version",
-                    |m: &Delta| { &m.base_version },
-                    |m: &mut Delta| { &mut m.base_version },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4ops::Op>>(
-                    "ops",
-                    |m: &Delta| { &m.ops },
-                    |m: &mut Delta| { &mut m.ops },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ChangeInfo>>(
-                    "info",
-                    |m: &Delta| { &m.info },
-                    |m: &mut Delta| { &mut m.info },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "base_version",
+                        |m: &Delta| &m.base_version,
+                        |m: &mut Delta| &mut m.base_version,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4ops::Op>,
+                    >("ops", |m: &Delta| &m.ops, |m: &mut Delta| &mut m.ops),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ChangeInfo>,
+                    >("info", |m: &Delta| &m.info, |m: &mut Delta| &mut m.info),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Delta>(
                     "Delta",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -736,9 +804,7 @@ impl ::protobuf::Message for Delta {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Delta,
         };
-        unsafe {
-            instance.get(Delta::new)
-        }
+        unsafe { instance.get(Delta::new) }
     }
 }
 
@@ -763,7 +829,7 @@ impl ::protobuf::reflect::ProtobufValue for Delta {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Merge {
     // message fields
     base_version: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -786,7 +852,6 @@ impl Merge {
     }
 
     // optional bytes base_version = 1;
-
 
     pub fn get_base_version(&self) -> &[u8] {
         match self.base_version.as_ref() {
@@ -818,11 +883,12 @@ impl Merge {
 
     // Take field
     pub fn take_base_version(&mut self) -> ::std::vec::Vec<u8> {
-        self.base_version.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.base_version
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional bytes merge_version = 2;
-
 
     pub fn get_merge_version(&self) -> &[u8] {
         match self.merge_version.as_ref() {
@@ -854,14 +920,17 @@ impl Merge {
 
     // Take field
     pub fn take_merge_version(&mut self) -> ::std::vec::Vec<u8> {
-        self.merge_version.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.merge_version
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional .ChangeInfo info = 4;
 
-
     pub fn get_info(&self) -> &ChangeInfo {
-        self.info.as_ref().unwrap_or_else(|| ChangeInfo::default_instance())
+        self.info
+            .as_ref()
+            .unwrap_or_else(|| ChangeInfo::default_instance())
     }
     pub fn clear_info(&mut self) {
         self.info.clear();
@@ -897,26 +966,42 @@ impl ::protobuf::Message for Merge {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.base_version)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.base_version,
+                    )?;
+                }
                 2 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.merge_version)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.merge_version,
+                    )?;
+                }
                 4 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.info)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -941,7 +1026,10 @@ impl ::protobuf::Message for Merge {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.base_version.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -988,32 +1076,44 @@ impl ::protobuf::Message for Merge {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "base_version",
-                    |m: &Merge| { &m.base_version },
-                    |m: &mut Merge| { &mut m.base_version },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "merge_version",
-                    |m: &Merge| { &m.merge_version },
-                    |m: &mut Merge| { &mut m.merge_version },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ChangeInfo>>(
-                    "info",
-                    |m: &Merge| { &m.info },
-                    |m: &mut Merge| { &mut m.info },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "base_version",
+                        |m: &Merge| &m.base_version,
+                        |m: &mut Merge| &mut m.base_version,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "merge_version",
+                        |m: &Merge| &m.merge_version,
+                        |m: &mut Merge| &mut m.merge_version,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ChangeInfo>,
+                    >("info", |m: &Merge| &m.info, |m: &mut Merge| &mut m.info),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Merge>(
                     "Merge",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1024,9 +1124,7 @@ impl ::protobuf::Message for Merge {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Merge,
         };
-        unsafe {
-            instance.get(Merge::new)
-        }
+        unsafe { instance.get(Merge::new) }
     }
 }
 
@@ -1051,7 +1149,7 @@ impl ::protobuf::reflect::ProtobufValue for Merge {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ChangeSet {
     // message fields
     kind: ::std::option::Option<ChangeSet_Kind>,
@@ -1075,7 +1173,6 @@ impl ChangeSet {
 
     // optional .ChangeSet.Kind kind = 1;
 
-
     pub fn get_kind(&self) -> ChangeSet_Kind {
         self.kind.unwrap_or(ChangeSet_Kind::KIND_UNKNOWN)
     }
@@ -1094,9 +1191,10 @@ impl ChangeSet {
 
     // optional .Delta delta = 2;
 
-
     pub fn get_delta(&self) -> &Delta {
-        self.delta.as_ref().unwrap_or_else(|| Delta::default_instance())
+        self.delta
+            .as_ref()
+            .unwrap_or_else(|| Delta::default_instance())
     }
     pub fn clear_delta(&mut self) {
         self.delta.clear();
@@ -1127,9 +1225,10 @@ impl ChangeSet {
 
     // optional .Merge merge = 3;
 
-
     pub fn get_merge(&self) -> &Merge {
-        self.merge.as_ref().unwrap_or_else(|| Merge::default_instance())
+        self.merge
+            .as_ref()
+            .unwrap_or_else(|| Merge::default_instance())
     }
     pub fn clear_merge(&mut self) {
         self.merge.clear();
@@ -1165,31 +1264,43 @@ impl ::protobuf::Message for ChangeSet {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.merge {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                1 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.kind, 1, &mut self.unknown_fields)?
-                },
+                1 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.kind,
+                    1,
+                    &mut self.unknown_fields,
+                )?,
                 2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.delta)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.merge)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1215,7 +1326,10 @@ impl ::protobuf::Message for ChangeSet {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.kind {
             os.write_enum(1, v.value())?;
         }
@@ -1264,32 +1378,46 @@ impl ::protobuf::Message for ChangeSet {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ChangeSet_Kind>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<ChangeSet_Kind>,
+                >(
                     "kind",
-                    |m: &ChangeSet| { &m.kind },
-                    |m: &mut ChangeSet| { &mut m.kind },
+                    |m: &ChangeSet| &m.kind,
+                    |m: &mut ChangeSet| &mut m.kind,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Delta>>(
-                    "delta",
-                    |m: &ChangeSet| { &m.delta },
-                    |m: &mut ChangeSet| { &mut m.delta },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Merge>>(
-                    "merge",
-                    |m: &ChangeSet| { &m.merge },
-                    |m: &mut ChangeSet| { &mut m.merge },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Delta>,
+                    >(
+                        "delta",
+                        |m: &ChangeSet| &m.delta,
+                        |m: &mut ChangeSet| &mut m.delta,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Merge>,
+                    >(
+                        "merge",
+                        |m: &ChangeSet| &m.merge,
+                        |m: &mut ChangeSet| &mut m.merge,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ChangeSet>(
                     "ChangeSet",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1300,9 +1428,7 @@ impl ::protobuf::Message for ChangeSet {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ChangeSet,
         };
-        unsafe {
-            instance.get(ChangeSet::new)
-        }
+        unsafe { instance.get(ChangeSet::new) }
     }
 }
 
@@ -1327,7 +1453,7 @@ impl ::protobuf::reflect::ProtobufValue for ChangeSet {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ChangeSet_Kind {
     KIND_UNKNOWN = 0,
     DELTA = 2,
@@ -1344,7 +1470,7 @@ impl ::protobuf::ProtobufEnum for ChangeSet_Kind {
             0 => ::std::option::Option::Some(ChangeSet_Kind::KIND_UNKNOWN),
             2 => ::std::option::Option::Some(ChangeSet_Kind::DELTA),
             3 => ::std::option::Option::Some(ChangeSet_Kind::MERGE),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -1358,10 +1484,11 @@ impl ::protobuf::ProtobufEnum for ChangeSet_Kind {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("ChangeSet_Kind", file_descriptor_proto())
@@ -1370,8 +1497,7 @@ impl ::protobuf::ProtobufEnum for ChangeSet_Kind {
     }
 }
 
-impl ::std::marker::Copy for ChangeSet_Kind {
-}
+impl ::std::marker::Copy for ChangeSet_Kind {}
 
 impl ::std::default::Default for ChangeSet_Kind {
     fn default() -> Self {
@@ -1385,7 +1511,7 @@ impl ::protobuf::reflect::ProtobufValue for ChangeSet_Kind {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct RevisionTaggedChangeSet {
     // message fields
     revision: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -1407,7 +1533,6 @@ impl RevisionTaggedChangeSet {
     }
 
     // optional bytes revision = 1;
-
 
     pub fn get_revision(&self) -> &[u8] {
         match self.revision.as_ref() {
@@ -1439,14 +1564,17 @@ impl RevisionTaggedChangeSet {
 
     // Take field
     pub fn take_revision(&mut self) -> ::std::vec::Vec<u8> {
-        self.revision.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.revision
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional .ChangeSet change_set = 2;
 
-
     pub fn get_change_set(&self) -> &ChangeSet {
-        self.change_set.as_ref().unwrap_or_else(|| ChangeSet::default_instance())
+        self.change_set
+            .as_ref()
+            .unwrap_or_else(|| ChangeSet::default_instance())
     }
     pub fn clear_change_set(&mut self) {
         self.change_set.clear();
@@ -1482,23 +1610,35 @@ impl ::protobuf::Message for RevisionTaggedChangeSet {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.revision)?;
-                },
+                }
                 2 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.change_set)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.change_set,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1520,7 +1660,10 @@ impl ::protobuf::Message for RevisionTaggedChangeSet {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.revision.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -1564,40 +1707,50 @@ impl ::protobuf::Message for RevisionTaggedChangeSet {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "revision",
-                    |m: &RevisionTaggedChangeSet| { &m.revision },
-                    |m: &mut RevisionTaggedChangeSet| { &mut m.revision },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ChangeSet>>(
-                    "change_set",
-                    |m: &RevisionTaggedChangeSet| { &m.change_set },
-                    |m: &mut RevisionTaggedChangeSet| { &mut m.change_set },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "revision",
+                        |m: &RevisionTaggedChangeSet| &m.revision,
+                        |m: &mut RevisionTaggedChangeSet| &mut m.revision,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ChangeSet>,
+                    >(
+                        "change_set",
+                        |m: &RevisionTaggedChangeSet| &m.change_set,
+                        |m: &mut RevisionTaggedChangeSet| &mut m.change_set,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<RevisionTaggedChangeSet>(
                     "RevisionTaggedChangeSet",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static RevisionTaggedChangeSet {
-        static mut instance: ::protobuf::lazy::Lazy<RevisionTaggedChangeSet> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const RevisionTaggedChangeSet,
-        };
-        unsafe {
-            instance.get(RevisionTaggedChangeSet::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<RevisionTaggedChangeSet> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const RevisionTaggedChangeSet,
+            };
+        unsafe { instance.get(RevisionTaggedChangeSet::new) }
     }
 }
 
@@ -1621,7 +1774,7 @@ impl ::protobuf::reflect::ProtobufValue for RevisionTaggedChangeSet {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Diff {
     // message fields
     from_revision: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -1644,7 +1797,6 @@ impl Diff {
     }
 
     // optional bytes from_revision = 1;
-
 
     pub fn get_from_revision(&self) -> &[u8] {
         match self.from_revision.as_ref() {
@@ -1676,11 +1828,12 @@ impl Diff {
 
     // Take field
     pub fn take_from_revision(&mut self) -> ::std::vec::Vec<u8> {
-        self.from_revision.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.from_revision
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // repeated .Op ops = 2;
-
 
     pub fn get_ops(&self) -> &[super::playlist4ops::Op] {
         &self.ops
@@ -1705,7 +1858,6 @@ impl Diff {
     }
 
     // optional bytes to_revision = 3;
-
 
     pub fn get_to_revision(&self) -> &[u8] {
         match self.to_revision.as_ref() {
@@ -1737,7 +1889,9 @@ impl Diff {
 
     // Take field
     pub fn take_to_revision(&mut self) -> ::std::vec::Vec<u8> {
-        self.to_revision.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.to_revision
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 }
 
@@ -1747,26 +1901,38 @@ impl ::protobuf::Message for Diff {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.from_revision)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.from_revision,
+                    )?;
+                }
                 2 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.ops)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.to_revision)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1782,7 +1948,7 @@ impl ::protobuf::Message for Diff {
         for value in &self.ops {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.to_revision.as_ref() {
             my_size += ::protobuf::rt::bytes_size(3, &v);
         }
@@ -1791,7 +1957,10 @@ impl ::protobuf::Message for Diff {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.from_revision.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -1799,7 +1968,7 @@ impl ::protobuf::Message for Diff {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.to_revision.as_ref() {
             os.write_bytes(3, &v)?;
         }
@@ -1838,32 +2007,44 @@ impl ::protobuf::Message for Diff {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "from_revision",
-                    |m: &Diff| { &m.from_revision },
-                    |m: &mut Diff| { &mut m.from_revision },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4ops::Op>>(
-                    "ops",
-                    |m: &Diff| { &m.ops },
-                    |m: &mut Diff| { &mut m.ops },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "to_revision",
-                    |m: &Diff| { &m.to_revision },
-                    |m: &mut Diff| { &mut m.to_revision },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "from_revision",
+                        |m: &Diff| &m.from_revision,
+                        |m: &mut Diff| &mut m.from_revision,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4ops::Op>,
+                    >("ops", |m: &Diff| &m.ops, |m: &mut Diff| &mut m.ops),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "to_revision",
+                        |m: &Diff| &m.to_revision,
+                        |m: &mut Diff| &mut m.to_revision,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Diff>(
                     "Diff",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1874,9 +2055,7 @@ impl ::protobuf::Message for Diff {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Diff,
         };
-        unsafe {
-            instance.get(Diff::new)
-        }
+        unsafe { instance.get(Diff::new) }
     }
 }
 
@@ -1901,7 +2080,7 @@ impl ::protobuf::reflect::ProtobufValue for Diff {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ListDump {
     // message fields
     latestRevision: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -1927,7 +2106,6 @@ impl ListDump {
     }
 
     // optional bytes latestRevision = 1;
-
 
     pub fn get_latestRevision(&self) -> &[u8] {
         match self.latestRevision.as_ref() {
@@ -1959,11 +2137,12 @@ impl ListDump {
 
     // Take field
     pub fn take_latestRevision(&mut self) -> ::std::vec::Vec<u8> {
-        self.latestRevision.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.latestRevision
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional int32 length = 2;
-
 
     pub fn get_length(&self) -> i32 {
         self.length.unwrap_or(0)
@@ -1983,9 +2162,10 @@ impl ListDump {
 
     // optional .ListAttributes attributes = 3;
 
-
     pub fn get_attributes(&self) -> &super::playlist4meta::ListAttributes {
-        self.attributes.as_ref().unwrap_or_else(|| super::playlist4meta::ListAttributes::default_instance())
+        self.attributes
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListAttributes::default_instance())
     }
     pub fn clear_attributes(&mut self) {
         self.attributes.clear();
@@ -2011,14 +2191,17 @@ impl ListDump {
 
     // Take field
     pub fn take_attributes(&mut self) -> super::playlist4meta::ListAttributes {
-        self.attributes.take().unwrap_or_else(|| super::playlist4meta::ListAttributes::new())
+        self.attributes
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListAttributes::new())
     }
 
     // optional .ListChecksum checksum = 4;
 
-
     pub fn get_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_checksum(&mut self) {
         self.checksum.clear();
@@ -2044,14 +2227,17 @@ impl ListDump {
 
     // Take field
     pub fn take_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional .ListItems contents = 5;
 
-
     pub fn get_contents(&self) -> &super::playlist4content::ListItems {
-        self.contents.as_ref().unwrap_or_else(|| super::playlist4content::ListItems::default_instance())
+        self.contents
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4content::ListItems::default_instance())
     }
     pub fn clear_contents(&mut self) {
         self.contents.clear();
@@ -2077,11 +2263,12 @@ impl ListDump {
 
     // Take field
     pub fn take_contents(&mut self) -> super::playlist4content::ListItems {
-        self.contents.take().unwrap_or_else(|| super::playlist4content::ListItems::new())
+        self.contents
+            .take()
+            .unwrap_or_else(|| super::playlist4content::ListItems::new())
     }
 
     // repeated .Delta pendingDeltas = 7;
-
 
     pub fn get_pendingDeltas(&self) -> &[Delta] {
         &self.pendingDeltas
@@ -2112,54 +2299,76 @@ impl ::protobuf::Message for ListDump {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.contents {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.pendingDeltas {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.latestRevision)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.latestRevision,
+                    )?;
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.length = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.attributes)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.attributes,
+                    )?;
+                }
                 4 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.checksum)?;
-                },
+                }
                 5 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.contents)?;
-                },
+                }
                 7 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.pendingDeltas)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.pendingDeltas,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2190,13 +2399,16 @@ impl ::protobuf::Message for ListDump {
         for value in &self.pendingDeltas {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.latestRevision.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -2222,7 +2434,7 @@ impl ::protobuf::Message for ListDump {
             os.write_tag(7, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -2258,47 +2470,78 @@ impl ::protobuf::Message for ListDump {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "latestRevision",
-                    |m: &ListDump| { &m.latestRevision },
-                    |m: &mut ListDump| { &mut m.latestRevision },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "latestRevision",
+                        |m: &ListDump| &m.latestRevision,
+                        |m: &mut ListDump| &mut m.latestRevision,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "length",
-                    |m: &ListDump| { &m.length },
-                    |m: &mut ListDump| { &mut m.length },
+                    |m: &ListDump| &m.length,
+                    |m: &mut ListDump| &mut m.length,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListAttributes>>(
-                    "attributes",
-                    |m: &ListDump| { &m.attributes },
-                    |m: &mut ListDump| { &mut m.attributes },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "checksum",
-                    |m: &ListDump| { &m.checksum },
-                    |m: &mut ListDump| { &mut m.checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4content::ListItems>>(
-                    "contents",
-                    |m: &ListDump| { &m.contents },
-                    |m: &mut ListDump| { &mut m.contents },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Delta>>(
-                    "pendingDeltas",
-                    |m: &ListDump| { &m.pendingDeltas },
-                    |m: &mut ListDump| { &mut m.pendingDeltas },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<
+                            super::playlist4meta::ListAttributes,
+                        >,
+                    >(
+                        "attributes",
+                        |m: &ListDump| &m.attributes,
+                        |m: &mut ListDump| &mut m.attributes,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "checksum",
+                        |m: &ListDump| &m.checksum,
+                        |m: &mut ListDump| &mut m.checksum,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4content::ListItems>,
+                    >(
+                        "contents",
+                        |m: &ListDump| &m.contents,
+                        |m: &mut ListDump| &mut m.contents,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Delta>,
+                    >(
+                        "pendingDeltas",
+                        |m: &ListDump| &m.pendingDeltas,
+                        |m: &mut ListDump| &mut m.pendingDeltas,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ListDump>(
                     "ListDump",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -2309,9 +2552,7 @@ impl ::protobuf::Message for ListDump {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ListDump,
         };
-        unsafe {
-            instance.get(ListDump::new)
-        }
+        unsafe { instance.get(ListDump::new) }
     }
 }
 
@@ -2339,7 +2580,7 @@ impl ::protobuf::reflect::ProtobufValue for ListDump {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ListChanges {
     // message fields
     baseRevision: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -2365,7 +2606,6 @@ impl ListChanges {
     }
 
     // optional bytes baseRevision = 1;
-
 
     pub fn get_baseRevision(&self) -> &[u8] {
         match self.baseRevision.as_ref() {
@@ -2397,11 +2637,12 @@ impl ListChanges {
 
     // Take field
     pub fn take_baseRevision(&mut self) -> ::std::vec::Vec<u8> {
-        self.baseRevision.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.baseRevision
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // repeated .Delta deltas = 2;
-
 
     pub fn get_deltas(&self) -> &[Delta] {
         &self.deltas
@@ -2427,7 +2668,6 @@ impl ListChanges {
 
     // optional bool wantResultingRevisions = 3;
 
-
     pub fn get_wantResultingRevisions(&self) -> bool {
         self.wantResultingRevisions.unwrap_or(false)
     }
@@ -2445,7 +2685,6 @@ impl ListChanges {
     }
 
     // optional bool wantSyncResult = 4;
-
 
     pub fn get_wantSyncResult(&self) -> bool {
         self.wantSyncResult.unwrap_or(false)
@@ -2465,9 +2704,10 @@ impl ListChanges {
 
     // optional .ListDump dump = 5;
 
-
     pub fn get_dump(&self) -> &ListDump {
-        self.dump.as_ref().unwrap_or_else(|| ListDump::default_instance())
+        self.dump
+            .as_ref()
+            .unwrap_or_else(|| ListDump::default_instance())
     }
     pub fn clear_dump(&mut self) {
         self.dump.clear();
@@ -2498,7 +2738,6 @@ impl ListChanges {
 
     // repeated int32 nonces = 6;
 
-
     pub fn get_nonces(&self) -> &[i32] {
         &self.nonces
     }
@@ -2528,48 +2767,64 @@ impl ::protobuf::Message for ListChanges {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.dump {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.baseRevision)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.baseRevision,
+                    )?;
+                }
                 2 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.deltas)?;
-                },
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantResultingRevisions = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantSyncResult = ::std::option::Option::Some(tmp);
-                },
+                }
                 5 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.dump)?;
-                },
+                }
                 6 => {
                     ::protobuf::rt::read_repeated_int32_into(wire_type, is, &mut self.nonces)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2585,7 +2840,7 @@ impl ::protobuf::Message for ListChanges {
         for value in &self.deltas {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(v) = self.wantResultingRevisions {
             my_size += 2;
         }
@@ -2597,14 +2852,18 @@ impl ::protobuf::Message for ListChanges {
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
         }
         for value in &self.nonces {
-            my_size += ::protobuf::rt::value_size(6, *value, ::protobuf::wire_format::WireTypeVarint);
-        };
+            my_size +=
+                ::protobuf::rt::value_size(6, *value, ::protobuf::wire_format::WireTypeVarint);
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.baseRevision.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -2612,7 +2871,7 @@ impl ::protobuf::Message for ListChanges {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(v) = self.wantResultingRevisions {
             os.write_bool(3, v)?;
         }
@@ -2626,7 +2885,7 @@ impl ::protobuf::Message for ListChanges {
         }
         for v in &self.nonces {
             os.write_int32(6, *v)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -2662,47 +2921,72 @@ impl ::protobuf::Message for ListChanges {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "baseRevision",
-                    |m: &ListChanges| { &m.baseRevision },
-                    |m: &mut ListChanges| { &mut m.baseRevision },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Delta>>(
-                    "deltas",
-                    |m: &ListChanges| { &m.deltas },
-                    |m: &mut ListChanges| { &mut m.deltas },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "baseRevision",
+                        |m: &ListChanges| &m.baseRevision,
+                        |m: &mut ListChanges| &mut m.baseRevision,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Delta>,
+                    >(
+                        "deltas",
+                        |m: &ListChanges| &m.deltas,
+                        |m: &mut ListChanges| &mut m.deltas,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantResultingRevisions",
-                    |m: &ListChanges| { &m.wantResultingRevisions },
-                    |m: &mut ListChanges| { &mut m.wantResultingRevisions },
+                    |m: &ListChanges| &m.wantResultingRevisions,
+                    |m: &mut ListChanges| &mut m.wantResultingRevisions,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantSyncResult",
-                    |m: &ListChanges| { &m.wantSyncResult },
-                    |m: &mut ListChanges| { &mut m.wantSyncResult },
+                    |m: &ListChanges| &m.wantSyncResult,
+                    |m: &mut ListChanges| &mut m.wantSyncResult,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ListDump>>(
-                    "dump",
-                    |m: &ListChanges| { &m.dump },
-                    |m: &mut ListChanges| { &mut m.dump },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ListDump>,
+                    >(
+                        "dump",
+                        |m: &ListChanges| &m.dump,
+                        |m: &mut ListChanges| &mut m.dump,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "nonces",
-                    |m: &ListChanges| { &m.nonces },
-                    |m: &mut ListChanges| { &mut m.nonces },
+                    |m: &ListChanges| &m.nonces,
+                    |m: &mut ListChanges| &mut m.nonces,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ListChanges>(
                     "ListChanges",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -2713,9 +2997,7 @@ impl ::protobuf::Message for ListChanges {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ListChanges,
         };
-        unsafe {
-            instance.get(ListChanges::new)
-        }
+        unsafe { instance.get(ListChanges::new) }
     }
 }
 
@@ -2743,7 +3025,7 @@ impl ::protobuf::reflect::ProtobufValue for ListChanges {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct SelectedListContent {
     // message fields
     revision: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -2778,7 +3060,6 @@ impl SelectedListContent {
 
     // optional bytes revision = 1;
 
-
     pub fn get_revision(&self) -> &[u8] {
         match self.revision.as_ref() {
             Some(v) => &v,
@@ -2809,11 +3090,12 @@ impl SelectedListContent {
 
     // Take field
     pub fn take_revision(&mut self) -> ::std::vec::Vec<u8> {
-        self.revision.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.revision
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional int32 length = 2;
-
 
     pub fn get_length(&self) -> i32 {
         self.length.unwrap_or(0)
@@ -2833,9 +3115,10 @@ impl SelectedListContent {
 
     // optional .ListAttributes attributes = 3;
 
-
     pub fn get_attributes(&self) -> &super::playlist4meta::ListAttributes {
-        self.attributes.as_ref().unwrap_or_else(|| super::playlist4meta::ListAttributes::default_instance())
+        self.attributes
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListAttributes::default_instance())
     }
     pub fn clear_attributes(&mut self) {
         self.attributes.clear();
@@ -2861,14 +3144,17 @@ impl SelectedListContent {
 
     // Take field
     pub fn take_attributes(&mut self) -> super::playlist4meta::ListAttributes {
-        self.attributes.take().unwrap_or_else(|| super::playlist4meta::ListAttributes::new())
+        self.attributes
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListAttributes::new())
     }
 
     // optional .ListChecksum checksum = 4;
 
-
     pub fn get_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_checksum(&mut self) {
         self.checksum.clear();
@@ -2894,14 +3180,17 @@ impl SelectedListContent {
 
     // Take field
     pub fn take_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional .ListItems contents = 5;
 
-
     pub fn get_contents(&self) -> &super::playlist4content::ListItems {
-        self.contents.as_ref().unwrap_or_else(|| super::playlist4content::ListItems::default_instance())
+        self.contents
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4content::ListItems::default_instance())
     }
     pub fn clear_contents(&mut self) {
         self.contents.clear();
@@ -2927,14 +3216,17 @@ impl SelectedListContent {
 
     // Take field
     pub fn take_contents(&mut self) -> super::playlist4content::ListItems {
-        self.contents.take().unwrap_or_else(|| super::playlist4content::ListItems::new())
+        self.contents
+            .take()
+            .unwrap_or_else(|| super::playlist4content::ListItems::new())
     }
 
     // optional .Diff diff = 6;
 
-
     pub fn get_diff(&self) -> &Diff {
-        self.diff.as_ref().unwrap_or_else(|| Diff::default_instance())
+        self.diff
+            .as_ref()
+            .unwrap_or_else(|| Diff::default_instance())
     }
     pub fn clear_diff(&mut self) {
         self.diff.clear();
@@ -2965,9 +3257,10 @@ impl SelectedListContent {
 
     // optional .Diff syncResult = 7;
 
-
     pub fn get_syncResult(&self) -> &Diff {
-        self.syncResult.as_ref().unwrap_or_else(|| Diff::default_instance())
+        self.syncResult
+            .as_ref()
+            .unwrap_or_else(|| Diff::default_instance())
     }
     pub fn clear_syncResult(&mut self) {
         self.syncResult.clear();
@@ -2998,7 +3291,6 @@ impl SelectedListContent {
 
     // repeated bytes resultingRevisions = 8;
 
-
     pub fn get_resultingRevisions(&self) -> &[::std::vec::Vec<u8>] {
         &self.resultingRevisions
     }
@@ -3012,17 +3304,21 @@ impl SelectedListContent {
     }
 
     // Mutable pointer to the field.
-    pub fn mut_resultingRevisions(&mut self) -> &mut ::protobuf::RepeatedField<::std::vec::Vec<u8>> {
+    pub fn mut_resultingRevisions(
+        &mut self,
+    ) -> &mut ::protobuf::RepeatedField<::std::vec::Vec<u8>> {
         &mut self.resultingRevisions
     }
 
     // Take field
     pub fn take_resultingRevisions(&mut self) -> ::protobuf::RepeatedField<::std::vec::Vec<u8>> {
-        ::std::mem::replace(&mut self.resultingRevisions, ::protobuf::RepeatedField::new())
+        ::std::mem::replace(
+            &mut self.resultingRevisions,
+            ::protobuf::RepeatedField::new(),
+        )
     }
 
     // optional bool multipleHeads = 9;
-
 
     pub fn get_multipleHeads(&self) -> bool {
         self.multipleHeads.unwrap_or(false)
@@ -3042,7 +3338,6 @@ impl SelectedListContent {
 
     // optional bool upToDate = 10;
 
-
     pub fn get_upToDate(&self) -> bool {
         self.upToDate.unwrap_or(false)
     }
@@ -3061,7 +3356,6 @@ impl SelectedListContent {
 
     // repeated .ClientResolveAction resolveAction = 12;
 
-
     pub fn get_resolveAction(&self) -> &[super::playlist4issues::ClientResolveAction] {
         &self.resolveAction
     }
@@ -3070,22 +3364,28 @@ impl SelectedListContent {
     }
 
     // Param is passed by value, moved
-    pub fn set_resolveAction(&mut self, v: ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction>) {
+    pub fn set_resolveAction(
+        &mut self,
+        v: ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction>,
+    ) {
         self.resolveAction = v;
     }
 
     // Mutable pointer to the field.
-    pub fn mut_resolveAction(&mut self) -> &mut ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction> {
+    pub fn mut_resolveAction(
+        &mut self,
+    ) -> &mut ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction> {
         &mut self.resolveAction
     }
 
     // Take field
-    pub fn take_resolveAction(&mut self) -> ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction> {
+    pub fn take_resolveAction(
+        &mut self,
+    ) -> ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction> {
         ::std::mem::replace(&mut self.resolveAction, ::protobuf::RepeatedField::new())
     }
 
     // repeated .ClientIssue issues = 13;
-
 
     pub fn get_issues(&self) -> &[super::playlist4issues::ClientIssue] {
         &self.issues
@@ -3095,22 +3395,28 @@ impl SelectedListContent {
     }
 
     // Param is passed by value, moved
-    pub fn set_issues(&mut self, v: ::protobuf::RepeatedField<super::playlist4issues::ClientIssue>) {
+    pub fn set_issues(
+        &mut self,
+        v: ::protobuf::RepeatedField<super::playlist4issues::ClientIssue>,
+    ) {
         self.issues = v;
     }
 
     // Mutable pointer to the field.
-    pub fn mut_issues(&mut self) -> &mut ::protobuf::RepeatedField<super::playlist4issues::ClientIssue> {
+    pub fn mut_issues(
+        &mut self,
+    ) -> &mut ::protobuf::RepeatedField<super::playlist4issues::ClientIssue> {
         &mut self.issues
     }
 
     // Take field
-    pub fn take_issues(&mut self) -> ::protobuf::RepeatedField<super::playlist4issues::ClientIssue> {
+    pub fn take_issues(
+        &mut self,
+    ) -> ::protobuf::RepeatedField<super::playlist4issues::ClientIssue> {
         ::std::mem::replace(&mut self.issues, ::protobuf::RepeatedField::new())
     }
 
     // repeated int32 nonces = 14;
-
 
     pub fn get_nonces(&self) -> &[i32] {
         &self.nonces
@@ -3135,7 +3441,6 @@ impl SelectedListContent {
     }
 
     // optional string owner_username = 16;
-
 
     pub fn get_owner_username(&self) -> &str {
         match self.owner_username.as_ref() {
@@ -3167,7 +3472,9 @@ impl SelectedListContent {
 
     // Take field
     pub fn take_owner_username(&mut self) -> ::std::string::String {
-        self.owner_username.take().unwrap_or_else(|| ::std::string::String::new())
+        self.owner_username
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -3177,101 +3484,135 @@ impl ::protobuf::Message for SelectedListContent {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.contents {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.diff {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.syncResult {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.resolveAction {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.issues {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.revision)?;
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.length = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.attributes)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.attributes,
+                    )?;
+                }
                 4 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.checksum)?;
-                },
+                }
                 5 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.contents)?;
-                },
+                }
                 6 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.diff)?;
-                },
+                }
                 7 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.syncResult)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.syncResult,
+                    )?;
+                }
                 8 => {
-                    ::protobuf::rt::read_repeated_bytes_into(wire_type, is, &mut self.resultingRevisions)?;
-                },
+                    ::protobuf::rt::read_repeated_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.resultingRevisions,
+                    )?;
+                }
                 9 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.multipleHeads = ::std::option::Option::Some(tmp);
-                },
+                }
                 10 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.upToDate = ::std::option::Option::Some(tmp);
-                },
+                }
                 12 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.resolveAction)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.resolveAction,
+                    )?;
+                }
                 13 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.issues)?;
-                },
+                }
                 14 => {
                     ::protobuf::rt::read_repeated_int32_into(wire_type, is, &mut self.nonces)?;
-                },
+                }
                 16 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.owner_username)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.owner_username,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3309,7 +3650,7 @@ impl ::protobuf::Message for SelectedListContent {
         }
         for value in &self.resultingRevisions {
             my_size += ::protobuf::rt::bytes_size(8, &value);
-        };
+        }
         if let Some(v) = self.multipleHeads {
             my_size += 2;
         }
@@ -3319,14 +3660,15 @@ impl ::protobuf::Message for SelectedListContent {
         for value in &self.resolveAction {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.issues {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.nonces {
-            my_size += ::protobuf::rt::value_size(14, *value, ::protobuf::wire_format::WireTypeVarint);
-        };
+            my_size +=
+                ::protobuf::rt::value_size(14, *value, ::protobuf::wire_format::WireTypeVarint);
+        }
         if let Some(ref v) = self.owner_username.as_ref() {
             my_size += ::protobuf::rt::string_size(16, &v);
         }
@@ -3335,7 +3677,10 @@ impl ::protobuf::Message for SelectedListContent {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.revision.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -3369,7 +3714,7 @@ impl ::protobuf::Message for SelectedListContent {
         }
         for v in &self.resultingRevisions {
             os.write_bytes(8, &v)?;
-        };
+        }
         if let Some(v) = self.multipleHeads {
             os.write_bool(9, v)?;
         }
@@ -3380,15 +3725,15 @@ impl ::protobuf::Message for SelectedListContent {
             os.write_tag(12, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.issues {
             os.write_tag(13, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.nonces {
             os.write_int32(14, *v)?;
-        };
+        }
         if let Some(ref v) = self.owner_username.as_ref() {
             os.write_string(16, &v)?;
         }
@@ -3427,87 +3772,154 @@ impl ::protobuf::Message for SelectedListContent {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "revision",
-                    |m: &SelectedListContent| { &m.revision },
-                    |m: &mut SelectedListContent| { &mut m.revision },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "revision",
+                        |m: &SelectedListContent| &m.revision,
+                        |m: &mut SelectedListContent| &mut m.revision,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "length",
-                    |m: &SelectedListContent| { &m.length },
-                    |m: &mut SelectedListContent| { &mut m.length },
+                    |m: &SelectedListContent| &m.length,
+                    |m: &mut SelectedListContent| &mut m.length,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListAttributes>>(
-                    "attributes",
-                    |m: &SelectedListContent| { &m.attributes },
-                    |m: &mut SelectedListContent| { &mut m.attributes },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "checksum",
-                    |m: &SelectedListContent| { &m.checksum },
-                    |m: &mut SelectedListContent| { &mut m.checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4content::ListItems>>(
-                    "contents",
-                    |m: &SelectedListContent| { &m.contents },
-                    |m: &mut SelectedListContent| { &mut m.contents },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Diff>>(
-                    "diff",
-                    |m: &SelectedListContent| { &m.diff },
-                    |m: &mut SelectedListContent| { &mut m.diff },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Diff>>(
-                    "syncResult",
-                    |m: &SelectedListContent| { &m.syncResult },
-                    |m: &mut SelectedListContent| { &mut m.syncResult },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "resultingRevisions",
-                    |m: &SelectedListContent| { &m.resultingRevisions },
-                    |m: &mut SelectedListContent| { &mut m.resultingRevisions },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<
+                            super::playlist4meta::ListAttributes,
+                        >,
+                    >(
+                        "attributes",
+                        |m: &SelectedListContent| &m.attributes,
+                        |m: &mut SelectedListContent| &mut m.attributes,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "checksum",
+                        |m: &SelectedListContent| &m.checksum,
+                        |m: &mut SelectedListContent| &mut m.checksum,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4content::ListItems>,
+                    >(
+                        "contents",
+                        |m: &SelectedListContent| &m.contents,
+                        |m: &mut SelectedListContent| &mut m.contents,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Diff>,
+                    >(
+                        "diff",
+                        |m: &SelectedListContent| &m.diff,
+                        |m: &mut SelectedListContent| &mut m.diff,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Diff>,
+                    >(
+                        "syncResult",
+                        |m: &SelectedListContent| &m.syncResult,
+                        |m: &mut SelectedListContent| &mut m.syncResult,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "resultingRevisions",
+                        |m: &SelectedListContent| &m.resultingRevisions,
+                        |m: &mut SelectedListContent| &mut m.resultingRevisions,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "multipleHeads",
-                    |m: &SelectedListContent| { &m.multipleHeads },
-                    |m: &mut SelectedListContent| { &mut m.multipleHeads },
+                    |m: &SelectedListContent| &m.multipleHeads,
+                    |m: &mut SelectedListContent| &mut m.multipleHeads,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "upToDate",
-                    |m: &SelectedListContent| { &m.upToDate },
-                    |m: &mut SelectedListContent| { &mut m.upToDate },
+                    |m: &SelectedListContent| &m.upToDate,
+                    |m: &mut SelectedListContent| &mut m.upToDate,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4issues::ClientResolveAction>>(
-                    "resolveAction",
-                    |m: &SelectedListContent| { &m.resolveAction },
-                    |m: &mut SelectedListContent| { &mut m.resolveAction },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4issues::ClientIssue>>(
-                    "issues",
-                    |m: &SelectedListContent| { &m.issues },
-                    |m: &mut SelectedListContent| { &mut m.issues },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<
+                            super::playlist4issues::ClientResolveAction,
+                        >,
+                    >(
+                        "resolveAction",
+                        |m: &SelectedListContent| &m.resolveAction,
+                        |m: &mut SelectedListContent| &mut m.resolveAction,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4issues::ClientIssue>,
+                    >(
+                        "issues",
+                        |m: &SelectedListContent| &m.issues,
+                        |m: &mut SelectedListContent| &mut m.issues,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "nonces",
-                    |m: &SelectedListContent| { &m.nonces },
-                    |m: &mut SelectedListContent| { &mut m.nonces },
+                    |m: &SelectedListContent| &m.nonces,
+                    |m: &mut SelectedListContent| &mut m.nonces,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "owner_username",
-                    |m: &SelectedListContent| { &m.owner_username },
-                    |m: &mut SelectedListContent| { &mut m.owner_username },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "owner_username",
+                        |m: &SelectedListContent| &m.owner_username,
+                        |m: &mut SelectedListContent| &mut m.owner_username,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<SelectedListContent>(
                     "SelectedListContent",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3518,9 +3930,7 @@ impl ::protobuf::Message for SelectedListContent {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const SelectedListContent,
         };
-        unsafe {
-            instance.get(SelectedListContent::new)
-        }
+        unsafe { instance.get(SelectedListContent::new) }
     }
 }
 
@@ -3600,7 +4010,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x20\x01(\tB\0:\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -3610,9 +4022,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/playlist4content.rs
+++ b/protocol/src/playlist4content.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Item {
     // message fields
     uri: ::protobuf::SingularField<::std::string::String>,
@@ -48,7 +48,6 @@ impl Item {
     }
 
     // optional string uri = 1;
-
 
     pub fn get_uri(&self) -> &str {
         match self.uri.as_ref() {
@@ -80,14 +79,17 @@ impl Item {
 
     // Take field
     pub fn take_uri(&mut self) -> ::std::string::String {
-        self.uri.take().unwrap_or_else(|| ::std::string::String::new())
+        self.uri
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional .ItemAttributes attributes = 2;
 
-
     pub fn get_attributes(&self) -> &super::playlist4meta::ItemAttributes {
-        self.attributes.as_ref().unwrap_or_else(|| super::playlist4meta::ItemAttributes::default_instance())
+        self.attributes
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ItemAttributes::default_instance())
     }
     pub fn clear_attributes(&mut self) {
         self.attributes.clear();
@@ -113,7 +115,9 @@ impl Item {
 
     // Take field
     pub fn take_attributes(&mut self) -> super::playlist4meta::ItemAttributes {
-        self.attributes.take().unwrap_or_else(|| super::playlist4meta::ItemAttributes::new())
+        self.attributes
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ItemAttributes::new())
     }
 }
 
@@ -123,23 +127,35 @@ impl ::protobuf::Message for Item {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.uri)?;
-                },
+                }
                 2 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.attributes)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.attributes,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -161,7 +177,10 @@ impl ::protobuf::Message for Item {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.uri.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -205,27 +224,36 @@ impl ::protobuf::Message for Item {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "uri",
-                    |m: &Item| { &m.uri },
-                    |m: &mut Item| { &mut m.uri },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ItemAttributes>>(
-                    "attributes",
-                    |m: &Item| { &m.attributes },
-                    |m: &mut Item| { &mut m.attributes },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >("uri", |m: &Item| &m.uri, |m: &mut Item| &mut m.uri),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<
+                            super::playlist4meta::ItemAttributes,
+                        >,
+                    >(
+                        "attributes",
+                        |m: &Item| &m.attributes,
+                        |m: &mut Item| &mut m.attributes,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Item>(
                     "Item",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -236,9 +264,7 @@ impl ::protobuf::Message for Item {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Item,
         };
-        unsafe {
-            instance.get(Item::new)
-        }
+        unsafe { instance.get(Item::new) }
     }
 }
 
@@ -262,7 +288,7 @@ impl ::protobuf::reflect::ProtobufValue for Item {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ListItems {
     // message fields
     pos: ::std::option::Option<i32>,
@@ -286,7 +312,6 @@ impl ListItems {
 
     // optional int32 pos = 1;
 
-
     pub fn get_pos(&self) -> i32 {
         self.pos.unwrap_or(0)
     }
@@ -305,7 +330,6 @@ impl ListItems {
 
     // optional bool truncated = 2;
 
-
     pub fn get_truncated(&self) -> bool {
         self.truncated.unwrap_or(false)
     }
@@ -323,7 +347,6 @@ impl ListItems {
     }
 
     // repeated .Item items = 3;
-
 
     pub fn get_items(&self) -> &[Item] {
         &self.items
@@ -354,34 +377,46 @@ impl ::protobuf::Message for ListItems {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.pos = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.truncated = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.items)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -400,13 +435,16 @@ impl ::protobuf::Message for ListItems {
         for value in &self.items {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.pos {
             os.write_int32(1, v)?;
         }
@@ -417,7 +455,7 @@ impl ::protobuf::Message for ListItems {
             os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -453,32 +491,44 @@ impl ::protobuf::Message for ListItems {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "pos",
-                    |m: &ListItems| { &m.pos },
-                    |m: &mut ListItems| { &mut m.pos },
+                    |m: &ListItems| &m.pos,
+                    |m: &mut ListItems| &mut m.pos,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "truncated",
-                    |m: &ListItems| { &m.truncated },
-                    |m: &mut ListItems| { &mut m.truncated },
+                    |m: &ListItems| &m.truncated,
+                    |m: &mut ListItems| &mut m.truncated,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Item>>(
-                    "items",
-                    |m: &ListItems| { &m.items },
-                    |m: &mut ListItems| { &mut m.items },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Item>,
+                    >(
+                        "items",
+                        |m: &ListItems| &m.items,
+                        |m: &mut ListItems| &mut m.items,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ListItems>(
                     "ListItems",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -489,9 +539,7 @@ impl ::protobuf::Message for ListItems {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ListItems,
         };
-        unsafe {
-            instance.get(ListItems::new)
-        }
+        unsafe { instance.get(ListItems::new) }
     }
 }
 
@@ -516,7 +564,7 @@ impl ::protobuf::reflect::ProtobufValue for ListItems {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ContentRange {
     // message fields
     pos: ::std::option::Option<i32>,
@@ -539,7 +587,6 @@ impl ContentRange {
 
     // optional int32 pos = 1;
 
-
     pub fn get_pos(&self) -> i32 {
         self.pos.unwrap_or(0)
     }
@@ -557,7 +604,6 @@ impl ContentRange {
     }
 
     // optional int32 length = 2;
-
 
     pub fn get_length(&self) -> i32 {
         self.length.unwrap_or(0)
@@ -581,27 +627,39 @@ impl ::protobuf::Message for ContentRange {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.pos = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.length = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -622,7 +680,10 @@ impl ::protobuf::Message for ContentRange {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.pos {
             os.write_int32(1, v)?;
         }
@@ -664,27 +725,34 @@ impl ::protobuf::Message for ContentRange {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "pos",
-                    |m: &ContentRange| { &m.pos },
-                    |m: &mut ContentRange| { &mut m.pos },
+                    |m: &ContentRange| &m.pos,
+                    |m: &mut ContentRange| &mut m.pos,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "length",
-                    |m: &ContentRange| { &m.length },
-                    |m: &mut ContentRange| { &mut m.length },
+                    |m: &ContentRange| &m.length,
+                    |m: &mut ContentRange| &mut m.length,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ContentRange>(
                     "ContentRange",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -695,9 +763,7 @@ impl ::protobuf::Message for ContentRange {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ContentRange,
         };
-        unsafe {
-            instance.get(ContentRange::new)
-        }
+        unsafe { instance.get(ContentRange::new) }
     }
 }
 
@@ -721,7 +787,7 @@ impl ::protobuf::reflect::ProtobufValue for ContentRange {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ListContentSelection {
     // message fields
     wantRevision: ::std::option::Option<bool>,
@@ -755,7 +821,6 @@ impl ListContentSelection {
 
     // optional bool wantRevision = 1;
 
-
     pub fn get_wantRevision(&self) -> bool {
         self.wantRevision.unwrap_or(false)
     }
@@ -773,7 +838,6 @@ impl ListContentSelection {
     }
 
     // optional bool wantLength = 2;
-
 
     pub fn get_wantLength(&self) -> bool {
         self.wantLength.unwrap_or(false)
@@ -793,7 +857,6 @@ impl ListContentSelection {
 
     // optional bool wantAttributes = 3;
 
-
     pub fn get_wantAttributes(&self) -> bool {
         self.wantAttributes.unwrap_or(false)
     }
@@ -811,7 +874,6 @@ impl ListContentSelection {
     }
 
     // optional bool wantChecksum = 4;
-
 
     pub fn get_wantChecksum(&self) -> bool {
         self.wantChecksum.unwrap_or(false)
@@ -831,7 +893,6 @@ impl ListContentSelection {
 
     // optional bool wantContent = 5;
 
-
     pub fn get_wantContent(&self) -> bool {
         self.wantContent.unwrap_or(false)
     }
@@ -850,9 +911,10 @@ impl ListContentSelection {
 
     // optional .ContentRange contentRange = 6;
 
-
     pub fn get_contentRange(&self) -> &ContentRange {
-        self.contentRange.as_ref().unwrap_or_else(|| ContentRange::default_instance())
+        self.contentRange
+            .as_ref()
+            .unwrap_or_else(|| ContentRange::default_instance())
     }
     pub fn clear_contentRange(&mut self) {
         self.contentRange.clear();
@@ -878,11 +940,12 @@ impl ListContentSelection {
 
     // Take field
     pub fn take_contentRange(&mut self) -> ContentRange {
-        self.contentRange.take().unwrap_or_else(|| ContentRange::new())
+        self.contentRange
+            .take()
+            .unwrap_or_else(|| ContentRange::new())
     }
 
     // optional bool wantDiff = 7;
-
 
     pub fn get_wantDiff(&self) -> bool {
         self.wantDiff.unwrap_or(false)
@@ -901,7 +964,6 @@ impl ListContentSelection {
     }
 
     // optional bytes baseRevision = 8;
-
 
     pub fn get_baseRevision(&self) -> &[u8] {
         match self.baseRevision.as_ref() {
@@ -933,11 +995,12 @@ impl ListContentSelection {
 
     // Take field
     pub fn take_baseRevision(&mut self) -> ::std::vec::Vec<u8> {
-        self.baseRevision.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.baseRevision
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional bytes hintRevision = 9;
-
 
     pub fn get_hintRevision(&self) -> &[u8] {
         match self.hintRevision.as_ref() {
@@ -969,11 +1032,12 @@ impl ListContentSelection {
 
     // Take field
     pub fn take_hintRevision(&mut self) -> ::std::vec::Vec<u8> {
-        self.hintRevision.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.hintRevision
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional bool wantNothingIfUpToDate = 10;
-
 
     pub fn get_wantNothingIfUpToDate(&self) -> bool {
         self.wantNothingIfUpToDate.unwrap_or(false)
@@ -993,7 +1057,6 @@ impl ListContentSelection {
 
     // optional bool wantResolveAction = 12;
 
-
     pub fn get_wantResolveAction(&self) -> bool {
         self.wantResolveAction.unwrap_or(false)
     }
@@ -1012,7 +1075,6 @@ impl ListContentSelection {
 
     // repeated .ClientIssue issues = 13;
 
-
     pub fn get_issues(&self) -> &[super::playlist4issues::ClientIssue] {
         &self.issues
     }
@@ -1021,22 +1083,28 @@ impl ListContentSelection {
     }
 
     // Param is passed by value, moved
-    pub fn set_issues(&mut self, v: ::protobuf::RepeatedField<super::playlist4issues::ClientIssue>) {
+    pub fn set_issues(
+        &mut self,
+        v: ::protobuf::RepeatedField<super::playlist4issues::ClientIssue>,
+    ) {
         self.issues = v;
     }
 
     // Mutable pointer to the field.
-    pub fn mut_issues(&mut self) -> &mut ::protobuf::RepeatedField<super::playlist4issues::ClientIssue> {
+    pub fn mut_issues(
+        &mut self,
+    ) -> &mut ::protobuf::RepeatedField<super::playlist4issues::ClientIssue> {
         &mut self.issues
     }
 
     // Take field
-    pub fn take_issues(&mut self) -> ::protobuf::RepeatedField<super::playlist4issues::ClientIssue> {
+    pub fn take_issues(
+        &mut self,
+    ) -> ::protobuf::RepeatedField<super::playlist4issues::ClientIssue> {
         ::std::mem::replace(&mut self.issues, ::protobuf::RepeatedField::new())
     }
 
     // repeated .ClientResolveAction resolveAction = 14;
-
 
     pub fn get_resolveAction(&self) -> &[super::playlist4issues::ClientResolveAction] {
         &self.resolveAction
@@ -1046,17 +1114,24 @@ impl ListContentSelection {
     }
 
     // Param is passed by value, moved
-    pub fn set_resolveAction(&mut self, v: ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction>) {
+    pub fn set_resolveAction(
+        &mut self,
+        v: ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction>,
+    ) {
         self.resolveAction = v;
     }
 
     // Mutable pointer to the field.
-    pub fn mut_resolveAction(&mut self) -> &mut ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction> {
+    pub fn mut_resolveAction(
+        &mut self,
+    ) -> &mut ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction> {
         &mut self.resolveAction
     }
 
     // Take field
-    pub fn take_resolveAction(&mut self) -> ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction> {
+    pub fn take_resolveAction(
+        &mut self,
+    ) -> ::protobuf::RepeatedField<super::playlist4issues::ClientResolveAction> {
         ::std::mem::replace(&mut self.resolveAction, ::protobuf::RepeatedField::new())
     }
 }
@@ -1067,98 +1142,138 @@ impl ::protobuf::Message for ListContentSelection {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.issues {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.resolveAction {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantRevision = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantLength = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantAttributes = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantChecksum = ::std::option::Option::Some(tmp);
-                },
+                }
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantContent = ::std::option::Option::Some(tmp);
-                },
+                }
                 6 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.contentRange)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.contentRange,
+                    )?;
+                }
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantDiff = ::std::option::Option::Some(tmp);
-                },
+                }
                 8 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.baseRevision)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.baseRevision,
+                    )?;
+                }
                 9 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.hintRevision)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.hintRevision,
+                    )?;
+                }
                 10 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantNothingIfUpToDate = ::std::option::Option::Some(tmp);
-                },
+                }
                 12 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.wantResolveAction = ::std::option::Option::Some(tmp);
-                },
+                }
                 13 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.issues)?;
-                },
+                }
                 14 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.resolveAction)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.resolveAction,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1205,17 +1320,20 @@ impl ::protobuf::Message for ListContentSelection {
         for value in &self.issues {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         for value in &self.resolveAction {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.wantRevision {
             os.write_bool(1, v)?;
         }
@@ -1255,12 +1373,12 @@ impl ::protobuf::Message for ListContentSelection {
             os.write_tag(13, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         for v in &self.resolveAction {
             os.write_tag(14, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -1296,95 +1414,146 @@ impl ::protobuf::Message for ListContentSelection {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantRevision",
-                    |m: &ListContentSelection| { &m.wantRevision },
-                    |m: &mut ListContentSelection| { &mut m.wantRevision },
+                    |m: &ListContentSelection| &m.wantRevision,
+                    |m: &mut ListContentSelection| &mut m.wantRevision,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantLength",
-                    |m: &ListContentSelection| { &m.wantLength },
-                    |m: &mut ListContentSelection| { &mut m.wantLength },
+                    |m: &ListContentSelection| &m.wantLength,
+                    |m: &mut ListContentSelection| &mut m.wantLength,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantAttributes",
-                    |m: &ListContentSelection| { &m.wantAttributes },
-                    |m: &mut ListContentSelection| { &mut m.wantAttributes },
+                    |m: &ListContentSelection| &m.wantAttributes,
+                    |m: &mut ListContentSelection| &mut m.wantAttributes,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantChecksum",
-                    |m: &ListContentSelection| { &m.wantChecksum },
-                    |m: &mut ListContentSelection| { &mut m.wantChecksum },
+                    |m: &ListContentSelection| &m.wantChecksum,
+                    |m: &mut ListContentSelection| &mut m.wantChecksum,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantContent",
-                    |m: &ListContentSelection| { &m.wantContent },
-                    |m: &mut ListContentSelection| { &mut m.wantContent },
+                    |m: &ListContentSelection| &m.wantContent,
+                    |m: &mut ListContentSelection| &mut m.wantContent,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ContentRange>>(
-                    "contentRange",
-                    |m: &ListContentSelection| { &m.contentRange },
-                    |m: &mut ListContentSelection| { &mut m.contentRange },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ContentRange>,
+                    >(
+                        "contentRange",
+                        |m: &ListContentSelection| &m.contentRange,
+                        |m: &mut ListContentSelection| &mut m.contentRange,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantDiff",
-                    |m: &ListContentSelection| { &m.wantDiff },
-                    |m: &mut ListContentSelection| { &mut m.wantDiff },
+                    |m: &ListContentSelection| &m.wantDiff,
+                    |m: &mut ListContentSelection| &mut m.wantDiff,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "baseRevision",
-                    |m: &ListContentSelection| { &m.baseRevision },
-                    |m: &mut ListContentSelection| { &mut m.baseRevision },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "hintRevision",
-                    |m: &ListContentSelection| { &m.hintRevision },
-                    |m: &mut ListContentSelection| { &mut m.hintRevision },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "baseRevision",
+                        |m: &ListContentSelection| &m.baseRevision,
+                        |m: &mut ListContentSelection| &mut m.baseRevision,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "hintRevision",
+                        |m: &ListContentSelection| &m.hintRevision,
+                        |m: &mut ListContentSelection| &mut m.hintRevision,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantNothingIfUpToDate",
-                    |m: &ListContentSelection| { &m.wantNothingIfUpToDate },
-                    |m: &mut ListContentSelection| { &mut m.wantNothingIfUpToDate },
+                    |m: &ListContentSelection| &m.wantNothingIfUpToDate,
+                    |m: &mut ListContentSelection| &mut m.wantNothingIfUpToDate,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "wantResolveAction",
-                    |m: &ListContentSelection| { &m.wantResolveAction },
-                    |m: &mut ListContentSelection| { &mut m.wantResolveAction },
+                    |m: &ListContentSelection| &m.wantResolveAction,
+                    |m: &mut ListContentSelection| &mut m.wantResolveAction,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4issues::ClientIssue>>(
-                    "issues",
-                    |m: &ListContentSelection| { &m.issues },
-                    |m: &mut ListContentSelection| { &mut m.issues },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4issues::ClientResolveAction>>(
-                    "resolveAction",
-                    |m: &ListContentSelection| { &m.resolveAction },
-                    |m: &mut ListContentSelection| { &mut m.resolveAction },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4issues::ClientIssue>,
+                    >(
+                        "issues",
+                        |m: &ListContentSelection| &m.issues,
+                        |m: &mut ListContentSelection| &mut m.issues,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<
+                            super::playlist4issues::ClientResolveAction,
+                        >,
+                    >(
+                        "resolveAction",
+                        |m: &ListContentSelection| &m.resolveAction,
+                        |m: &mut ListContentSelection| &mut m.resolveAction,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ListContentSelection>(
                     "ListContentSelection",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static ListContentSelection {
-        static mut instance: ::protobuf::lazy::Lazy<ListContentSelection> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ListContentSelection,
-        };
-        unsafe {
-            instance.get(ListContentSelection::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<ListContentSelection> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ListContentSelection,
+            };
+        unsafe { instance.get(ListContentSelection::new) }
     }
 }
 
@@ -1439,7 +1608,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     ionB\0:\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -1449,9 +1620,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/playlist4issues.rs
+++ b/protocol/src/playlist4issues.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ClientIssue {
     // message fields
     level: ::std::option::Option<ClientIssue_Level>,
@@ -50,7 +50,6 @@ impl ClientIssue {
 
     // optional .ClientIssue.Level level = 1;
 
-
     pub fn get_level(&self) -> ClientIssue_Level {
         self.level.unwrap_or(ClientIssue_Level::LEVEL_UNKNOWN)
     }
@@ -69,7 +68,6 @@ impl ClientIssue {
 
     // optional .ClientIssue.Code code = 2;
 
-
     pub fn get_code(&self) -> ClientIssue_Code {
         self.code.unwrap_or(ClientIssue_Code::CODE_UNKNOWN)
     }
@@ -87,7 +85,6 @@ impl ClientIssue {
     }
 
     // optional int32 repeatCount = 3;
-
 
     pub fn get_repeatCount(&self) -> i32 {
         self.repeatCount.unwrap_or(0)
@@ -111,26 +108,44 @@ impl ::protobuf::Message for ClientIssue {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                1 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.level, 1, &mut self.unknown_fields)?
-                },
-                2 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.code, 2, &mut self.unknown_fields)?
-                },
+                1 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.level,
+                    1,
+                    &mut self.unknown_fields,
+                )?,
+                2 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.code,
+                    2,
+                    &mut self.unknown_fields,
+                )?,
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.repeatCount = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -154,7 +169,10 @@ impl ::protobuf::Message for ClientIssue {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.level {
             os.write_enum(1, v.value())?;
         }
@@ -199,32 +217,42 @@ impl ::protobuf::Message for ClientIssue {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ClientIssue_Level>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<ClientIssue_Level>,
+                >(
                     "level",
-                    |m: &ClientIssue| { &m.level },
-                    |m: &mut ClientIssue| { &mut m.level },
+                    |m: &ClientIssue| &m.level,
+                    |m: &mut ClientIssue| &mut m.level,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ClientIssue_Code>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<ClientIssue_Code>,
+                >(
                     "code",
-                    |m: &ClientIssue| { &m.code },
-                    |m: &mut ClientIssue| { &mut m.code },
+                    |m: &ClientIssue| &m.code,
+                    |m: &mut ClientIssue| &mut m.code,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "repeatCount",
-                    |m: &ClientIssue| { &m.repeatCount },
-                    |m: &mut ClientIssue| { &mut m.repeatCount },
+                    |m: &ClientIssue| &m.repeatCount,
+                    |m: &mut ClientIssue| &mut m.repeatCount,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ClientIssue>(
                     "ClientIssue",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -235,9 +263,7 @@ impl ::protobuf::Message for ClientIssue {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ClientIssue,
         };
-        unsafe {
-            instance.get(ClientIssue::new)
-        }
+        unsafe { instance.get(ClientIssue::new) }
     }
 }
 
@@ -262,7 +288,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientIssue {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ClientIssue_Level {
     LEVEL_UNKNOWN = 0,
     LEVEL_DEBUG = 1,
@@ -285,7 +311,7 @@ impl ::protobuf::ProtobufEnum for ClientIssue_Level {
             3 => ::std::option::Option::Some(ClientIssue_Level::LEVEL_NOTICE),
             4 => ::std::option::Option::Some(ClientIssue_Level::LEVEL_WARNING),
             5 => ::std::option::Option::Some(ClientIssue_Level::LEVEL_ERROR),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -302,20 +328,23 @@ impl ::protobuf::ProtobufEnum for ClientIssue_Level {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("ClientIssue_Level", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "ClientIssue_Level",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for ClientIssue_Level {
-}
+impl ::std::marker::Copy for ClientIssue_Level {}
 
 impl ::std::default::Default for ClientIssue_Level {
     fn default() -> Self {
@@ -329,7 +358,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientIssue_Level {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ClientIssue_Code {
     CODE_UNKNOWN = 0,
     CODE_INDEX_OUT_OF_BOUNDS = 1,
@@ -352,7 +381,7 @@ impl ::protobuf::ProtobufEnum for ClientIssue_Code {
             3 => ::std::option::Option::Some(ClientIssue_Code::CODE_CACHED_CHANGE),
             4 => ::std::option::Option::Some(ClientIssue_Code::CODE_OFFLINE_CHANGE),
             5 => ::std::option::Option::Some(ClientIssue_Code::CODE_CONCURRENT_CHANGE),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -369,20 +398,23 @@ impl ::protobuf::ProtobufEnum for ClientIssue_Code {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("ClientIssue_Code", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "ClientIssue_Code",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for ClientIssue_Code {
-}
+impl ::std::marker::Copy for ClientIssue_Code {}
 
 impl ::std::default::Default for ClientIssue_Code {
     fn default() -> Self {
@@ -396,7 +428,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientIssue_Code {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ClientResolveAction {
     // message fields
     code: ::std::option::Option<ClientResolveAction_Code>,
@@ -419,7 +451,6 @@ impl ClientResolveAction {
 
     // optional .ClientResolveAction.Code code = 1;
 
-
     pub fn get_code(&self) -> ClientResolveAction_Code {
         self.code.unwrap_or(ClientResolveAction_Code::CODE_UNKNOWN)
     }
@@ -438,9 +469,9 @@ impl ClientResolveAction {
 
     // optional .ClientResolveAction.Initiator initiator = 2;
 
-
     pub fn get_initiator(&self) -> ClientResolveAction_Initiator {
-        self.initiator.unwrap_or(ClientResolveAction_Initiator::INITIATOR_UNKNOWN)
+        self.initiator
+            .unwrap_or(ClientResolveAction_Initiator::INITIATOR_UNKNOWN)
     }
     pub fn clear_initiator(&mut self) {
         self.initiator = ::std::option::Option::None;
@@ -461,19 +492,35 @@ impl ::protobuf::Message for ClientResolveAction {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                1 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.code, 1, &mut self.unknown_fields)?
-                },
-                2 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.initiator, 2, &mut self.unknown_fields)?
-                },
+                1 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.code,
+                    1,
+                    &mut self.unknown_fields,
+                )?,
+                2 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.initiator,
+                    2,
+                    &mut self.unknown_fields,
+                )?,
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -494,7 +541,10 @@ impl ::protobuf::Message for ClientResolveAction {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.code {
             os.write_enum(1, v.value())?;
         }
@@ -536,27 +586,34 @@ impl ::protobuf::Message for ClientResolveAction {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ClientResolveAction_Code>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<ClientResolveAction_Code>,
+                >(
                     "code",
-                    |m: &ClientResolveAction| { &m.code },
-                    |m: &mut ClientResolveAction| { &mut m.code },
+                    |m: &ClientResolveAction| &m.code,
+                    |m: &mut ClientResolveAction| &mut m.code,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ClientResolveAction_Initiator>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<ClientResolveAction_Initiator>,
+                >(
                     "initiator",
-                    |m: &ClientResolveAction| { &m.initiator },
-                    |m: &mut ClientResolveAction| { &mut m.initiator },
+                    |m: &ClientResolveAction| &m.initiator,
+                    |m: &mut ClientResolveAction| &mut m.initiator,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ClientResolveAction>(
                     "ClientResolveAction",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -567,9 +624,7 @@ impl ::protobuf::Message for ClientResolveAction {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ClientResolveAction,
         };
-        unsafe {
-            instance.get(ClientResolveAction::new)
-        }
+        unsafe { instance.get(ClientResolveAction::new) }
     }
 }
 
@@ -593,7 +648,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientResolveAction {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ClientResolveAction_Code {
     CODE_UNKNOWN = 0,
     CODE_NO_ACTION = 1,
@@ -618,7 +673,7 @@ impl ::protobuf::ProtobufEnum for ClientResolveAction_Code {
             4 => ::std::option::Option::Some(ClientResolveAction_Code::CODE_DISCARD_LOCAL_CHANGES),
             5 => ::std::option::Option::Some(ClientResolveAction_Code::CODE_SEND_DUMP),
             6 => ::std::option::Option::Some(ClientResolveAction_Code::CODE_DISPLAY_ERROR_MESSAGE),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -636,20 +691,23 @@ impl ::protobuf::ProtobufEnum for ClientResolveAction_Code {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("ClientResolveAction_Code", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "ClientResolveAction_Code",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for ClientResolveAction_Code {
-}
+impl ::std::marker::Copy for ClientResolveAction_Code {}
 
 impl ::std::default::Default for ClientResolveAction_Code {
     fn default() -> Self {
@@ -663,7 +721,7 @@ impl ::protobuf::reflect::ProtobufValue for ClientResolveAction_Code {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ClientResolveAction_Initiator {
     INITIATOR_UNKNOWN = 0,
     INITIATOR_SERVER = 1,
@@ -680,7 +738,7 @@ impl ::protobuf::ProtobufEnum for ClientResolveAction_Initiator {
             0 => ::std::option::Option::Some(ClientResolveAction_Initiator::INITIATOR_UNKNOWN),
             1 => ::std::option::Option::Some(ClientResolveAction_Initiator::INITIATOR_SERVER),
             2 => ::std::option::Option::Some(ClientResolveAction_Initiator::INITIATOR_CLIENT),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -694,20 +752,23 @@ impl ::protobuf::ProtobufEnum for ClientResolveAction_Initiator {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("ClientResolveAction_Initiator", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "ClientResolveAction_Initiator",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for ClientResolveAction_Initiator {
-}
+impl ::std::marker::Copy for ClientResolveAction_Initiator {}
 
 impl ::std::default::Default for ClientResolveAction_Initiator {
     fn default() -> Self {
@@ -743,7 +804,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x10\x01\x12\x14\n\x10INITIATOR_CLIENT\x10\x02\x1a\0:\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -753,9 +816,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/playlist4meta.rs
+++ b/protocol/src/playlist4meta.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ListChecksum {
     // message fields
     version: ::std::option::Option<i32>,
@@ -49,7 +49,6 @@ impl ListChecksum {
 
     // optional int32 version = 1;
 
-
     pub fn get_version(&self) -> i32 {
         self.version.unwrap_or(0)
     }
@@ -67,7 +66,6 @@ impl ListChecksum {
     }
 
     // optional bytes sha1 = 4;
-
 
     pub fn get_sha1(&self) -> &[u8] {
         match self.sha1.as_ref() {
@@ -108,23 +106,33 @@ impl ::protobuf::Message for ListChecksum {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.version = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.sha1)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -145,7 +153,10 @@ impl ::protobuf::Message for ListChecksum {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.version {
             os.write_int32(1, v)?;
         }
@@ -187,27 +198,36 @@ impl ::protobuf::Message for ListChecksum {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "version",
-                    |m: &ListChecksum| { &m.version },
-                    |m: &mut ListChecksum| { &mut m.version },
+                    |m: &ListChecksum| &m.version,
+                    |m: &mut ListChecksum| &mut m.version,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "sha1",
-                    |m: &ListChecksum| { &m.sha1 },
-                    |m: &mut ListChecksum| { &mut m.sha1 },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "sha1",
+                        |m: &ListChecksum| &m.sha1,
+                        |m: &mut ListChecksum| &mut m.sha1,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ListChecksum>(
                     "ListChecksum",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -218,9 +238,7 @@ impl ::protobuf::Message for ListChecksum {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ListChecksum,
         };
-        unsafe {
-            instance.get(ListChecksum::new)
-        }
+        unsafe { instance.get(ListChecksum::new) }
     }
 }
 
@@ -244,7 +262,7 @@ impl ::protobuf::reflect::ProtobufValue for ListChecksum {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct DownloadFormat {
     // message fields
     codec: ::std::option::Option<DownloadFormat_Codec>,
@@ -265,7 +283,6 @@ impl DownloadFormat {
     }
 
     // optional .DownloadFormat.Codec codec = 1;
-
 
     pub fn get_codec(&self) -> DownloadFormat_Codec {
         self.codec.unwrap_or(DownloadFormat_Codec::CODEC_UNKNOWN)
@@ -289,16 +306,28 @@ impl ::protobuf::Message for DownloadFormat {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                1 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.codec, 1, &mut self.unknown_fields)?
-                },
+                1 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.codec,
+                    1,
+                    &mut self.unknown_fields,
+                )?,
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -316,7 +345,10 @@ impl ::protobuf::Message for DownloadFormat {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.codec {
             os.write_enum(1, v.value())?;
         }
@@ -355,22 +387,26 @@ impl ::protobuf::Message for DownloadFormat {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<DownloadFormat_Codec>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<DownloadFormat_Codec>,
+                >(
                     "codec",
-                    |m: &DownloadFormat| { &m.codec },
-                    |m: &mut DownloadFormat| { &mut m.codec },
+                    |m: &DownloadFormat| &m.codec,
+                    |m: &mut DownloadFormat| &mut m.codec,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<DownloadFormat>(
                     "DownloadFormat",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -381,9 +417,7 @@ impl ::protobuf::Message for DownloadFormat {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const DownloadFormat,
         };
-        unsafe {
-            instance.get(DownloadFormat::new)
-        }
+        unsafe { instance.get(DownloadFormat::new) }
     }
 }
 
@@ -406,7 +440,7 @@ impl ::protobuf::reflect::ProtobufValue for DownloadFormat {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum DownloadFormat_Codec {
     CODEC_UNKNOWN = 0,
     OGG_VORBIS = 1,
@@ -425,7 +459,7 @@ impl ::protobuf::ProtobufEnum for DownloadFormat_Codec {
             1 => ::std::option::Option::Some(DownloadFormat_Codec::OGG_VORBIS),
             2 => ::std::option::Option::Some(DownloadFormat_Codec::FLAC),
             3 => ::std::option::Option::Some(DownloadFormat_Codec::MPEG_1_LAYER_3),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -440,20 +474,23 @@ impl ::protobuf::ProtobufEnum for DownloadFormat_Codec {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("DownloadFormat_Codec", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "DownloadFormat_Codec",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for DownloadFormat_Codec {
-}
+impl ::std::marker::Copy for DownloadFormat_Codec {}
 
 impl ::std::default::Default for DownloadFormat_Codec {
     fn default() -> Self {
@@ -467,7 +504,7 @@ impl ::protobuf::reflect::ProtobufValue for DownloadFormat_Codec {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ListAttributes {
     // message fields
     name: ::protobuf::SingularField<::std::string::String>,
@@ -497,7 +534,6 @@ impl ListAttributes {
     }
 
     // optional string name = 1;
-
 
     pub fn get_name(&self) -> &str {
         match self.name.as_ref() {
@@ -529,11 +565,12 @@ impl ListAttributes {
 
     // Take field
     pub fn take_name(&mut self) -> ::std::string::String {
-        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string description = 2;
-
 
     pub fn get_description(&self) -> &str {
         match self.description.as_ref() {
@@ -565,11 +602,12 @@ impl ListAttributes {
 
     // Take field
     pub fn take_description(&mut self) -> ::std::string::String {
-        self.description.take().unwrap_or_else(|| ::std::string::String::new())
+        self.description
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bytes picture = 3;
-
 
     pub fn get_picture(&self) -> &[u8] {
         match self.picture.as_ref() {
@@ -601,11 +639,12 @@ impl ListAttributes {
 
     // Take field
     pub fn take_picture(&mut self) -> ::std::vec::Vec<u8> {
-        self.picture.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.picture
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional bool collaborative = 4;
-
 
     pub fn get_collaborative(&self) -> bool {
         self.collaborative.unwrap_or(false)
@@ -624,7 +663,6 @@ impl ListAttributes {
     }
 
     // optional string pl3_version = 5;
-
 
     pub fn get_pl3_version(&self) -> &str {
         match self.pl3_version.as_ref() {
@@ -656,11 +694,12 @@ impl ListAttributes {
 
     // Take field
     pub fn take_pl3_version(&mut self) -> ::std::string::String {
-        self.pl3_version.take().unwrap_or_else(|| ::std::string::String::new())
+        self.pl3_version
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bool deleted_by_owner = 6;
-
 
     pub fn get_deleted_by_owner(&self) -> bool {
         self.deleted_by_owner.unwrap_or(false)
@@ -680,7 +719,6 @@ impl ListAttributes {
 
     // optional bool restricted_collaborative = 7;
 
-
     pub fn get_restricted_collaborative(&self) -> bool {
         self.restricted_collaborative.unwrap_or(false)
     }
@@ -698,7 +736,6 @@ impl ListAttributes {
     }
 
     // optional int64 deprecated_client_id = 8;
-
 
     pub fn get_deprecated_client_id(&self) -> i64 {
         self.deprecated_client_id.unwrap_or(0)
@@ -718,7 +755,6 @@ impl ListAttributes {
 
     // optional bool public_starred = 9;
 
-
     pub fn get_public_starred(&self) -> bool {
         self.public_starred.unwrap_or(false)
     }
@@ -736,7 +772,6 @@ impl ListAttributes {
     }
 
     // optional string client_id = 10;
-
 
     pub fn get_client_id(&self) -> &str {
         match self.client_id.as_ref() {
@@ -768,7 +803,9 @@ impl ListAttributes {
 
     // Take field
     pub fn take_client_id(&mut self) -> ::std::string::String {
-        self.client_id.take().unwrap_or_else(|| ::std::string::String::new())
+        self.client_id
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -777,63 +814,89 @@ impl ::protobuf::Message for ListAttributes {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
-                },
+                }
                 2 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.description)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.description,
+                    )?;
+                }
                 3 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.picture)?;
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.collaborative = ::std::option::Option::Some(tmp);
-                },
+                }
                 5 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.pl3_version)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.pl3_version,
+                    )?;
+                }
                 6 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.deleted_by_owner = ::std::option::Option::Some(tmp);
-                },
+                }
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.restricted_collaborative = ::std::option::Option::Some(tmp);
-                },
+                }
                 8 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int64()?;
                     self.deprecated_client_id = ::std::option::Option::Some(tmp);
-                },
+                }
                 9 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.public_starred = ::std::option::Option::Some(tmp);
-                },
+                }
                 10 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.client_id)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -878,7 +941,10 @@ impl ::protobuf::Message for ListAttributes {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.name.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -944,67 +1010,108 @@ impl ::protobuf::Message for ListAttributes {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "name",
-                    |m: &ListAttributes| { &m.name },
-                    |m: &mut ListAttributes| { &mut m.name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "description",
-                    |m: &ListAttributes| { &m.description },
-                    |m: &mut ListAttributes| { &mut m.description },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "picture",
-                    |m: &ListAttributes| { &m.picture },
-                    |m: &mut ListAttributes| { &mut m.picture },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "name",
+                        |m: &ListAttributes| &m.name,
+                        |m: &mut ListAttributes| &mut m.name,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "description",
+                        |m: &ListAttributes| &m.description,
+                        |m: &mut ListAttributes| &mut m.description,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "picture",
+                        |m: &ListAttributes| &m.picture,
+                        |m: &mut ListAttributes| &mut m.picture,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "collaborative",
-                    |m: &ListAttributes| { &m.collaborative },
-                    |m: &mut ListAttributes| { &mut m.collaborative },
+                    |m: &ListAttributes| &m.collaborative,
+                    |m: &mut ListAttributes| &mut m.collaborative,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "pl3_version",
-                    |m: &ListAttributes| { &m.pl3_version },
-                    |m: &mut ListAttributes| { &mut m.pl3_version },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "pl3_version",
+                        |m: &ListAttributes| &m.pl3_version,
+                        |m: &mut ListAttributes| &mut m.pl3_version,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "deleted_by_owner",
-                    |m: &ListAttributes| { &m.deleted_by_owner },
-                    |m: &mut ListAttributes| { &mut m.deleted_by_owner },
+                    |m: &ListAttributes| &m.deleted_by_owner,
+                    |m: &mut ListAttributes| &mut m.deleted_by_owner,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "restricted_collaborative",
-                    |m: &ListAttributes| { &m.restricted_collaborative },
-                    |m: &mut ListAttributes| { &mut m.restricted_collaborative },
+                    |m: &ListAttributes| &m.restricted_collaborative,
+                    |m: &mut ListAttributes| &mut m.restricted_collaborative,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt64,
+                >(
                     "deprecated_client_id",
-                    |m: &ListAttributes| { &m.deprecated_client_id },
-                    |m: &mut ListAttributes| { &mut m.deprecated_client_id },
+                    |m: &ListAttributes| &m.deprecated_client_id,
+                    |m: &mut ListAttributes| &mut m.deprecated_client_id,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "public_starred",
-                    |m: &ListAttributes| { &m.public_starred },
-                    |m: &mut ListAttributes| { &mut m.public_starred },
+                    |m: &ListAttributes| &m.public_starred,
+                    |m: &mut ListAttributes| &mut m.public_starred,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "client_id",
-                    |m: &ListAttributes| { &m.client_id },
-                    |m: &mut ListAttributes| { &mut m.client_id },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "client_id",
+                        |m: &ListAttributes| &m.client_id,
+                        |m: &mut ListAttributes| &mut m.client_id,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<ListAttributes>(
                     "ListAttributes",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1015,9 +1122,7 @@ impl ::protobuf::Message for ListAttributes {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ListAttributes,
         };
-        unsafe {
-            instance.get(ListAttributes::new)
-        }
+        unsafe { instance.get(ListAttributes::new) }
     }
 }
 
@@ -1049,7 +1154,7 @@ impl ::protobuf::reflect::ProtobufValue for ListAttributes {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ItemAttributes {
     // message fields
     added_by: ::protobuf::SingularField<::std::string::String>,
@@ -1079,7 +1184,6 @@ impl ItemAttributes {
     }
 
     // optional string added_by = 1;
-
 
     pub fn get_added_by(&self) -> &str {
         match self.added_by.as_ref() {
@@ -1111,11 +1215,12 @@ impl ItemAttributes {
 
     // Take field
     pub fn take_added_by(&mut self) -> ::std::string::String {
-        self.added_by.take().unwrap_or_else(|| ::std::string::String::new())
+        self.added_by
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional int64 timestamp = 2;
-
 
     pub fn get_timestamp(&self) -> i64 {
         self.timestamp.unwrap_or(0)
@@ -1134,7 +1239,6 @@ impl ItemAttributes {
     }
 
     // optional string message = 3;
-
 
     pub fn get_message(&self) -> &str {
         match self.message.as_ref() {
@@ -1166,11 +1270,12 @@ impl ItemAttributes {
 
     // Take field
     pub fn take_message(&mut self) -> ::std::string::String {
-        self.message.take().unwrap_or_else(|| ::std::string::String::new())
+        self.message
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bool seen = 4;
-
 
     pub fn get_seen(&self) -> bool {
         self.seen.unwrap_or(false)
@@ -1190,7 +1295,6 @@ impl ItemAttributes {
 
     // optional int64 download_count = 5;
 
-
     pub fn get_download_count(&self) -> i64 {
         self.download_count.unwrap_or(0)
     }
@@ -1209,9 +1313,10 @@ impl ItemAttributes {
 
     // optional .DownloadFormat download_format = 6;
 
-
     pub fn get_download_format(&self) -> &DownloadFormat {
-        self.download_format.as_ref().unwrap_or_else(|| DownloadFormat::default_instance())
+        self.download_format
+            .as_ref()
+            .unwrap_or_else(|| DownloadFormat::default_instance())
     }
     pub fn clear_download_format(&mut self) {
         self.download_format.clear();
@@ -1237,11 +1342,12 @@ impl ItemAttributes {
 
     // Take field
     pub fn take_download_format(&mut self) -> DownloadFormat {
-        self.download_format.take().unwrap_or_else(|| DownloadFormat::new())
+        self.download_format
+            .take()
+            .unwrap_or_else(|| DownloadFormat::new())
     }
 
     // optional string sevendigital_id = 7;
-
 
     pub fn get_sevendigital_id(&self) -> &str {
         match self.sevendigital_id.as_ref() {
@@ -1273,11 +1379,12 @@ impl ItemAttributes {
 
     // Take field
     pub fn take_sevendigital_id(&mut self) -> ::std::string::String {
-        self.sevendigital_id.take().unwrap_or_else(|| ::std::string::String::new())
+        self.sevendigital_id
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional int64 sevendigital_left = 8;
-
 
     pub fn get_sevendigital_left(&self) -> i64 {
         self.sevendigital_left.unwrap_or(0)
@@ -1297,7 +1404,6 @@ impl ItemAttributes {
 
     // optional int64 seen_at = 9;
 
-
     pub fn get_seen_at(&self) -> i64 {
         self.seen_at.unwrap_or(0)
     }
@@ -1315,7 +1421,6 @@ impl ItemAttributes {
     }
 
     // optional bool public = 10;
-
 
     pub fn get_public(&self) -> bool {
         self.public.unwrap_or(false)
@@ -1340,71 +1445,99 @@ impl ::protobuf::Message for ItemAttributes {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.added_by)?;
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int64()?;
                     self.timestamp = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.message)?;
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.seen = ::std::option::Option::Some(tmp);
-                },
+                }
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int64()?;
                     self.download_count = ::std::option::Option::Some(tmp);
-                },
+                }
                 6 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.download_format)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.download_format,
+                    )?;
+                }
                 7 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.sevendigital_id)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.sevendigital_id,
+                    )?;
+                }
                 8 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int64()?;
                     self.sevendigital_left = ::std::option::Option::Some(tmp);
-                },
+                }
                 9 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int64()?;
                     self.seen_at = ::std::option::Option::Some(tmp);
-                },
+                }
                 10 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.public = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1450,7 +1583,10 @@ impl ::protobuf::Message for ItemAttributes {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.added_by.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -1518,67 +1654,106 @@ impl ::protobuf::Message for ItemAttributes {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "added_by",
-                    |m: &ItemAttributes| { &m.added_by },
-                    |m: &mut ItemAttributes| { &mut m.added_by },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "added_by",
+                        |m: &ItemAttributes| &m.added_by,
+                        |m: &mut ItemAttributes| &mut m.added_by,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt64,
+                >(
                     "timestamp",
-                    |m: &ItemAttributes| { &m.timestamp },
-                    |m: &mut ItemAttributes| { &mut m.timestamp },
+                    |m: &ItemAttributes| &m.timestamp,
+                    |m: &mut ItemAttributes| &mut m.timestamp,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "message",
-                    |m: &ItemAttributes| { &m.message },
-                    |m: &mut ItemAttributes| { &mut m.message },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "message",
+                        |m: &ItemAttributes| &m.message,
+                        |m: &mut ItemAttributes| &mut m.message,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "seen",
-                    |m: &ItemAttributes| { &m.seen },
-                    |m: &mut ItemAttributes| { &mut m.seen },
+                    |m: &ItemAttributes| &m.seen,
+                    |m: &mut ItemAttributes| &mut m.seen,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt64,
+                >(
                     "download_count",
-                    |m: &ItemAttributes| { &m.download_count },
-                    |m: &mut ItemAttributes| { &mut m.download_count },
+                    |m: &ItemAttributes| &m.download_count,
+                    |m: &mut ItemAttributes| &mut m.download_count,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<DownloadFormat>>(
-                    "download_format",
-                    |m: &ItemAttributes| { &m.download_format },
-                    |m: &mut ItemAttributes| { &mut m.download_format },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "sevendigital_id",
-                    |m: &ItemAttributes| { &m.sevendigital_id },
-                    |m: &mut ItemAttributes| { &mut m.sevendigital_id },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<DownloadFormat>,
+                    >(
+                        "download_format",
+                        |m: &ItemAttributes| &m.download_format,
+                        |m: &mut ItemAttributes| &mut m.download_format,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "sevendigital_id",
+                        |m: &ItemAttributes| &m.sevendigital_id,
+                        |m: &mut ItemAttributes| &mut m.sevendigital_id,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt64,
+                >(
                     "sevendigital_left",
-                    |m: &ItemAttributes| { &m.sevendigital_left },
-                    |m: &mut ItemAttributes| { &mut m.sevendigital_left },
+                    |m: &ItemAttributes| &m.sevendigital_left,
+                    |m: &mut ItemAttributes| &mut m.sevendigital_left,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt64,
+                >(
                     "seen_at",
-                    |m: &ItemAttributes| { &m.seen_at },
-                    |m: &mut ItemAttributes| { &mut m.seen_at },
+                    |m: &ItemAttributes| &m.seen_at,
+                    |m: &mut ItemAttributes| &mut m.seen_at,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "public",
-                    |m: &ItemAttributes| { &m.public },
-                    |m: &mut ItemAttributes| { &mut m.public },
+                    |m: &ItemAttributes| &m.public,
+                    |m: &mut ItemAttributes| &mut m.public,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ItemAttributes>(
                     "ItemAttributes",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1589,9 +1764,7 @@ impl ::protobuf::Message for ItemAttributes {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const ItemAttributes,
         };
-        unsafe {
-            instance.get(ItemAttributes::new)
-        }
+        unsafe { instance.get(ItemAttributes::new) }
     }
 }
 
@@ -1623,7 +1796,7 @@ impl ::protobuf::reflect::ProtobufValue for ItemAttributes {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct StringAttribute {
     // message fields
     key: ::protobuf::SingularField<::std::string::String>,
@@ -1645,7 +1818,6 @@ impl StringAttribute {
     }
 
     // optional string key = 1;
-
 
     pub fn get_key(&self) -> &str {
         match self.key.as_ref() {
@@ -1677,11 +1849,12 @@ impl StringAttribute {
 
     // Take field
     pub fn take_key(&mut self) -> ::std::string::String {
-        self.key.take().unwrap_or_else(|| ::std::string::String::new())
+        self.key
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string value = 2;
-
 
     pub fn get_value(&self) -> &str {
         match self.value.as_ref() {
@@ -1713,7 +1886,9 @@ impl StringAttribute {
 
     // Take field
     pub fn take_value(&mut self) -> ::std::string::String {
-        self.value.take().unwrap_or_else(|| ::std::string::String::new())
+        self.value
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -1722,19 +1897,27 @@ impl ::protobuf::Message for StringAttribute {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.key)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.value)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1755,7 +1938,10 @@ impl ::protobuf::Message for StringAttribute {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.key.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -1797,27 +1983,38 @@ impl ::protobuf::Message for StringAttribute {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "key",
-                    |m: &StringAttribute| { &m.key },
-                    |m: &mut StringAttribute| { &mut m.key },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "value",
-                    |m: &StringAttribute| { &m.value },
-                    |m: &mut StringAttribute| { &mut m.value },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "key",
+                        |m: &StringAttribute| &m.key,
+                        |m: &mut StringAttribute| &mut m.key,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "value",
+                        |m: &StringAttribute| &m.value,
+                        |m: &mut StringAttribute| &mut m.value,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<StringAttribute>(
                     "StringAttribute",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1828,9 +2025,7 @@ impl ::protobuf::Message for StringAttribute {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const StringAttribute,
         };
-        unsafe {
-            instance.get(StringAttribute::new)
-        }
+        unsafe { instance.get(StringAttribute::new) }
     }
 }
 
@@ -1854,7 +2049,7 @@ impl ::protobuf::reflect::ProtobufValue for StringAttribute {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct StringAttributes {
     // message fields
     attribute: ::protobuf::RepeatedField<StringAttribute>,
@@ -1875,7 +2070,6 @@ impl StringAttributes {
     }
 
     // repeated .StringAttribute attribute = 1;
-
 
     pub fn get_attribute(&self) -> &[StringAttribute] {
         &self.attribute
@@ -1906,20 +2100,28 @@ impl ::protobuf::Message for StringAttributes {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.attribute)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1932,18 +2134,21 @@ impl ::protobuf::Message for StringAttributes {
         for value in &self.attribute {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         for v in &self.attribute {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -1979,22 +2184,28 @@ impl ::protobuf::Message for StringAttributes {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<StringAttribute>>(
-                    "attribute",
-                    |m: &StringAttributes| { &m.attribute },
-                    |m: &mut StringAttributes| { &mut m.attribute },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<StringAttribute>,
+                    >(
+                        "attribute",
+                        |m: &StringAttributes| &m.attribute,
+                        |m: &mut StringAttributes| &mut m.attribute,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<StringAttributes>(
                     "StringAttributes",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -2005,9 +2216,7 @@ impl ::protobuf::Message for StringAttributes {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const StringAttributes,
         };
-        unsafe {
-            instance.get(StringAttributes::new)
-        }
+        unsafe { instance.get(StringAttributes::new) }
     }
 }
 
@@ -2056,7 +2265,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     tribute\x18\x01\x20\x03(\x0b2\x10.StringAttributeB\0:\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -2066,9 +2277,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/playlist4ops.rs
+++ b/protocol/src/playlist4ops.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Add {
     // message fields
     fromIndex: ::std::option::Option<i32>,
@@ -52,7 +52,6 @@ impl Add {
 
     // optional int32 fromIndex = 1;
 
-
     pub fn get_fromIndex(&self) -> i32 {
         self.fromIndex.unwrap_or(0)
     }
@@ -70,7 +69,6 @@ impl Add {
     }
 
     // repeated .Item items = 2;
-
 
     pub fn get_items(&self) -> &[super::playlist4content::Item] {
         &self.items
@@ -96,9 +94,10 @@ impl Add {
 
     // optional .ListChecksum list_checksum = 3;
 
-
     pub fn get_list_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.list_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.list_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_list_checksum(&mut self) {
         self.list_checksum.clear();
@@ -124,11 +123,12 @@ impl Add {
 
     // Take field
     pub fn take_list_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.list_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.list_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional bool addLast = 4;
-
 
     pub fn get_addLast(&self) -> bool {
         self.addLast.unwrap_or(false)
@@ -147,7 +147,6 @@ impl Add {
     }
 
     // optional bool addFirst = 5;
-
 
     pub fn get_addFirst(&self) -> bool {
         self.addFirst.unwrap_or(false)
@@ -172,49 +171,67 @@ impl ::protobuf::Message for Add {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.list_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.fromIndex = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.items)?;
-                },
+                }
                 3 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.list_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.list_checksum,
+                    )?;
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.addLast = ::std::option::Option::Some(tmp);
-                },
+                }
                 5 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.addFirst = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -230,7 +247,7 @@ impl ::protobuf::Message for Add {
         for value in &self.items {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.list_checksum.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -246,7 +263,10 @@ impl ::protobuf::Message for Add {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.fromIndex {
             os.write_int32(1, v)?;
         }
@@ -254,7 +274,7 @@ impl ::protobuf::Message for Add {
             os.write_tag(2, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.list_checksum.as_ref() {
             os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -301,42 +321,58 @@ impl ::protobuf::Message for Add {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "fromIndex",
-                    |m: &Add| { &m.fromIndex },
-                    |m: &mut Add| { &mut m.fromIndex },
+                    |m: &Add| &m.fromIndex,
+                    |m: &mut Add| &mut m.fromIndex,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4content::Item>>(
-                    "items",
-                    |m: &Add| { &m.items },
-                    |m: &mut Add| { &mut m.items },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "list_checksum",
-                    |m: &Add| { &m.list_checksum },
-                    |m: &mut Add| { &mut m.list_checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4content::Item>,
+                    >("items", |m: &Add| &m.items, |m: &mut Add| &mut m.items),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "list_checksum",
+                        |m: &Add| &m.list_checksum,
+                        |m: &mut Add| &mut m.list_checksum,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "addLast",
-                    |m: &Add| { &m.addLast },
-                    |m: &mut Add| { &mut m.addLast },
+                    |m: &Add| &m.addLast,
+                    |m: &mut Add| &mut m.addLast,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "addFirst",
-                    |m: &Add| { &m.addFirst },
-                    |m: &mut Add| { &mut m.addFirst },
+                    |m: &Add| &m.addFirst,
+                    |m: &mut Add| &mut m.addFirst,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Add>(
                     "Add",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -347,9 +383,7 @@ impl ::protobuf::Message for Add {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Add,
         };
-        unsafe {
-            instance.get(Add::new)
-        }
+        unsafe { instance.get(Add::new) }
     }
 }
 
@@ -376,7 +410,7 @@ impl ::protobuf::reflect::ProtobufValue for Add {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Rem {
     // message fields
     fromIndex: ::std::option::Option<i32>,
@@ -404,7 +438,6 @@ impl Rem {
 
     // optional int32 fromIndex = 1;
 
-
     pub fn get_fromIndex(&self) -> i32 {
         self.fromIndex.unwrap_or(0)
     }
@@ -423,7 +456,6 @@ impl Rem {
 
     // optional int32 length = 2;
 
-
     pub fn get_length(&self) -> i32 {
         self.length.unwrap_or(0)
     }
@@ -441,7 +473,6 @@ impl Rem {
     }
 
     // repeated .Item items = 3;
-
 
     pub fn get_items(&self) -> &[super::playlist4content::Item] {
         &self.items
@@ -467,9 +498,10 @@ impl Rem {
 
     // optional .ListChecksum list_checksum = 4;
 
-
     pub fn get_list_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.list_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.list_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_list_checksum(&mut self) {
         self.list_checksum.clear();
@@ -495,14 +527,17 @@ impl Rem {
 
     // Take field
     pub fn take_list_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.list_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.list_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional .ListChecksum items_checksum = 5;
 
-
     pub fn get_items_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.items_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.items_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_items_checksum(&mut self) {
         self.items_checksum.clear();
@@ -528,14 +563,17 @@ impl Rem {
 
     // Take field
     pub fn take_items_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.items_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.items_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional .ListChecksum uris_checksum = 6;
 
-
     pub fn get_uris_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.uris_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.uris_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_uris_checksum(&mut self) {
         self.uris_checksum.clear();
@@ -561,11 +599,12 @@ impl Rem {
 
     // Take field
     pub fn take_uris_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.uris_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.uris_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional bool itemsAsKey = 7;
-
 
     pub fn get_itemsAsKey(&self) -> bool {
         self.itemsAsKey.unwrap_or(false)
@@ -590,65 +629,91 @@ impl ::protobuf::Message for Rem {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.list_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.items_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.uris_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.fromIndex = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.length = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.items)?;
-                },
+                }
                 4 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.list_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.list_checksum,
+                    )?;
+                }
                 5 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.items_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.items_checksum,
+                    )?;
+                }
                 6 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.uris_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.uris_checksum,
+                    )?;
+                }
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.itemsAsKey = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -667,7 +732,7 @@ impl ::protobuf::Message for Rem {
         for value in &self.items {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.list_checksum.as_ref() {
             let len = v.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -688,7 +753,10 @@ impl ::protobuf::Message for Rem {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.fromIndex {
             os.write_int32(1, v)?;
         }
@@ -699,7 +767,7 @@ impl ::protobuf::Message for Rem {
             os.write_tag(3, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.list_checksum.as_ref() {
             os.write_tag(4, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -753,52 +821,76 @@ impl ::protobuf::Message for Rem {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "fromIndex",
-                    |m: &Rem| { &m.fromIndex },
-                    |m: &mut Rem| { &mut m.fromIndex },
+                    |m: &Rem| &m.fromIndex,
+                    |m: &mut Rem| &mut m.fromIndex,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
-                    "length",
-                    |m: &Rem| { &m.length },
-                    |m: &mut Rem| { &mut m.length },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
+                    "length", |m: &Rem| &m.length, |m: &mut Rem| &mut m.length
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4content::Item>>(
-                    "items",
-                    |m: &Rem| { &m.items },
-                    |m: &mut Rem| { &mut m.items },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "list_checksum",
-                    |m: &Rem| { &m.list_checksum },
-                    |m: &mut Rem| { &mut m.list_checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "items_checksum",
-                    |m: &Rem| { &m.items_checksum },
-                    |m: &mut Rem| { &mut m.items_checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "uris_checksum",
-                    |m: &Rem| { &m.uris_checksum },
-                    |m: &mut Rem| { &mut m.uris_checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4content::Item>,
+                    >("items", |m: &Rem| &m.items, |m: &mut Rem| &mut m.items),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "list_checksum",
+                        |m: &Rem| &m.list_checksum,
+                        |m: &mut Rem| &mut m.list_checksum,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "items_checksum",
+                        |m: &Rem| &m.items_checksum,
+                        |m: &mut Rem| &mut m.items_checksum,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "uris_checksum",
+                        |m: &Rem| &m.uris_checksum,
+                        |m: &mut Rem| &mut m.uris_checksum,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "itemsAsKey",
-                    |m: &Rem| { &m.itemsAsKey },
-                    |m: &mut Rem| { &mut m.itemsAsKey },
+                    |m: &Rem| &m.itemsAsKey,
+                    |m: &mut Rem| &mut m.itemsAsKey,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Rem>(
                     "Rem",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -809,9 +901,7 @@ impl ::protobuf::Message for Rem {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Rem,
         };
-        unsafe {
-            instance.get(Rem::new)
-        }
+        unsafe { instance.get(Rem::new) }
     }
 }
 
@@ -840,7 +930,7 @@ impl ::protobuf::reflect::ProtobufValue for Rem {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Mov {
     // message fields
     fromIndex: ::std::option::Option<i32>,
@@ -867,7 +957,6 @@ impl Mov {
 
     // optional int32 fromIndex = 1;
 
-
     pub fn get_fromIndex(&self) -> i32 {
         self.fromIndex.unwrap_or(0)
     }
@@ -885,7 +974,6 @@ impl Mov {
     }
 
     // optional int32 length = 2;
-
 
     pub fn get_length(&self) -> i32 {
         self.length.unwrap_or(0)
@@ -905,7 +993,6 @@ impl Mov {
 
     // optional int32 toIndex = 3;
 
-
     pub fn get_toIndex(&self) -> i32 {
         self.toIndex.unwrap_or(0)
     }
@@ -924,9 +1011,10 @@ impl Mov {
 
     // optional .ListChecksum list_checksum = 4;
 
-
     pub fn get_list_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.list_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.list_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_list_checksum(&mut self) {
         self.list_checksum.clear();
@@ -952,14 +1040,17 @@ impl Mov {
 
     // Take field
     pub fn take_list_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.list_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.list_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional .ListChecksum items_checksum = 5;
 
-
     pub fn get_items_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.items_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.items_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_items_checksum(&mut self) {
         self.items_checksum.clear();
@@ -985,14 +1076,17 @@ impl Mov {
 
     // Take field
     pub fn take_items_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.items_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.items_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional .ListChecksum uris_checksum = 6;
 
-
     pub fn get_uris_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.uris_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.uris_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_uris_checksum(&mut self) {
         self.uris_checksum.clear();
@@ -1018,7 +1112,9 @@ impl Mov {
 
     // Take field
     pub fn take_uris_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.uris_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.uris_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 }
 
@@ -1028,57 +1124,83 @@ impl ::protobuf::Message for Mov {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.items_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.uris_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.fromIndex = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.length = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.toIndex = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.list_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.list_checksum,
+                    )?;
+                }
                 5 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.items_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.items_checksum,
+                    )?;
+                }
                 6 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.uris_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.uris_checksum,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1114,7 +1236,10 @@ impl ::protobuf::Message for Mov {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.fromIndex {
             os.write_int32(1, v)?;
         }
@@ -1174,47 +1299,70 @@ impl ::protobuf::Message for Mov {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "fromIndex",
-                    |m: &Mov| { &m.fromIndex },
-                    |m: &mut Mov| { &mut m.fromIndex },
+                    |m: &Mov| &m.fromIndex,
+                    |m: &mut Mov| &mut m.fromIndex,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
-                    "length",
-                    |m: &Mov| { &m.length },
-                    |m: &mut Mov| { &mut m.length },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
+                    "length", |m: &Mov| &m.length, |m: &mut Mov| &mut m.length
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "toIndex",
-                    |m: &Mov| { &m.toIndex },
-                    |m: &mut Mov| { &mut m.toIndex },
+                    |m: &Mov| &m.toIndex,
+                    |m: &mut Mov| &mut m.toIndex,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "list_checksum",
-                    |m: &Mov| { &m.list_checksum },
-                    |m: &mut Mov| { &mut m.list_checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "items_checksum",
-                    |m: &Mov| { &m.items_checksum },
-                    |m: &mut Mov| { &mut m.items_checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "uris_checksum",
-                    |m: &Mov| { &m.uris_checksum },
-                    |m: &mut Mov| { &mut m.uris_checksum },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "list_checksum",
+                        |m: &Mov| &m.list_checksum,
+                        |m: &mut Mov| &mut m.list_checksum,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "items_checksum",
+                        |m: &Mov| &m.items_checksum,
+                        |m: &mut Mov| &mut m.items_checksum,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "uris_checksum",
+                        |m: &Mov| &m.uris_checksum,
+                        |m: &mut Mov| &mut m.uris_checksum,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Mov>(
                     "Mov",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1225,9 +1373,7 @@ impl ::protobuf::Message for Mov {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Mov,
         };
-        unsafe {
-            instance.get(Mov::new)
-        }
+        unsafe { instance.get(Mov::new) }
     }
 }
 
@@ -1255,7 +1401,7 @@ impl ::protobuf::reflect::ProtobufValue for Mov {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ItemAttributesPartialState {
     // message fields
     values: ::protobuf::SingularPtrField<super::playlist4meta::ItemAttributes>,
@@ -1278,9 +1424,10 @@ impl ItemAttributesPartialState {
 
     // optional .ItemAttributes values = 1;
 
-
     pub fn get_values(&self) -> &super::playlist4meta::ItemAttributes {
-        self.values.as_ref().unwrap_or_else(|| super::playlist4meta::ItemAttributes::default_instance())
+        self.values
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ItemAttributes::default_instance())
     }
     pub fn clear_values(&mut self) {
         self.values.clear();
@@ -1306,11 +1453,12 @@ impl ItemAttributesPartialState {
 
     // Take field
     pub fn take_values(&mut self) -> super::playlist4meta::ItemAttributes {
-        self.values.take().unwrap_or_else(|| super::playlist4meta::ItemAttributes::new())
+        self.values
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ItemAttributes::new())
     }
 
     // repeated .ItemAttributesPartialState.ItemAttributeKind no_value = 2;
-
 
     pub fn get_no_value(&self) -> &[ItemAttributesPartialState_ItemAttributeKind] {
         &self.no_value
@@ -1320,17 +1468,24 @@ impl ItemAttributesPartialState {
     }
 
     // Param is passed by value, moved
-    pub fn set_no_value(&mut self, v: ::std::vec::Vec<ItemAttributesPartialState_ItemAttributeKind>) {
+    pub fn set_no_value(
+        &mut self,
+        v: ::std::vec::Vec<ItemAttributesPartialState_ItemAttributeKind>,
+    ) {
         self.no_value = v;
     }
 
     // Mutable pointer to the field.
-    pub fn mut_no_value(&mut self) -> &mut ::std::vec::Vec<ItemAttributesPartialState_ItemAttributeKind> {
+    pub fn mut_no_value(
+        &mut self,
+    ) -> &mut ::std::vec::Vec<ItemAttributesPartialState_ItemAttributeKind> {
         &mut self.no_value
     }
 
     // Take field
-    pub fn take_no_value(&mut self) -> ::std::vec::Vec<ItemAttributesPartialState_ItemAttributeKind> {
+    pub fn take_no_value(
+        &mut self,
+    ) -> ::std::vec::Vec<ItemAttributesPartialState_ItemAttributeKind> {
         ::std::mem::replace(&mut self.no_value, ::std::vec::Vec::new())
     }
 }
@@ -1341,23 +1496,35 @@ impl ::protobuf::Message for ItemAttributesPartialState {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.values)?;
-                },
-                2 => {
-                    ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(wire_type, is, &mut self.no_value, 2, &mut self.unknown_fields)?
-                },
+                }
+                2 => ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.no_value,
+                    2,
+                    &mut self.unknown_fields,
+                )?,
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1373,13 +1540,16 @@ impl ::protobuf::Message for ItemAttributesPartialState {
         }
         for value in &self.no_value {
             my_size += ::protobuf::rt::enum_size(2, *value);
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.values.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1387,7 +1557,7 @@ impl ::protobuf::Message for ItemAttributesPartialState {
         }
         for v in &self.no_value {
             os.write_enum(2, v.value())?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -1423,40 +1593,52 @@ impl ::protobuf::Message for ItemAttributesPartialState {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ItemAttributes>>(
-                    "values",
-                    |m: &ItemAttributesPartialState| { &m.values },
-                    |m: &mut ItemAttributesPartialState| { &mut m.values },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ItemAttributesPartialState_ItemAttributeKind>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<
+                            super::playlist4meta::ItemAttributes,
+                        >,
+                    >(
+                        "values",
+                        |m: &ItemAttributesPartialState| &m.values,
+                        |m: &mut ItemAttributesPartialState| &mut m.values,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<
+                        ItemAttributesPartialState_ItemAttributeKind,
+                    >,
+                >(
                     "no_value",
-                    |m: &ItemAttributesPartialState| { &m.no_value },
-                    |m: &mut ItemAttributesPartialState| { &mut m.no_value },
+                    |m: &ItemAttributesPartialState| &m.no_value,
+                    |m: &mut ItemAttributesPartialState| &mut m.no_value,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ItemAttributesPartialState>(
                     "ItemAttributesPartialState",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static ItemAttributesPartialState {
-        static mut instance: ::protobuf::lazy::Lazy<ItemAttributesPartialState> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ItemAttributesPartialState,
-        };
-        unsafe {
-            instance.get(ItemAttributesPartialState::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<ItemAttributesPartialState> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ItemAttributesPartialState,
+            };
+        unsafe { instance.get(ItemAttributesPartialState::new) }
     }
 }
 
@@ -1480,7 +1662,7 @@ impl ::protobuf::reflect::ProtobufValue for ItemAttributesPartialState {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ItemAttributesPartialState_ItemAttributeKind {
     ITEM_UNKNOWN = 0,
     ITEM_ADDED_BY = 1,
@@ -1502,18 +1684,40 @@ impl ::protobuf::ProtobufEnum for ItemAttributesPartialState_ItemAttributeKind {
 
     fn from_i32(value: i32) -> ::std::option::Option<ItemAttributesPartialState_ItemAttributeKind> {
         match value {
-            0 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_UNKNOWN),
-            1 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_ADDED_BY),
-            2 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_TIMESTAMP),
-            3 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_MESSAGE),
-            4 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_SEEN),
-            5 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_DOWNLOAD_COUNT),
-            6 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_DOWNLOAD_FORMAT),
-            7 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_SEVENDIGITAL_ID),
-            8 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_SEVENDIGITAL_LEFT),
-            9 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_SEEN_AT),
-            10 => ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_PUBLIC),
-            _ => ::std::option::Option::None
+            0 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_UNKNOWN,
+            ),
+            1 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_ADDED_BY,
+            ),
+            2 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_TIMESTAMP,
+            ),
+            3 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_MESSAGE,
+            ),
+            4 => {
+                ::std::option::Option::Some(ItemAttributesPartialState_ItemAttributeKind::ITEM_SEEN)
+            }
+            5 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_DOWNLOAD_COUNT,
+            ),
+            6 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_DOWNLOAD_FORMAT,
+            ),
+            7 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_SEVENDIGITAL_ID,
+            ),
+            8 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_SEVENDIGITAL_LEFT,
+            ),
+            9 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_SEEN_AT,
+            ),
+            10 => ::std::option::Option::Some(
+                ItemAttributesPartialState_ItemAttributeKind::ITEM_PUBLIC,
+            ),
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -1535,20 +1739,23 @@ impl ::protobuf::ProtobufEnum for ItemAttributesPartialState_ItemAttributeKind {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("ItemAttributesPartialState_ItemAttributeKind", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "ItemAttributesPartialState_ItemAttributeKind",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for ItemAttributesPartialState_ItemAttributeKind {
-}
+impl ::std::marker::Copy for ItemAttributesPartialState_ItemAttributeKind {}
 
 impl ::std::default::Default for ItemAttributesPartialState_ItemAttributeKind {
     fn default() -> Self {
@@ -1562,7 +1769,7 @@ impl ::protobuf::reflect::ProtobufValue for ItemAttributesPartialState_ItemAttri
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct ListAttributesPartialState {
     // message fields
     values: ::protobuf::SingularPtrField<super::playlist4meta::ListAttributes>,
@@ -1585,9 +1792,10 @@ impl ListAttributesPartialState {
 
     // optional .ListAttributes values = 1;
 
-
     pub fn get_values(&self) -> &super::playlist4meta::ListAttributes {
-        self.values.as_ref().unwrap_or_else(|| super::playlist4meta::ListAttributes::default_instance())
+        self.values
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListAttributes::default_instance())
     }
     pub fn clear_values(&mut self) {
         self.values.clear();
@@ -1613,11 +1821,12 @@ impl ListAttributesPartialState {
 
     // Take field
     pub fn take_values(&mut self) -> super::playlist4meta::ListAttributes {
-        self.values.take().unwrap_or_else(|| super::playlist4meta::ListAttributes::new())
+        self.values
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListAttributes::new())
     }
 
     // repeated .ListAttributesPartialState.ListAttributeKind no_value = 2;
-
 
     pub fn get_no_value(&self) -> &[ListAttributesPartialState_ListAttributeKind] {
         &self.no_value
@@ -1627,17 +1836,24 @@ impl ListAttributesPartialState {
     }
 
     // Param is passed by value, moved
-    pub fn set_no_value(&mut self, v: ::std::vec::Vec<ListAttributesPartialState_ListAttributeKind>) {
+    pub fn set_no_value(
+        &mut self,
+        v: ::std::vec::Vec<ListAttributesPartialState_ListAttributeKind>,
+    ) {
         self.no_value = v;
     }
 
     // Mutable pointer to the field.
-    pub fn mut_no_value(&mut self) -> &mut ::std::vec::Vec<ListAttributesPartialState_ListAttributeKind> {
+    pub fn mut_no_value(
+        &mut self,
+    ) -> &mut ::std::vec::Vec<ListAttributesPartialState_ListAttributeKind> {
         &mut self.no_value
     }
 
     // Take field
-    pub fn take_no_value(&mut self) -> ::std::vec::Vec<ListAttributesPartialState_ListAttributeKind> {
+    pub fn take_no_value(
+        &mut self,
+    ) -> ::std::vec::Vec<ListAttributesPartialState_ListAttributeKind> {
         ::std::mem::replace(&mut self.no_value, ::std::vec::Vec::new())
     }
 }
@@ -1648,23 +1864,35 @@ impl ::protobuf::Message for ListAttributesPartialState {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.values)?;
-                },
-                2 => {
-                    ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(wire_type, is, &mut self.no_value, 2, &mut self.unknown_fields)?
-                },
+                }
+                2 => ::protobuf::rt::read_repeated_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.no_value,
+                    2,
+                    &mut self.unknown_fields,
+                )?,
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1680,13 +1908,16 @@ impl ::protobuf::Message for ListAttributesPartialState {
         }
         for value in &self.no_value {
             my_size += ::protobuf::rt::enum_size(2, *value);
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.values.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -1694,7 +1925,7 @@ impl ::protobuf::Message for ListAttributesPartialState {
         }
         for v in &self.no_value {
             os.write_enum(2, v.value())?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -1730,40 +1961,52 @@ impl ::protobuf::Message for ListAttributesPartialState {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListAttributes>>(
-                    "values",
-                    |m: &ListAttributesPartialState| { &m.values },
-                    |m: &mut ListAttributesPartialState| { &mut m.values },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeEnum<ListAttributesPartialState_ListAttributeKind>>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<
+                            super::playlist4meta::ListAttributes,
+                        >,
+                    >(
+                        "values",
+                        |m: &ListAttributesPartialState| &m.values,
+                        |m: &mut ListAttributesPartialState| &mut m.values,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<
+                        ListAttributesPartialState_ListAttributeKind,
+                    >,
+                >(
                     "no_value",
-                    |m: &ListAttributesPartialState| { &m.no_value },
-                    |m: &mut ListAttributesPartialState| { &mut m.no_value },
+                    |m: &ListAttributesPartialState| &m.no_value,
+                    |m: &mut ListAttributesPartialState| &mut m.no_value,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<ListAttributesPartialState>(
                     "ListAttributesPartialState",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static ListAttributesPartialState {
-        static mut instance: ::protobuf::lazy::Lazy<ListAttributesPartialState> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ListAttributesPartialState,
-        };
-        unsafe {
-            instance.get(ListAttributesPartialState::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<ListAttributesPartialState> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ListAttributesPartialState,
+            };
+        unsafe { instance.get(ListAttributesPartialState::new) }
     }
 }
 
@@ -1787,7 +2030,7 @@ impl ::protobuf::reflect::ProtobufValue for ListAttributesPartialState {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum ListAttributesPartialState_ListAttributeKind {
     LIST_UNKNOWN = 0,
     LIST_NAME = 1,
@@ -1806,15 +2049,31 @@ impl ::protobuf::ProtobufEnum for ListAttributesPartialState_ListAttributeKind {
 
     fn from_i32(value: i32) -> ::std::option::Option<ListAttributesPartialState_ListAttributeKind> {
         match value {
-            0 => ::std::option::Option::Some(ListAttributesPartialState_ListAttributeKind::LIST_UNKNOWN),
-            1 => ::std::option::Option::Some(ListAttributesPartialState_ListAttributeKind::LIST_NAME),
-            2 => ::std::option::Option::Some(ListAttributesPartialState_ListAttributeKind::LIST_DESCRIPTION),
-            3 => ::std::option::Option::Some(ListAttributesPartialState_ListAttributeKind::LIST_PICTURE),
-            4 => ::std::option::Option::Some(ListAttributesPartialState_ListAttributeKind::LIST_COLLABORATIVE),
-            5 => ::std::option::Option::Some(ListAttributesPartialState_ListAttributeKind::LIST_PL3_VERSION),
-            6 => ::std::option::Option::Some(ListAttributesPartialState_ListAttributeKind::LIST_DELETED_BY_OWNER),
-            7 => ::std::option::Option::Some(ListAttributesPartialState_ListAttributeKind::LIST_RESTRICTED_COLLABORATIVE),
-            _ => ::std::option::Option::None
+            0 => ::std::option::Option::Some(
+                ListAttributesPartialState_ListAttributeKind::LIST_UNKNOWN,
+            ),
+            1 => {
+                ::std::option::Option::Some(ListAttributesPartialState_ListAttributeKind::LIST_NAME)
+            }
+            2 => ::std::option::Option::Some(
+                ListAttributesPartialState_ListAttributeKind::LIST_DESCRIPTION,
+            ),
+            3 => ::std::option::Option::Some(
+                ListAttributesPartialState_ListAttributeKind::LIST_PICTURE,
+            ),
+            4 => ::std::option::Option::Some(
+                ListAttributesPartialState_ListAttributeKind::LIST_COLLABORATIVE,
+            ),
+            5 => ::std::option::Option::Some(
+                ListAttributesPartialState_ListAttributeKind::LIST_PL3_VERSION,
+            ),
+            6 => ::std::option::Option::Some(
+                ListAttributesPartialState_ListAttributeKind::LIST_DELETED_BY_OWNER,
+            ),
+            7 => ::std::option::Option::Some(
+                ListAttributesPartialState_ListAttributeKind::LIST_RESTRICTED_COLLABORATIVE,
+            ),
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -1833,20 +2092,23 @@ impl ::protobuf::ProtobufEnum for ListAttributesPartialState_ListAttributeKind {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
-                ::protobuf::reflect::EnumDescriptor::new("ListAttributesPartialState_ListAttributeKind", file_descriptor_proto())
+                ::protobuf::reflect::EnumDescriptor::new(
+                    "ListAttributesPartialState_ListAttributeKind",
+                    file_descriptor_proto(),
+                )
             })
         }
     }
 }
 
-impl ::std::marker::Copy for ListAttributesPartialState_ListAttributeKind {
-}
+impl ::std::marker::Copy for ListAttributesPartialState_ListAttributeKind {}
 
 impl ::std::default::Default for ListAttributesPartialState_ListAttributeKind {
     fn default() -> Self {
@@ -1860,7 +2122,7 @@ impl ::protobuf::reflect::ProtobufValue for ListAttributesPartialState_ListAttri
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct UpdateItemAttributes {
     // message fields
     index: ::std::option::Option<i32>,
@@ -1886,7 +2148,6 @@ impl UpdateItemAttributes {
 
     // optional int32 index = 1;
 
-
     pub fn get_index(&self) -> i32 {
         self.index.unwrap_or(0)
     }
@@ -1905,9 +2166,10 @@ impl UpdateItemAttributes {
 
     // optional .ItemAttributesPartialState new_attributes = 2;
 
-
     pub fn get_new_attributes(&self) -> &ItemAttributesPartialState {
-        self.new_attributes.as_ref().unwrap_or_else(|| ItemAttributesPartialState::default_instance())
+        self.new_attributes
+            .as_ref()
+            .unwrap_or_else(|| ItemAttributesPartialState::default_instance())
     }
     pub fn clear_new_attributes(&mut self) {
         self.new_attributes.clear();
@@ -1933,14 +2195,17 @@ impl UpdateItemAttributes {
 
     // Take field
     pub fn take_new_attributes(&mut self) -> ItemAttributesPartialState {
-        self.new_attributes.take().unwrap_or_else(|| ItemAttributesPartialState::new())
+        self.new_attributes
+            .take()
+            .unwrap_or_else(|| ItemAttributesPartialState::new())
     }
 
     // optional .ItemAttributesPartialState old_attributes = 3;
 
-
     pub fn get_old_attributes(&self) -> &ItemAttributesPartialState {
-        self.old_attributes.as_ref().unwrap_or_else(|| ItemAttributesPartialState::default_instance())
+        self.old_attributes
+            .as_ref()
+            .unwrap_or_else(|| ItemAttributesPartialState::default_instance())
     }
     pub fn clear_old_attributes(&mut self) {
         self.old_attributes.clear();
@@ -1966,14 +2231,17 @@ impl UpdateItemAttributes {
 
     // Take field
     pub fn take_old_attributes(&mut self) -> ItemAttributesPartialState {
-        self.old_attributes.take().unwrap_or_else(|| ItemAttributesPartialState::new())
+        self.old_attributes
+            .take()
+            .unwrap_or_else(|| ItemAttributesPartialState::new())
     }
 
     // optional .ListChecksum list_checksum = 4;
 
-
     pub fn get_list_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.list_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.list_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_list_checksum(&mut self) {
         self.list_checksum.clear();
@@ -1999,14 +2267,17 @@ impl UpdateItemAttributes {
 
     // Take field
     pub fn take_list_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.list_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.list_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional .ListChecksum old_attributes_checksum = 5;
 
-
     pub fn get_old_attributes_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.old_attributes_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.old_attributes_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_old_attributes_checksum(&mut self) {
         self.old_attributes_checksum.clear();
@@ -2032,7 +2303,9 @@ impl UpdateItemAttributes {
 
     // Take field
     pub fn take_old_attributes_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.old_attributes_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.old_attributes_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 }
 
@@ -2042,51 +2315,77 @@ impl ::protobuf::Message for UpdateItemAttributes {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.old_attributes {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.list_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.old_attributes_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.index = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.new_attributes)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.new_attributes,
+                    )?;
+                }
                 3 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.old_attributes)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.old_attributes,
+                    )?;
+                }
                 4 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.list_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.list_checksum,
+                    )?;
+                }
                 5 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.old_attributes_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.old_attributes_checksum,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2120,7 +2419,10 @@ impl ::protobuf::Message for UpdateItemAttributes {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.index {
             os.write_int32(1, v)?;
         }
@@ -2179,55 +2481,78 @@ impl ::protobuf::Message for UpdateItemAttributes {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "index",
-                    |m: &UpdateItemAttributes| { &m.index },
-                    |m: &mut UpdateItemAttributes| { &mut m.index },
+                    |m: &UpdateItemAttributes| &m.index,
+                    |m: &mut UpdateItemAttributes| &mut m.index,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ItemAttributesPartialState>>(
-                    "new_attributes",
-                    |m: &UpdateItemAttributes| { &m.new_attributes },
-                    |m: &mut UpdateItemAttributes| { &mut m.new_attributes },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ItemAttributesPartialState>>(
-                    "old_attributes",
-                    |m: &UpdateItemAttributes| { &m.old_attributes },
-                    |m: &mut UpdateItemAttributes| { &mut m.old_attributes },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "list_checksum",
-                    |m: &UpdateItemAttributes| { &m.list_checksum },
-                    |m: &mut UpdateItemAttributes| { &mut m.list_checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "old_attributes_checksum",
-                    |m: &UpdateItemAttributes| { &m.old_attributes_checksum },
-                    |m: &mut UpdateItemAttributes| { &mut m.old_attributes_checksum },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ItemAttributesPartialState>,
+                    >(
+                        "new_attributes",
+                        |m: &UpdateItemAttributes| &m.new_attributes,
+                        |m: &mut UpdateItemAttributes| &mut m.new_attributes,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ItemAttributesPartialState>,
+                    >(
+                        "old_attributes",
+                        |m: &UpdateItemAttributes| &m.old_attributes,
+                        |m: &mut UpdateItemAttributes| &mut m.old_attributes,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "list_checksum",
+                        |m: &UpdateItemAttributes| &m.list_checksum,
+                        |m: &mut UpdateItemAttributes| &mut m.list_checksum,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "old_attributes_checksum",
+                        |m: &UpdateItemAttributes| &m.old_attributes_checksum,
+                        |m: &mut UpdateItemAttributes| &mut m.old_attributes_checksum,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<UpdateItemAttributes>(
                     "UpdateItemAttributes",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static UpdateItemAttributes {
-        static mut instance: ::protobuf::lazy::Lazy<UpdateItemAttributes> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const UpdateItemAttributes,
-        };
-        unsafe {
-            instance.get(UpdateItemAttributes::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<UpdateItemAttributes> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const UpdateItemAttributes,
+            };
+        unsafe { instance.get(UpdateItemAttributes::new) }
     }
 }
 
@@ -2254,7 +2579,7 @@ impl ::protobuf::reflect::ProtobufValue for UpdateItemAttributes {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct UpdateListAttributes {
     // message fields
     new_attributes: ::protobuf::SingularPtrField<ListAttributesPartialState>,
@@ -2279,9 +2604,10 @@ impl UpdateListAttributes {
 
     // optional .ListAttributesPartialState new_attributes = 1;
 
-
     pub fn get_new_attributes(&self) -> &ListAttributesPartialState {
-        self.new_attributes.as_ref().unwrap_or_else(|| ListAttributesPartialState::default_instance())
+        self.new_attributes
+            .as_ref()
+            .unwrap_or_else(|| ListAttributesPartialState::default_instance())
     }
     pub fn clear_new_attributes(&mut self) {
         self.new_attributes.clear();
@@ -2307,14 +2633,17 @@ impl UpdateListAttributes {
 
     // Take field
     pub fn take_new_attributes(&mut self) -> ListAttributesPartialState {
-        self.new_attributes.take().unwrap_or_else(|| ListAttributesPartialState::new())
+        self.new_attributes
+            .take()
+            .unwrap_or_else(|| ListAttributesPartialState::new())
     }
 
     // optional .ListAttributesPartialState old_attributes = 2;
 
-
     pub fn get_old_attributes(&self) -> &ListAttributesPartialState {
-        self.old_attributes.as_ref().unwrap_or_else(|| ListAttributesPartialState::default_instance())
+        self.old_attributes
+            .as_ref()
+            .unwrap_or_else(|| ListAttributesPartialState::default_instance())
     }
     pub fn clear_old_attributes(&mut self) {
         self.old_attributes.clear();
@@ -2340,14 +2669,17 @@ impl UpdateListAttributes {
 
     // Take field
     pub fn take_old_attributes(&mut self) -> ListAttributesPartialState {
-        self.old_attributes.take().unwrap_or_else(|| ListAttributesPartialState::new())
+        self.old_attributes
+            .take()
+            .unwrap_or_else(|| ListAttributesPartialState::new())
     }
 
     // optional .ListChecksum list_checksum = 3;
 
-
     pub fn get_list_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.list_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.list_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_list_checksum(&mut self) {
         self.list_checksum.clear();
@@ -2373,14 +2705,17 @@ impl UpdateListAttributes {
 
     // Take field
     pub fn take_list_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.list_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.list_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 
     // optional .ListChecksum old_attributes_checksum = 4;
 
-
     pub fn get_old_attributes_checksum(&self) -> &super::playlist4meta::ListChecksum {
-        self.old_attributes_checksum.as_ref().unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
+        self.old_attributes_checksum
+            .as_ref()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::default_instance())
     }
     pub fn clear_old_attributes_checksum(&mut self) {
         self.old_attributes_checksum.clear();
@@ -2406,7 +2741,9 @@ impl UpdateListAttributes {
 
     // Take field
     pub fn take_old_attributes_checksum(&mut self) -> super::playlist4meta::ListChecksum {
-        self.old_attributes_checksum.take().unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
+        self.old_attributes_checksum
+            .take()
+            .unwrap_or_else(|| super::playlist4meta::ListChecksum::new())
     }
 }
 
@@ -2416,44 +2753,68 @@ impl ::protobuf::Message for UpdateListAttributes {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.old_attributes {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.list_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.old_attributes_checksum {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.new_attributes)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.new_attributes,
+                    )?;
+                }
                 2 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.old_attributes)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.old_attributes,
+                    )?;
+                }
                 3 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.list_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.list_checksum,
+                    )?;
+                }
                 4 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.old_attributes_checksum)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.old_attributes_checksum,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2484,7 +2845,10 @@ impl ::protobuf::Message for UpdateListAttributes {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.new_attributes.as_ref() {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -2540,50 +2904,70 @@ impl ::protobuf::Message for UpdateListAttributes {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ListAttributesPartialState>>(
-                    "new_attributes",
-                    |m: &UpdateListAttributes| { &m.new_attributes },
-                    |m: &mut UpdateListAttributes| { &mut m.new_attributes },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<ListAttributesPartialState>>(
-                    "old_attributes",
-                    |m: &UpdateListAttributes| { &m.old_attributes },
-                    |m: &mut UpdateListAttributes| { &mut m.old_attributes },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "list_checksum",
-                    |m: &UpdateListAttributes| { &m.list_checksum },
-                    |m: &mut UpdateListAttributes| { &mut m.list_checksum },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>>(
-                    "old_attributes_checksum",
-                    |m: &UpdateListAttributes| { &m.old_attributes_checksum },
-                    |m: &mut UpdateListAttributes| { &mut m.old_attributes_checksum },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ListAttributesPartialState>,
+                    >(
+                        "new_attributes",
+                        |m: &UpdateListAttributes| &m.new_attributes,
+                        |m: &mut UpdateListAttributes| &mut m.new_attributes,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<ListAttributesPartialState>,
+                    >(
+                        "old_attributes",
+                        |m: &UpdateListAttributes| &m.old_attributes,
+                        |m: &mut UpdateListAttributes| &mut m.old_attributes,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "list_checksum",
+                        |m: &UpdateListAttributes| &m.list_checksum,
+                        |m: &mut UpdateListAttributes| &mut m.list_checksum,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<super::playlist4meta::ListChecksum>,
+                    >(
+                        "old_attributes_checksum",
+                        |m: &UpdateListAttributes| &m.old_attributes_checksum,
+                        |m: &mut UpdateListAttributes| &mut m.old_attributes_checksum,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<UpdateListAttributes>(
                     "UpdateListAttributes",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
     }
 
     fn default_instance() -> &'static UpdateListAttributes {
-        static mut instance: ::protobuf::lazy::Lazy<UpdateListAttributes> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const UpdateListAttributes,
-        };
-        unsafe {
-            instance.get(UpdateListAttributes::new)
-        }
+        static mut instance: ::protobuf::lazy::Lazy<UpdateListAttributes> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const UpdateListAttributes,
+            };
+        unsafe { instance.get(UpdateListAttributes::new) }
     }
 }
 
@@ -2609,7 +2993,7 @@ impl ::protobuf::reflect::ProtobufValue for UpdateListAttributes {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Op {
     // message fields
     kind: ::std::option::Option<Op_Kind>,
@@ -2636,7 +3020,6 @@ impl Op {
 
     // optional .Op.Kind kind = 1;
 
-
     pub fn get_kind(&self) -> Op_Kind {
         self.kind.unwrap_or(Op_Kind::KIND_UNKNOWN)
     }
@@ -2654,7 +3037,6 @@ impl Op {
     }
 
     // optional .Add add = 2;
-
 
     pub fn get_add(&self) -> &Add {
         self.add.as_ref().unwrap_or_else(|| Add::default_instance())
@@ -2688,7 +3070,6 @@ impl Op {
 
     // optional .Rem rem = 3;
 
-
     pub fn get_rem(&self) -> &Rem {
         self.rem.as_ref().unwrap_or_else(|| Rem::default_instance())
     }
@@ -2720,7 +3101,6 @@ impl Op {
     }
 
     // optional .Mov mov = 4;
-
 
     pub fn get_mov(&self) -> &Mov {
         self.mov.as_ref().unwrap_or_else(|| Mov::default_instance())
@@ -2754,9 +3134,10 @@ impl Op {
 
     // optional .UpdateItemAttributes update_item_attributes = 5;
 
-
     pub fn get_update_item_attributes(&self) -> &UpdateItemAttributes {
-        self.update_item_attributes.as_ref().unwrap_or_else(|| UpdateItemAttributes::default_instance())
+        self.update_item_attributes
+            .as_ref()
+            .unwrap_or_else(|| UpdateItemAttributes::default_instance())
     }
     pub fn clear_update_item_attributes(&mut self) {
         self.update_item_attributes.clear();
@@ -2782,14 +3163,17 @@ impl Op {
 
     // Take field
     pub fn take_update_item_attributes(&mut self) -> UpdateItemAttributes {
-        self.update_item_attributes.take().unwrap_or_else(|| UpdateItemAttributes::new())
+        self.update_item_attributes
+            .take()
+            .unwrap_or_else(|| UpdateItemAttributes::new())
     }
 
     // optional .UpdateListAttributes update_list_attributes = 6;
 
-
     pub fn get_update_list_attributes(&self) -> &UpdateListAttributes {
-        self.update_list_attributes.as_ref().unwrap_or_else(|| UpdateListAttributes::default_instance())
+        self.update_list_attributes
+            .as_ref()
+            .unwrap_or_else(|| UpdateListAttributes::default_instance())
     }
     pub fn clear_update_list_attributes(&mut self) {
         self.update_list_attributes.clear();
@@ -2815,7 +3199,9 @@ impl Op {
 
     // Take field
     pub fn take_update_list_attributes(&mut self) -> UpdateListAttributes {
-        self.update_list_attributes.take().unwrap_or_else(|| UpdateListAttributes::new())
+        self.update_list_attributes
+            .take()
+            .unwrap_or_else(|| UpdateListAttributes::new())
     }
 }
 
@@ -2825,55 +3211,75 @@ impl ::protobuf::Message for Op {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.rem {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.mov {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.update_item_attributes {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.update_list_attributes {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                1 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.kind, 1, &mut self.unknown_fields)?
-                },
+                1 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.kind,
+                    1,
+                    &mut self.unknown_fields,
+                )?,
                 2 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.add)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.rem)?;
-                },
+                }
                 4 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.mov)?;
-                },
+                }
                 5 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.update_item_attributes)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.update_item_attributes,
+                    )?;
+                }
                 6 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.update_list_attributes)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.update_list_attributes,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2911,7 +3317,10 @@ impl ::protobuf::Message for Op {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.kind {
             os.write_enum(1, v.value())?;
         }
@@ -2975,47 +3384,62 @@ impl ::protobuf::Message for Op {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<Op_Kind>>(
-                    "kind",
-                    |m: &Op| { &m.kind },
-                    |m: &mut Op| { &mut m.kind },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<Op_Kind>,
+                >(
+                    "kind", |m: &Op| &m.kind, |m: &mut Op| &mut m.kind
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Add>>(
-                    "add",
-                    |m: &Op| { &m.add },
-                    |m: &mut Op| { &mut m.add },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Rem>>(
-                    "rem",
-                    |m: &Op| { &m.rem },
-                    |m: &mut Op| { &mut m.rem },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Mov>>(
-                    "mov",
-                    |m: &Op| { &m.mov },
-                    |m: &mut Op| { &mut m.mov },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<UpdateItemAttributes>>(
-                    "update_item_attributes",
-                    |m: &Op| { &m.update_item_attributes },
-                    |m: &mut Op| { &mut m.update_item_attributes },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<UpdateListAttributes>>(
-                    "update_list_attributes",
-                    |m: &Op| { &m.update_list_attributes },
-                    |m: &mut Op| { &mut m.update_list_attributes },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Add>,
+                    >("add", |m: &Op| &m.add, |m: &mut Op| &mut m.add),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Rem>,
+                    >("rem", |m: &Op| &m.rem, |m: &mut Op| &mut m.rem),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Mov>,
+                    >("mov", |m: &Op| &m.mov, |m: &mut Op| &mut m.mov),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<UpdateItemAttributes>,
+                    >(
+                        "update_item_attributes",
+                        |m: &Op| &m.update_item_attributes,
+                        |m: &mut Op| &mut m.update_item_attributes,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<UpdateListAttributes>,
+                    >(
+                        "update_list_attributes",
+                        |m: &Op| &m.update_list_attributes,
+                        |m: &mut Op| &mut m.update_list_attributes,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Op>(
                     "Op",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3026,9 +3450,7 @@ impl ::protobuf::Message for Op {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Op,
         };
-        unsafe {
-            instance.get(Op::new)
-        }
+        unsafe { instance.get(Op::new) }
     }
 }
 
@@ -3056,7 +3478,7 @@ impl ::protobuf::reflect::ProtobufValue for Op {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum Op_Kind {
     KIND_UNKNOWN = 0,
     ADD = 2,
@@ -3079,7 +3501,7 @@ impl ::protobuf::ProtobufEnum for Op_Kind {
             4 => ::std::option::Option::Some(Op_Kind::MOV),
             5 => ::std::option::Option::Some(Op_Kind::UPDATE_ITEM_ATTRIBUTES),
             6 => ::std::option::Option::Some(Op_Kind::UPDATE_LIST_ATTRIBUTES),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -3096,10 +3518,11 @@ impl ::protobuf::ProtobufEnum for Op_Kind {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("Op_Kind", file_descriptor_proto())
@@ -3108,8 +3531,7 @@ impl ::protobuf::ProtobufEnum for Op_Kind {
     }
 }
 
-impl ::std::marker::Copy for Op_Kind {
-}
+impl ::std::marker::Copy for Op_Kind {}
 
 impl ::std::default::Default for Op_Kind {
     fn default() -> Self {
@@ -3123,7 +3545,7 @@ impl ::protobuf::reflect::ProtobufValue for Op_Kind {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct OpList {
     // message fields
     ops: ::protobuf::RepeatedField<Op>,
@@ -3144,7 +3566,6 @@ impl OpList {
     }
 
     // repeated .Op ops = 1;
-
 
     pub fn get_ops(&self) -> &[Op] {
         &self.ops
@@ -3175,20 +3596,28 @@ impl ::protobuf::Message for OpList {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.ops)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3201,18 +3630,21 @@ impl ::protobuf::Message for OpList {
         for value in &self.ops {
             let len = value.compute_size();
             my_size += 1 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         for v in &self.ops {
             os.write_tag(1, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -3248,22 +3680,24 @@ impl ::protobuf::Message for OpList {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Op>>(
-                    "ops",
-                    |m: &OpList| { &m.ops },
-                    |m: &mut OpList| { &mut m.ops },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Op>,
+                    >("ops", |m: &OpList| &m.ops, |m: &mut OpList| &mut m.ops),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<OpList>(
                     "OpList",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3274,9 +3708,7 @@ impl ::protobuf::Message for OpList {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const OpList,
         };
-        unsafe {
-            instance.get(OpList::new)
-        }
+        unsafe { instance.get(OpList::new) }
     }
 }
 
@@ -3353,7 +3785,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     \x18\x01\x20\x03(\x0b2\x03.OpB\0:\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -3363,9 +3797,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/pubsub.rs
+++ b/protocol/src/pubsub.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Subscription {
     // message fields
     uri: ::protobuf::SingularField<::std::string::String>,
@@ -49,7 +49,6 @@ impl Subscription {
     }
 
     // optional string uri = 1;
-
 
     pub fn get_uri(&self) -> &str {
         match self.uri.as_ref() {
@@ -81,11 +80,12 @@ impl Subscription {
 
     // Take field
     pub fn take_uri(&mut self) -> ::std::string::String {
-        self.uri.take().unwrap_or_else(|| ::std::string::String::new())
+        self.uri
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional int32 expiry = 2;
-
 
     pub fn get_expiry(&self) -> i32 {
         self.expiry.unwrap_or(0)
@@ -104,7 +104,6 @@ impl Subscription {
     }
 
     // optional int32 status_code = 3;
-
 
     pub fn get_status_code(&self) -> i32 {
         self.status_code.unwrap_or(0)
@@ -128,30 +127,42 @@ impl ::protobuf::Message for Subscription {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.uri)?;
-                },
+                }
                 2 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.expiry = ::std::option::Option::Some(tmp);
-                },
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.status_code = ::std::option::Option::Some(tmp);
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -175,7 +186,10 @@ impl ::protobuf::Message for Subscription {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.uri.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -220,32 +234,44 @@ impl ::protobuf::Message for Subscription {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "uri",
-                    |m: &Subscription| { &m.uri },
-                    |m: &mut Subscription| { &mut m.uri },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "uri",
+                        |m: &Subscription| &m.uri,
+                        |m: &mut Subscription| &mut m.uri,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "expiry",
-                    |m: &Subscription| { &m.expiry },
-                    |m: &mut Subscription| { &mut m.expiry },
+                    |m: &Subscription| &m.expiry,
+                    |m: &mut Subscription| &mut m.expiry,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "status_code",
-                    |m: &Subscription| { &m.status_code },
-                    |m: &mut Subscription| { &mut m.status_code },
+                    |m: &Subscription| &m.status_code,
+                    |m: &mut Subscription| &mut m.status_code,
                 ));
                 ::protobuf::reflect::MessageDescriptor::new::<Subscription>(
                     "Subscription",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -256,9 +282,7 @@ impl ::protobuf::Message for Subscription {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Subscription,
         };
-        unsafe {
-            instance.get(Subscription::new)
-        }
+        unsafe { instance.get(Subscription::new) }
     }
 }
 
@@ -289,7 +313,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     us_code\x18\x03\x20\x01(\x05B\0:\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -299,9 +325,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/protocol/src/spirc.rs
+++ b/protocol/src/spirc.rs
@@ -26,7 +26,7 @@ use protobuf::ProtobufEnum as ProtobufEnum_imported_for_functions;
 /// of protobuf runtime.
 const _PROTOBUF_VERSION_CHECK: () = ::protobuf::VERSION_2_8_1;
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Frame {
     // message fields
     version: ::std::option::Option<u32>,
@@ -62,7 +62,6 @@ impl Frame {
 
     // optional uint32 version = 1;
 
-
     pub fn get_version(&self) -> u32 {
         self.version.unwrap_or(0)
     }
@@ -80,7 +79,6 @@ impl Frame {
     }
 
     // optional string ident = 2;
-
 
     pub fn get_ident(&self) -> &str {
         match self.ident.as_ref() {
@@ -112,11 +110,12 @@ impl Frame {
 
     // Take field
     pub fn take_ident(&mut self) -> ::std::string::String {
-        self.ident.take().unwrap_or_else(|| ::std::string::String::new())
+        self.ident
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string protocol_version = 3;
-
 
     pub fn get_protocol_version(&self) -> &str {
         match self.protocol_version.as_ref() {
@@ -148,11 +147,12 @@ impl Frame {
 
     // Take field
     pub fn take_protocol_version(&mut self) -> ::std::string::String {
-        self.protocol_version.take().unwrap_or_else(|| ::std::string::String::new())
+        self.protocol_version
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional uint32 seq_nr = 4;
-
 
     pub fn get_seq_nr(&self) -> u32 {
         self.seq_nr.unwrap_or(0)
@@ -172,7 +172,6 @@ impl Frame {
 
     // optional .MessageType typ = 5;
 
-
     pub fn get_typ(&self) -> MessageType {
         self.typ.unwrap_or(MessageType::kMessageTypeHello)
     }
@@ -191,9 +190,10 @@ impl Frame {
 
     // optional .DeviceState device_state = 7;
 
-
     pub fn get_device_state(&self) -> &DeviceState {
-        self.device_state.as_ref().unwrap_or_else(|| DeviceState::default_instance())
+        self.device_state
+            .as_ref()
+            .unwrap_or_else(|| DeviceState::default_instance())
     }
     pub fn clear_device_state(&mut self) {
         self.device_state.clear();
@@ -219,14 +219,17 @@ impl Frame {
 
     // Take field
     pub fn take_device_state(&mut self) -> DeviceState {
-        self.device_state.take().unwrap_or_else(|| DeviceState::new())
+        self.device_state
+            .take()
+            .unwrap_or_else(|| DeviceState::new())
     }
 
     // optional .Goodbye goodbye = 11;
 
-
     pub fn get_goodbye(&self) -> &Goodbye {
-        self.goodbye.as_ref().unwrap_or_else(|| Goodbye::default_instance())
+        self.goodbye
+            .as_ref()
+            .unwrap_or_else(|| Goodbye::default_instance())
     }
     pub fn clear_goodbye(&mut self) {
         self.goodbye.clear();
@@ -257,9 +260,10 @@ impl Frame {
 
     // optional .State state = 12;
 
-
     pub fn get_state(&self) -> &State {
-        self.state.as_ref().unwrap_or_else(|| State::default_instance())
+        self.state
+            .as_ref()
+            .unwrap_or_else(|| State::default_instance())
     }
     pub fn clear_state(&mut self) {
         self.state.clear();
@@ -290,7 +294,6 @@ impl Frame {
 
     // optional uint32 position = 13;
 
-
     pub fn get_position(&self) -> u32 {
         self.position.unwrap_or(0)
     }
@@ -308,7 +311,6 @@ impl Frame {
     }
 
     // optional uint32 volume = 14;
-
 
     pub fn get_volume(&self) -> u32 {
         self.volume.unwrap_or(0)
@@ -328,7 +330,6 @@ impl Frame {
 
     // optional int64 state_update_id = 17;
 
-
     pub fn get_state_update_id(&self) -> i64 {
         self.state_update_id.unwrap_or(0)
     }
@@ -346,7 +347,6 @@ impl Frame {
     }
 
     // repeated string recipient = 18;
-
 
     pub fn get_recipient(&self) -> &[::std::string::String] {
         &self.recipient
@@ -371,7 +371,6 @@ impl Frame {
     }
 
     // optional bytes context_player_state = 19;
-
 
     pub fn get_context_player_state(&self) -> &[u8] {
         match self.context_player_state.as_ref() {
@@ -403,11 +402,12 @@ impl Frame {
 
     // Take field
     pub fn take_context_player_state(&mut self) -> ::std::vec::Vec<u8> {
-        self.context_player_state.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.context_player_state
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional string new_name = 20;
-
 
     pub fn get_new_name(&self) -> &str {
         match self.new_name.as_ref() {
@@ -439,14 +439,17 @@ impl Frame {
 
     // Take field
     pub fn take_new_name(&mut self) -> ::std::string::String {
-        self.new_name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.new_name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional .Metadata metadata = 25;
 
-
     pub fn get_metadata(&self) -> &Metadata {
-        self.metadata.as_ref().unwrap_or_else(|| Metadata::default_instance())
+        self.metadata
+            .as_ref()
+            .unwrap_or_else(|| Metadata::default_instance())
     }
     pub fn clear_metadata(&mut self) {
         self.metadata.clear();
@@ -482,97 +485,131 @@ impl ::protobuf::Message for Frame {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.goodbye {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.state {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.metadata {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.version = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.ident)?;
-                },
+                }
                 3 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.protocol_version)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.protocol_version,
+                    )?;
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.seq_nr = ::std::option::Option::Some(tmp);
-                },
-                5 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.typ, 5, &mut self.unknown_fields)?
-                },
+                }
+                5 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.typ,
+                    5,
+                    &mut self.unknown_fields,
+                )?,
                 7 => {
-                    ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.device_state)?;
-                },
+                    ::protobuf::rt::read_singular_message_into(
+                        wire_type,
+                        is,
+                        &mut self.device_state,
+                    )?;
+                }
                 11 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.goodbye)?;
-                },
+                }
                 12 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.state)?;
-                },
+                }
                 13 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.position = ::std::option::Option::Some(tmp);
-                },
+                }
                 14 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.volume = ::std::option::Option::Some(tmp);
-                },
+                }
                 17 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int64()?;
                     self.state_update_id = ::std::option::Option::Some(tmp);
-                },
+                }
                 18 => {
                     ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.recipient)?;
-                },
+                }
                 19 => {
-                    ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.context_player_state)?;
-                },
+                    ::protobuf::rt::read_singular_bytes_into(
+                        wire_type,
+                        is,
+                        &mut self.context_player_state,
+                    )?;
+                }
                 20 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.new_name)?;
-                },
+                }
                 25 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.metadata)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -620,7 +657,7 @@ impl ::protobuf::Message for Frame {
         }
         for value in &self.recipient {
             my_size += ::protobuf::rt::string_size(18, &value);
-        };
+        }
         if let Some(ref v) = self.context_player_state.as_ref() {
             my_size += ::protobuf::rt::bytes_size(19, &v);
         }
@@ -636,7 +673,10 @@ impl ::protobuf::Message for Frame {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.version {
             os.write_uint32(1, v)?;
         }
@@ -678,7 +718,7 @@ impl ::protobuf::Message for Frame {
         }
         for v in &self.recipient {
             os.write_string(18, &v)?;
-        };
+        }
         if let Some(ref v) = self.context_player_state.as_ref() {
             os.write_bytes(19, &v)?;
         }
@@ -725,92 +765,150 @@ impl ::protobuf::Message for Frame {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "version",
-                    |m: &Frame| { &m.version },
-                    |m: &mut Frame| { &mut m.version },
+                    |m: &Frame| &m.version,
+                    |m: &mut Frame| &mut m.version,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "ident",
-                    |m: &Frame| { &m.ident },
-                    |m: &mut Frame| { &mut m.ident },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "protocol_version",
-                    |m: &Frame| { &m.protocol_version },
-                    |m: &mut Frame| { &mut m.protocol_version },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "ident", |m: &Frame| &m.ident, |m: &mut Frame| &mut m.ident
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "protocol_version",
+                        |m: &Frame| &m.protocol_version,
+                        |m: &mut Frame| &mut m.protocol_version,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "seq_nr",
-                    |m: &Frame| { &m.seq_nr },
-                    |m: &mut Frame| { &mut m.seq_nr },
+                    |m: &Frame| &m.seq_nr,
+                    |m: &mut Frame| &mut m.seq_nr,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<MessageType>>(
-                    "typ",
-                    |m: &Frame| { &m.typ },
-                    |m: &mut Frame| { &mut m.typ },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<MessageType>,
+                >(
+                    "typ", |m: &Frame| &m.typ, |m: &mut Frame| &mut m.typ
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<DeviceState>>(
-                    "device_state",
-                    |m: &Frame| { &m.device_state },
-                    |m: &mut Frame| { &mut m.device_state },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Goodbye>>(
-                    "goodbye",
-                    |m: &Frame| { &m.goodbye },
-                    |m: &mut Frame| { &mut m.goodbye },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<State>>(
-                    "state",
-                    |m: &Frame| { &m.state },
-                    |m: &mut Frame| { &mut m.state },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<DeviceState>,
+                    >(
+                        "device_state",
+                        |m: &Frame| &m.device_state,
+                        |m: &mut Frame| &mut m.device_state,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Goodbye>,
+                    >(
+                        "goodbye",
+                        |m: &Frame| &m.goodbye,
+                        |m: &mut Frame| &mut m.goodbye,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<State>,
+                    >(
+                        "state", |m: &Frame| &m.state, |m: &mut Frame| &mut m.state
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "position",
-                    |m: &Frame| { &m.position },
-                    |m: &mut Frame| { &mut m.position },
+                    |m: &Frame| &m.position,
+                    |m: &mut Frame| &mut m.position,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "volume",
-                    |m: &Frame| { &m.volume },
-                    |m: &mut Frame| { &mut m.volume },
+                    |m: &Frame| &m.volume,
+                    |m: &mut Frame| &mut m.volume,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt64,
+                >(
                     "state_update_id",
-                    |m: &Frame| { &m.state_update_id },
-                    |m: &mut Frame| { &mut m.state_update_id },
+                    |m: &Frame| &m.state_update_id,
+                    |m: &mut Frame| &mut m.state_update_id,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "recipient",
-                    |m: &Frame| { &m.recipient },
-                    |m: &mut Frame| { &mut m.recipient },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "context_player_state",
-                    |m: &Frame| { &m.context_player_state },
-                    |m: &mut Frame| { &mut m.context_player_state },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "new_name",
-                    |m: &Frame| { &m.new_name },
-                    |m: &mut Frame| { &mut m.new_name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Metadata>>(
-                    "metadata",
-                    |m: &Frame| { &m.metadata },
-                    |m: &mut Frame| { &mut m.metadata },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "recipient",
+                        |m: &Frame| &m.recipient,
+                        |m: &mut Frame| &mut m.recipient,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "context_player_state",
+                        |m: &Frame| &m.context_player_state,
+                        |m: &mut Frame| &mut m.context_player_state,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "new_name",
+                        |m: &Frame| &m.new_name,
+                        |m: &mut Frame| &mut m.new_name,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Metadata>,
+                    >(
+                        "metadata",
+                        |m: &Frame| &m.metadata,
+                        |m: &mut Frame| &mut m.metadata,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Frame>(
                     "Frame",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -821,9 +919,7 @@ impl ::protobuf::Message for Frame {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Frame,
         };
-        unsafe {
-            instance.get(Frame::new)
-        }
+        unsafe { instance.get(Frame::new) }
     }
 }
 
@@ -860,7 +956,7 @@ impl ::protobuf::reflect::ProtobufValue for Frame {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct DeviceState {
     // message fields
     sw_version: ::protobuf::SingularField<::std::string::String>,
@@ -892,7 +988,6 @@ impl DeviceState {
 
     // optional string sw_version = 1;
 
-
     pub fn get_sw_version(&self) -> &str {
         match self.sw_version.as_ref() {
             Some(v) => &v,
@@ -923,11 +1018,12 @@ impl DeviceState {
 
     // Take field
     pub fn take_sw_version(&mut self) -> ::std::string::String {
-        self.sw_version.take().unwrap_or_else(|| ::std::string::String::new())
+        self.sw_version
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bool is_active = 10;
-
 
     pub fn get_is_active(&self) -> bool {
         self.is_active.unwrap_or(false)
@@ -947,7 +1043,6 @@ impl DeviceState {
 
     // optional bool can_play = 11;
 
-
     pub fn get_can_play(&self) -> bool {
         self.can_play.unwrap_or(false)
     }
@@ -966,7 +1061,6 @@ impl DeviceState {
 
     // optional uint32 volume = 12;
 
-
     pub fn get_volume(&self) -> u32 {
         self.volume.unwrap_or(0)
     }
@@ -984,7 +1078,6 @@ impl DeviceState {
     }
 
     // optional string name = 13;
-
 
     pub fn get_name(&self) -> &str {
         match self.name.as_ref() {
@@ -1016,11 +1109,12 @@ impl DeviceState {
 
     // Take field
     pub fn take_name(&mut self) -> ::std::string::String {
-        self.name.take().unwrap_or_else(|| ::std::string::String::new())
+        self.name
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional uint32 error_code = 14;
-
 
     pub fn get_error_code(&self) -> u32 {
         self.error_code.unwrap_or(0)
@@ -1040,7 +1134,6 @@ impl DeviceState {
 
     // optional int64 became_active_at = 15;
 
-
     pub fn get_became_active_at(&self) -> i64 {
         self.became_active_at.unwrap_or(0)
     }
@@ -1058,7 +1151,6 @@ impl DeviceState {
     }
 
     // optional string error_message = 16;
-
 
     pub fn get_error_message(&self) -> &str {
         match self.error_message.as_ref() {
@@ -1090,11 +1182,12 @@ impl DeviceState {
 
     // Take field
     pub fn take_error_message(&mut self) -> ::std::string::String {
-        self.error_message.take().unwrap_or_else(|| ::std::string::String::new())
+        self.error_message
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // repeated .Capability capabilities = 17;
-
 
     pub fn get_capabilities(&self) -> &[Capability] {
         &self.capabilities
@@ -1119,7 +1212,6 @@ impl DeviceState {
     }
 
     // optional string context_player_error = 20;
-
 
     pub fn get_context_player_error(&self) -> &str {
         match self.context_player_error.as_ref() {
@@ -1151,11 +1243,12 @@ impl DeviceState {
 
     // Take field
     pub fn take_context_player_error(&mut self) -> ::std::string::String {
-        self.context_player_error.take().unwrap_or_else(|| ::std::string::String::new())
+        self.context_player_error
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // repeated .Metadata metadata = 25;
-
 
     pub fn get_metadata(&self) -> &[Metadata] {
         &self.metadata
@@ -1186,75 +1279,105 @@ impl ::protobuf::Message for DeviceState {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.metadata {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.sw_version)?;
-                },
+                }
                 10 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.is_active = ::std::option::Option::Some(tmp);
-                },
+                }
                 11 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.can_play = ::std::option::Option::Some(tmp);
-                },
+                }
                 12 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.volume = ::std::option::Option::Some(tmp);
-                },
+                }
                 13 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.name)?;
-                },
+                }
                 14 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.error_code = ::std::option::Option::Some(tmp);
-                },
+                }
                 15 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int64()?;
                     self.became_active_at = ::std::option::Option::Some(tmp);
-                },
+                }
                 16 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.error_message)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.error_message,
+                    )?;
+                }
                 17 => {
-                    ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.capabilities)?;
-                },
+                    ::protobuf::rt::read_repeated_message_into(
+                        wire_type,
+                        is,
+                        &mut self.capabilities,
+                    )?;
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.context_player_error)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.context_player_error,
+                    )?;
+                }
                 25 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.metadata)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1291,20 +1414,23 @@ impl ::protobuf::Message for DeviceState {
         for value in &self.capabilities {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.context_player_error.as_ref() {
             my_size += ::protobuf::rt::string_size(20, &v);
         }
         for value in &self.metadata {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.sw_version.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -1333,7 +1459,7 @@ impl ::protobuf::Message for DeviceState {
             os.write_tag(17, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.context_player_error.as_ref() {
             os.write_string(20, &v)?;
         }
@@ -1341,7 +1467,7 @@ impl ::protobuf::Message for DeviceState {
             os.write_tag(25, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -1377,72 +1503,118 @@ impl ::protobuf::Message for DeviceState {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "sw_version",
-                    |m: &DeviceState| { &m.sw_version },
-                    |m: &mut DeviceState| { &mut m.sw_version },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "sw_version",
+                        |m: &DeviceState| &m.sw_version,
+                        |m: &mut DeviceState| &mut m.sw_version,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "is_active",
-                    |m: &DeviceState| { &m.is_active },
-                    |m: &mut DeviceState| { &mut m.is_active },
+                    |m: &DeviceState| &m.is_active,
+                    |m: &mut DeviceState| &mut m.is_active,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "can_play",
-                    |m: &DeviceState| { &m.can_play },
-                    |m: &mut DeviceState| { &mut m.can_play },
+                    |m: &DeviceState| &m.can_play,
+                    |m: &mut DeviceState| &mut m.can_play,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "volume",
-                    |m: &DeviceState| { &m.volume },
-                    |m: &mut DeviceState| { &mut m.volume },
+                    |m: &DeviceState| &m.volume,
+                    |m: &mut DeviceState| &mut m.volume,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "name",
-                    |m: &DeviceState| { &m.name },
-                    |m: &mut DeviceState| { &mut m.name },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "name",
+                        |m: &DeviceState| &m.name,
+                        |m: &mut DeviceState| &mut m.name,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "error_code",
-                    |m: &DeviceState| { &m.error_code },
-                    |m: &mut DeviceState| { &mut m.error_code },
+                    |m: &DeviceState| &m.error_code,
+                    |m: &mut DeviceState| &mut m.error_code,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt64,
+                >(
                     "became_active_at",
-                    |m: &DeviceState| { &m.became_active_at },
-                    |m: &mut DeviceState| { &mut m.became_active_at },
+                    |m: &DeviceState| &m.became_active_at,
+                    |m: &mut DeviceState| &mut m.became_active_at,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "error_message",
-                    |m: &DeviceState| { &m.error_message },
-                    |m: &mut DeviceState| { &mut m.error_message },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Capability>>(
-                    "capabilities",
-                    |m: &DeviceState| { &m.capabilities },
-                    |m: &mut DeviceState| { &mut m.capabilities },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "context_player_error",
-                    |m: &DeviceState| { &m.context_player_error },
-                    |m: &mut DeviceState| { &mut m.context_player_error },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Metadata>>(
-                    "metadata",
-                    |m: &DeviceState| { &m.metadata },
-                    |m: &mut DeviceState| { &mut m.metadata },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "error_message",
+                        |m: &DeviceState| &m.error_message,
+                        |m: &mut DeviceState| &mut m.error_message,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Capability>,
+                    >(
+                        "capabilities",
+                        |m: &DeviceState| &m.capabilities,
+                        |m: &mut DeviceState| &mut m.capabilities,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "context_player_error",
+                        |m: &DeviceState| &m.context_player_error,
+                        |m: &mut DeviceState| &mut m.context_player_error,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Metadata>,
+                    >(
+                        "metadata",
+                        |m: &DeviceState| &m.metadata,
+                        |m: &mut DeviceState| &mut m.metadata,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<DeviceState>(
                     "DeviceState",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1453,9 +1625,7 @@ impl ::protobuf::Message for DeviceState {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const DeviceState,
         };
-        unsafe {
-            instance.get(DeviceState::new)
-        }
+        unsafe { instance.get(DeviceState::new) }
     }
 }
 
@@ -1488,7 +1658,7 @@ impl ::protobuf::reflect::ProtobufValue for DeviceState {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Capability {
     // message fields
     typ: ::std::option::Option<CapabilityType>,
@@ -1512,7 +1682,6 @@ impl Capability {
 
     // optional .CapabilityType typ = 1;
 
-
     pub fn get_typ(&self) -> CapabilityType {
         self.typ.unwrap_or(CapabilityType::kSupportedContexts)
     }
@@ -1530,7 +1699,6 @@ impl Capability {
     }
 
     // repeated int64 intValue = 2;
-
 
     pub fn get_intValue(&self) -> &[i64] {
         &self.intValue
@@ -1555,7 +1723,6 @@ impl Capability {
     }
 
     // repeated string stringValue = 3;
-
 
     pub fn get_stringValue(&self) -> &[::std::string::String] {
         &self.stringValue
@@ -1585,22 +1752,38 @@ impl ::protobuf::Message for Capability {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
-                1 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.typ, 1, &mut self.unknown_fields)?
-                },
+                1 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.typ,
+                    1,
+                    &mut self.unknown_fields,
+                )?,
                 2 => {
                     ::protobuf::rt::read_repeated_int64_into(wire_type, is, &mut self.intValue)?;
-                },
+                }
                 3 => {
-                    ::protobuf::rt::read_repeated_string_into(wire_type, is, &mut self.stringValue)?;
-                },
+                    ::protobuf::rt::read_repeated_string_into(
+                        wire_type,
+                        is,
+                        &mut self.stringValue,
+                    )?;
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1614,26 +1797,30 @@ impl ::protobuf::Message for Capability {
             my_size += ::protobuf::rt::enum_size(1, v);
         }
         for value in &self.intValue {
-            my_size += ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
-        };
+            my_size +=
+                ::protobuf::rt::value_size(2, *value, ::protobuf::wire_format::WireTypeVarint);
+        }
         for value in &self.stringValue {
             my_size += ::protobuf::rt::string_size(3, &value);
-        };
+        }
         my_size += ::protobuf::rt::unknown_fields_size(self.get_unknown_fields());
         self.cached_size.set(my_size);
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.typ {
             os.write_enum(1, v.value())?;
         }
         for v in &self.intValue {
             os.write_int64(2, *v)?;
-        };
+        }
         for v in &self.stringValue {
             os.write_string(3, &v)?;
-        };
+        }
         os.write_unknown_fields(self.get_unknown_fields())?;
         ::std::result::Result::Ok(())
     }
@@ -1669,32 +1856,44 @@ impl ::protobuf::Message for Capability {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<CapabilityType>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<CapabilityType>,
+                >(
                     "typ",
-                    |m: &Capability| { &m.typ },
-                    |m: &mut Capability| { &mut m.typ },
+                    |m: &Capability| &m.typ,
+                    |m: &mut Capability| &mut m.typ,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<_, ::protobuf::types::ProtobufTypeInt64>(
+                fields.push(::protobuf::reflect::accessor::make_vec_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt64,
+                >(
                     "intValue",
-                    |m: &Capability| { &m.intValue },
-                    |m: &mut Capability| { &mut m.intValue },
+                    |m: &Capability| &m.intValue,
+                    |m: &mut Capability| &mut m.intValue,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "stringValue",
-                    |m: &Capability| { &m.stringValue },
-                    |m: &mut Capability| { &mut m.stringValue },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "stringValue",
+                        |m: &Capability| &m.stringValue,
+                        |m: &mut Capability| &mut m.stringValue,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Capability>(
                     "Capability",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1705,9 +1904,7 @@ impl ::protobuf::Message for Capability {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Capability,
         };
-        unsafe {
-            instance.get(Capability::new)
-        }
+        unsafe { instance.get(Capability::new) }
     }
 }
 
@@ -1732,7 +1929,7 @@ impl ::protobuf::reflect::ProtobufValue for Capability {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Goodbye {
     // message fields
     reason: ::protobuf::SingularField<::std::string::String>,
@@ -1753,7 +1950,6 @@ impl Goodbye {
     }
 
     // optional string reason = 1;
-
 
     pub fn get_reason(&self) -> &str {
         match self.reason.as_ref() {
@@ -1785,7 +1981,9 @@ impl Goodbye {
 
     // Take field
     pub fn take_reason(&mut self) -> ::std::string::String {
-        self.reason.take().unwrap_or_else(|| ::std::string::String::new())
+        self.reason
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -1794,16 +1992,24 @@ impl ::protobuf::Message for Goodbye {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.reason)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -1821,7 +2027,10 @@ impl ::protobuf::Message for Goodbye {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.reason.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -1860,22 +2069,28 @@ impl ::protobuf::Message for Goodbye {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "reason",
-                    |m: &Goodbye| { &m.reason },
-                    |m: &mut Goodbye| { &mut m.reason },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "reason",
+                        |m: &Goodbye| &m.reason,
+                        |m: &mut Goodbye| &mut m.reason,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Goodbye>(
                     "Goodbye",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -1886,9 +2101,7 @@ impl ::protobuf::Message for Goodbye {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Goodbye,
         };
-        unsafe {
-            instance.get(Goodbye::new)
-        }
+        unsafe { instance.get(Goodbye::new) }
     }
 }
 
@@ -1911,7 +2124,7 @@ impl ::protobuf::reflect::ProtobufValue for Goodbye {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct State {
     // message fields
     context_uri: ::protobuf::SingularField<::std::string::String>,
@@ -1947,7 +2160,6 @@ impl State {
 
     // optional string context_uri = 2;
 
-
     pub fn get_context_uri(&self) -> &str {
         match self.context_uri.as_ref() {
             Some(v) => &v,
@@ -1978,11 +2190,12 @@ impl State {
 
     // Take field
     pub fn take_context_uri(&mut self) -> ::std::string::String {
-        self.context_uri.take().unwrap_or_else(|| ::std::string::String::new())
+        self.context_uri
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional uint32 index = 3;
-
 
     pub fn get_index(&self) -> u32 {
         self.index.unwrap_or(0)
@@ -2002,7 +2215,6 @@ impl State {
 
     // optional uint32 position_ms = 4;
 
-
     pub fn get_position_ms(&self) -> u32 {
         self.position_ms.unwrap_or(0)
     }
@@ -2020,7 +2232,6 @@ impl State {
     }
 
     // optional .PlayStatus status = 5;
-
 
     pub fn get_status(&self) -> PlayStatus {
         self.status.unwrap_or(PlayStatus::kPlayStatusStop)
@@ -2040,7 +2251,6 @@ impl State {
 
     // optional uint64 position_measured_at = 7;
 
-
     pub fn get_position_measured_at(&self) -> u64 {
         self.position_measured_at.unwrap_or(0)
     }
@@ -2058,7 +2268,6 @@ impl State {
     }
 
     // optional string context_description = 8;
-
 
     pub fn get_context_description(&self) -> &str {
         match self.context_description.as_ref() {
@@ -2090,11 +2299,12 @@ impl State {
 
     // Take field
     pub fn take_context_description(&mut self) -> ::std::string::String {
-        self.context_description.take().unwrap_or_else(|| ::std::string::String::new())
+        self.context_description
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bool shuffle = 13;
-
 
     pub fn get_shuffle(&self) -> bool {
         self.shuffle.unwrap_or(false)
@@ -2114,7 +2324,6 @@ impl State {
 
     // optional bool repeat = 14;
 
-
     pub fn get_repeat(&self) -> bool {
         self.repeat.unwrap_or(false)
     }
@@ -2132,7 +2341,6 @@ impl State {
     }
 
     // optional string last_command_ident = 20;
-
 
     pub fn get_last_command_ident(&self) -> &str {
         match self.last_command_ident.as_ref() {
@@ -2164,11 +2372,12 @@ impl State {
 
     // Take field
     pub fn take_last_command_ident(&mut self) -> ::std::string::String {
-        self.last_command_ident.take().unwrap_or_else(|| ::std::string::String::new())
+        self.last_command_ident
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional uint32 last_command_msgid = 21;
-
 
     pub fn get_last_command_msgid(&self) -> u32 {
         self.last_command_msgid.unwrap_or(0)
@@ -2188,7 +2397,6 @@ impl State {
 
     // optional bool playing_from_fallback = 24;
 
-
     pub fn get_playing_from_fallback(&self) -> bool {
         self.playing_from_fallback.unwrap_or(false)
     }
@@ -2206,7 +2414,6 @@ impl State {
     }
 
     // optional uint32 row = 25;
-
 
     pub fn get_row(&self) -> u32 {
         self.row.unwrap_or(0)
@@ -2226,7 +2433,6 @@ impl State {
 
     // optional uint32 playing_track_index = 26;
 
-
     pub fn get_playing_track_index(&self) -> u32 {
         self.playing_track_index.unwrap_or(0)
     }
@@ -2244,7 +2450,6 @@ impl State {
     }
 
     // repeated .TrackRef track = 27;
-
 
     pub fn get_track(&self) -> &[TrackRef] {
         &self.track
@@ -2269,7 +2474,6 @@ impl State {
     }
 
     // optional .Ad ad = 28;
-
 
     pub fn get_ad(&self) -> &Ad {
         self.ad.as_ref().unwrap_or_else(|| Ad::default_instance())
@@ -2308,103 +2512,145 @@ impl ::protobuf::Message for State {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         for v in &self.ad {
             if !v.is_initialized() {
                 return false;
             }
-        };
+        }
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 2 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.context_uri)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.context_uri,
+                    )?;
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.index = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.position_ms = ::std::option::Option::Some(tmp);
-                },
-                5 => {
-                    ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(wire_type, is, &mut self.status, 5, &mut self.unknown_fields)?
-                },
+                }
+                5 => ::protobuf::rt::read_proto2_enum_with_unknown_fields_into(
+                    wire_type,
+                    is,
+                    &mut self.status,
+                    5,
+                    &mut self.unknown_fields,
+                )?,
                 7 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint64()?;
                     self.position_measured_at = ::std::option::Option::Some(tmp);
-                },
+                }
                 8 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.context_description)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.context_description,
+                    )?;
+                }
                 13 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.shuffle = ::std::option::Option::Some(tmp);
-                },
+                }
                 14 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.repeat = ::std::option::Option::Some(tmp);
-                },
+                }
                 20 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.last_command_ident)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.last_command_ident,
+                    )?;
+                }
                 21 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.last_command_msgid = ::std::option::Option::Some(tmp);
-                },
+                }
                 24 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.playing_from_fallback = ::std::option::Option::Some(tmp);
-                },
+                }
                 25 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.row = ::std::option::Option::Some(tmp);
-                },
+                }
                 26 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_uint32()?;
                     self.playing_track_index = ::std::option::Option::Some(tmp);
-                },
+                }
                 27 => {
                     ::protobuf::rt::read_repeated_message_into(wire_type, is, &mut self.track)?;
-                },
+                }
                 28 => {
                     ::protobuf::rt::read_singular_message_into(wire_type, is, &mut self.ad)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2456,7 +2702,7 @@ impl ::protobuf::Message for State {
         for value in &self.track {
             let len = value.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
-        };
+        }
         if let Some(ref v) = self.ad.as_ref() {
             let len = v.compute_size();
             my_size += 2 + ::protobuf::rt::compute_raw_varint32_size(len) + len;
@@ -2466,7 +2712,10 @@ impl ::protobuf::Message for State {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.context_uri.as_ref() {
             os.write_string(2, &v)?;
         }
@@ -2510,7 +2759,7 @@ impl ::protobuf::Message for State {
             os.write_tag(27, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
             v.write_to_with_cached_sizes(os)?;
-        };
+        }
         if let Some(ref v) = self.ad.as_ref() {
             os.write_tag(28, ::protobuf::wire_format::WireTypeLengthDelimited)?;
             os.write_raw_varint32(v.get_cached_size())?;
@@ -2551,92 +2800,140 @@ impl ::protobuf::Message for State {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "context_uri",
-                    |m: &State| { &m.context_uri },
-                    |m: &mut State| { &mut m.context_uri },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "context_uri",
+                        |m: &State| &m.context_uri,
+                        |m: &mut State| &mut m.context_uri,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "index",
-                    |m: &State| { &m.index },
-                    |m: &mut State| { &mut m.index },
+                    |m: &State| &m.index,
+                    |m: &mut State| &mut m.index,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "position_ms",
-                    |m: &State| { &m.position_ms },
-                    |m: &mut State| { &mut m.position_ms },
+                    |m: &State| &m.position_ms,
+                    |m: &mut State| &mut m.position_ms,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeEnum<PlayStatus>>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeEnum<PlayStatus>,
+                >(
                     "status",
-                    |m: &State| { &m.status },
-                    |m: &mut State| { &mut m.status },
+                    |m: &State| &m.status,
+                    |m: &mut State| &mut m.status,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint64>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint64,
+                >(
                     "position_measured_at",
-                    |m: &State| { &m.position_measured_at },
-                    |m: &mut State| { &mut m.position_measured_at },
+                    |m: &State| &m.position_measured_at,
+                    |m: &mut State| &mut m.position_measured_at,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "context_description",
-                    |m: &State| { &m.context_description },
-                    |m: &mut State| { &mut m.context_description },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "context_description",
+                        |m: &State| &m.context_description,
+                        |m: &mut State| &mut m.context_description,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "shuffle",
-                    |m: &State| { &m.shuffle },
-                    |m: &mut State| { &mut m.shuffle },
+                    |m: &State| &m.shuffle,
+                    |m: &mut State| &mut m.shuffle,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "repeat",
-                    |m: &State| { &m.repeat },
-                    |m: &mut State| { &mut m.repeat },
+                    |m: &State| &m.repeat,
+                    |m: &mut State| &mut m.repeat,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "last_command_ident",
-                    |m: &State| { &m.last_command_ident },
-                    |m: &mut State| { &mut m.last_command_ident },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "last_command_ident",
+                        |m: &State| &m.last_command_ident,
+                        |m: &mut State| &mut m.last_command_ident,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "last_command_msgid",
-                    |m: &State| { &m.last_command_msgid },
-                    |m: &mut State| { &mut m.last_command_msgid },
+                    |m: &State| &m.last_command_msgid,
+                    |m: &mut State| &mut m.last_command_msgid,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "playing_from_fallback",
-                    |m: &State| { &m.playing_from_fallback },
-                    |m: &mut State| { &mut m.playing_from_fallback },
+                    |m: &State| &m.playing_from_fallback,
+                    |m: &mut State| &mut m.playing_from_fallback,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
-                    "row",
-                    |m: &State| { &m.row },
-                    |m: &mut State| { &mut m.row },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
+                    "row", |m: &State| &m.row, |m: &mut State| &mut m.row
                 ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeUint32>(
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeUint32,
+                >(
                     "playing_track_index",
-                    |m: &State| { &m.playing_track_index },
-                    |m: &mut State| { &mut m.playing_track_index },
+                    |m: &State| &m.playing_track_index,
+                    |m: &mut State| &mut m.playing_track_index,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_repeated_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<TrackRef>>(
-                    "track",
-                    |m: &State| { &m.track },
-                    |m: &mut State| { &mut m.track },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<_, ::protobuf::types::ProtobufTypeMessage<Ad>>(
-                    "ad",
-                    |m: &State| { &m.ad },
-                    |m: &mut State| { &mut m.ad },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_repeated_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<TrackRef>,
+                    >(
+                        "track", |m: &State| &m.track, |m: &mut State| &mut m.track
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_ptr_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeMessage<Ad>,
+                    >("ad", |m: &State| &m.ad, |m: &mut State| &mut m.ad),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<State>(
                     "State",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -2647,9 +2944,7 @@ impl ::protobuf::Message for State {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const State,
         };
-        unsafe {
-            instance.get(State::new)
-        }
+        unsafe { instance.get(State::new) }
     }
 }
 
@@ -2686,7 +2981,7 @@ impl ::protobuf::reflect::ProtobufValue for State {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct TrackRef {
     // message fields
     gid: ::protobuf::SingularField<::std::vec::Vec<u8>>,
@@ -2710,7 +3005,6 @@ impl TrackRef {
     }
 
     // optional bytes gid = 1;
-
 
     pub fn get_gid(&self) -> &[u8] {
         match self.gid.as_ref() {
@@ -2747,7 +3041,6 @@ impl TrackRef {
 
     // optional string uri = 2;
 
-
     pub fn get_uri(&self) -> &str {
         match self.uri.as_ref() {
             Some(v) => &v,
@@ -2778,11 +3071,12 @@ impl TrackRef {
 
     // Take field
     pub fn take_uri(&mut self) -> ::std::string::String {
-        self.uri.take().unwrap_or_else(|| ::std::string::String::new())
+        self.uri
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bool queued = 3;
-
 
     pub fn get_queued(&self) -> bool {
         self.queued.unwrap_or(false)
@@ -2801,7 +3095,6 @@ impl TrackRef {
     }
 
     // optional string context = 4;
-
 
     pub fn get_context(&self) -> &str {
         match self.context.as_ref() {
@@ -2833,7 +3126,9 @@ impl TrackRef {
 
     // Take field
     pub fn take_context(&mut self) -> ::std::string::String {
-        self.context.take().unwrap_or_else(|| ::std::string::String::new())
+        self.context
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -2842,29 +3137,39 @@ impl ::protobuf::Message for TrackRef {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gid)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.uri)?;
-                },
+                }
                 3 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_bool()?;
                     self.queued = ::std::option::Option::Some(tmp);
-                },
+                }
                 4 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.context)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -2891,7 +3196,10 @@ impl ::protobuf::Message for TrackRef {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.gid.as_ref() {
             os.write_bytes(1, &v)?;
         }
@@ -2939,37 +3247,52 @@ impl ::protobuf::Message for TrackRef {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gid",
-                    |m: &TrackRef| { &m.gid },
-                    |m: &mut TrackRef| { &mut m.gid },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "uri",
-                    |m: &TrackRef| { &m.uri },
-                    |m: &mut TrackRef| { &mut m.uri },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeBool>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "gid", |m: &TrackRef| &m.gid, |m: &mut TrackRef| &mut m.gid
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "uri", |m: &TrackRef| &m.uri, |m: &mut TrackRef| &mut m.uri
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeBool,
+                >(
                     "queued",
-                    |m: &TrackRef| { &m.queued },
-                    |m: &mut TrackRef| { &mut m.queued },
+                    |m: &TrackRef| &m.queued,
+                    |m: &mut TrackRef| &mut m.queued,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "context",
-                    |m: &TrackRef| { &m.context },
-                    |m: &mut TrackRef| { &mut m.context },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "context",
+                        |m: &TrackRef| &m.context,
+                        |m: &mut TrackRef| &mut m.context,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<TrackRef>(
                     "TrackRef",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -2980,9 +3303,7 @@ impl ::protobuf::Message for TrackRef {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const TrackRef,
         };
-        unsafe {
-            instance.get(TrackRef::new)
-        }
+        unsafe { instance.get(TrackRef::new) }
     }
 }
 
@@ -3008,7 +3329,7 @@ impl ::protobuf::reflect::ProtobufValue for TrackRef {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Ad {
     // message fields
     next: ::std::option::Option<i32>,
@@ -3038,7 +3359,6 @@ impl Ad {
 
     // optional int32 next = 1;
 
-
     pub fn get_next(&self) -> i32 {
         self.next.unwrap_or(0)
     }
@@ -3056,7 +3376,6 @@ impl Ad {
     }
 
     // optional bytes ogg_fid = 2;
-
 
     pub fn get_ogg_fid(&self) -> &[u8] {
         match self.ogg_fid.as_ref() {
@@ -3088,11 +3407,12 @@ impl Ad {
 
     // Take field
     pub fn take_ogg_fid(&mut self) -> ::std::vec::Vec<u8> {
-        self.ogg_fid.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.ogg_fid
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional bytes image_fid = 3;
-
 
     pub fn get_image_fid(&self) -> &[u8] {
         match self.image_fid.as_ref() {
@@ -3124,11 +3444,12 @@ impl Ad {
 
     // Take field
     pub fn take_image_fid(&mut self) -> ::std::vec::Vec<u8> {
-        self.image_fid.take().unwrap_or_else(|| ::std::vec::Vec::new())
+        self.image_fid
+            .take()
+            .unwrap_or_else(|| ::std::vec::Vec::new())
     }
 
     // optional int32 duration = 4;
-
 
     pub fn get_duration(&self) -> i32 {
         self.duration.unwrap_or(0)
@@ -3147,7 +3468,6 @@ impl Ad {
     }
 
     // optional string click_url = 5;
-
 
     pub fn get_click_url(&self) -> &str {
         match self.click_url.as_ref() {
@@ -3179,11 +3499,12 @@ impl Ad {
 
     // Take field
     pub fn take_click_url(&mut self) -> ::std::string::String {
-        self.click_url.take().unwrap_or_else(|| ::std::string::String::new())
+        self.click_url
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string impression_url = 6;
-
 
     pub fn get_impression_url(&self) -> &str {
         match self.impression_url.as_ref() {
@@ -3215,11 +3536,12 @@ impl Ad {
 
     // Take field
     pub fn take_impression_url(&mut self) -> ::std::string::String {
-        self.impression_url.take().unwrap_or_else(|| ::std::string::String::new())
+        self.impression_url
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string product = 7;
-
 
     pub fn get_product(&self) -> &str {
         match self.product.as_ref() {
@@ -3251,11 +3573,12 @@ impl Ad {
 
     // Take field
     pub fn take_product(&mut self) -> ::std::string::String {
-        self.product.take().unwrap_or_else(|| ::std::string::String::new())
+        self.product
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string advertiser = 8;
-
 
     pub fn get_advertiser(&self) -> &str {
         match self.advertiser.as_ref() {
@@ -3287,11 +3610,12 @@ impl Ad {
 
     // Take field
     pub fn take_advertiser(&mut self) -> ::std::string::String {
-        self.advertiser.take().unwrap_or_else(|| ::std::string::String::new())
+        self.advertiser
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional bytes gid = 9;
-
 
     pub fn get_gid(&self) -> &[u8] {
         match self.gid.as_ref() {
@@ -3332,48 +3656,64 @@ impl ::protobuf::Message for Ad {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.next = ::std::option::Option::Some(tmp);
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.ogg_fid)?;
-                },
+                }
                 3 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.image_fid)?;
-                },
+                }
                 4 => {
                     if wire_type != ::protobuf::wire_format::WireTypeVarint {
-                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(wire_type));
+                        return ::std::result::Result::Err(::protobuf::rt::unexpected_wire_type(
+                            wire_type,
+                        ));
                     }
                     let tmp = is.read_int32()?;
                     self.duration = ::std::option::Option::Some(tmp);
-                },
+                }
                 5 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.click_url)?;
-                },
+                }
                 6 => {
-                    ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.impression_url)?;
-                },
+                    ::protobuf::rt::read_singular_string_into(
+                        wire_type,
+                        is,
+                        &mut self.impression_url,
+                    )?;
+                }
                 7 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.product)?;
-                },
+                }
                 8 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.advertiser)?;
-                },
+                }
                 9 => {
                     ::protobuf::rt::read_singular_bytes_into(wire_type, is, &mut self.gid)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3415,7 +3755,10 @@ impl ::protobuf::Message for Ad {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(v) = self.next {
             os.write_int32(1, v)?;
         }
@@ -3478,62 +3821,94 @@ impl ::protobuf::Message for Ad {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
-                    "next",
-                    |m: &Ad| { &m.next },
-                    |m: &mut Ad| { &mut m.next },
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
+                    "next", |m: &Ad| &m.next, |m: &mut Ad| &mut m.next
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "ogg_fid",
-                    |m: &Ad| { &m.ogg_fid },
-                    |m: &mut Ad| { &mut m.ogg_fid },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "image_fid",
-                    |m: &Ad| { &m.image_fid },
-                    |m: &mut Ad| { &mut m.image_fid },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_option_accessor::<_, ::protobuf::types::ProtobufTypeInt32>(
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "ogg_fid", |m: &Ad| &m.ogg_fid, |m: &mut Ad| &mut m.ogg_fid
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >(
+                        "image_fid",
+                        |m: &Ad| &m.image_fid,
+                        |m: &mut Ad| &mut m.image_fid,
+                    ),
+                );
+                fields.push(::protobuf::reflect::accessor::make_option_accessor::<
+                    _,
+                    ::protobuf::types::ProtobufTypeInt32,
+                >(
                     "duration",
-                    |m: &Ad| { &m.duration },
-                    |m: &mut Ad| { &mut m.duration },
+                    |m: &Ad| &m.duration,
+                    |m: &mut Ad| &mut m.duration,
                 ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "click_url",
-                    |m: &Ad| { &m.click_url },
-                    |m: &mut Ad| { &mut m.click_url },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "impression_url",
-                    |m: &Ad| { &m.impression_url },
-                    |m: &mut Ad| { &mut m.impression_url },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "product",
-                    |m: &Ad| { &m.product },
-                    |m: &mut Ad| { &mut m.product },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "advertiser",
-                    |m: &Ad| { &m.advertiser },
-                    |m: &mut Ad| { &mut m.advertiser },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeBytes>(
-                    "gid",
-                    |m: &Ad| { &m.gid },
-                    |m: &mut Ad| { &mut m.gid },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "click_url",
+                        |m: &Ad| &m.click_url,
+                        |m: &mut Ad| &mut m.click_url,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "impression_url",
+                        |m: &Ad| &m.impression_url,
+                        |m: &mut Ad| &mut m.impression_url,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "product", |m: &Ad| &m.product, |m: &mut Ad| &mut m.product
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "advertiser",
+                        |m: &Ad| &m.advertiser,
+                        |m: &mut Ad| &mut m.advertiser,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeBytes,
+                    >("gid", |m: &Ad| &m.gid, |m: &mut Ad| &mut m.gid),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Ad>(
                     "Ad",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3544,9 +3919,7 @@ impl ::protobuf::Message for Ad {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Ad,
         };
-        unsafe {
-            instance.get(Ad::new)
-        }
+        unsafe { instance.get(Ad::new) }
     }
 }
 
@@ -3577,7 +3950,7 @@ impl ::protobuf::reflect::ProtobufValue for Ad {
     }
 }
 
-#[derive(PartialEq,Clone,Default)]
+#[derive(PartialEq, Clone, Default)]
 pub struct Metadata {
     // message fields
     field_type: ::protobuf::SingularField<::std::string::String>,
@@ -3599,7 +3972,6 @@ impl Metadata {
     }
 
     // optional string type = 1;
-
 
     pub fn get_field_type(&self) -> &str {
         match self.field_type.as_ref() {
@@ -3631,11 +4003,12 @@ impl Metadata {
 
     // Take field
     pub fn take_field_type(&mut self) -> ::std::string::String {
-        self.field_type.take().unwrap_or_else(|| ::std::string::String::new())
+        self.field_type
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 
     // optional string metadata = 2;
-
 
     pub fn get_metadata(&self) -> &str {
         match self.metadata.as_ref() {
@@ -3667,7 +4040,9 @@ impl Metadata {
 
     // Take field
     pub fn take_metadata(&mut self) -> ::std::string::String {
-        self.metadata.take().unwrap_or_else(|| ::std::string::String::new())
+        self.metadata
+            .take()
+            .unwrap_or_else(|| ::std::string::String::new())
     }
 }
 
@@ -3676,19 +4051,27 @@ impl ::protobuf::Message for Metadata {
         true
     }
 
-    fn merge_from(&mut self, is: &mut ::protobuf::CodedInputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn merge_from(
+        &mut self,
+        is: &mut ::protobuf::CodedInputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         while !is.eof()? {
             let (field_number, wire_type) = is.read_tag_unpack()?;
             match field_number {
                 1 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.field_type)?;
-                },
+                }
                 2 => {
                     ::protobuf::rt::read_singular_string_into(wire_type, is, &mut self.metadata)?;
-                },
+                }
                 _ => {
-                    ::protobuf::rt::read_unknown_or_skip_group(field_number, wire_type, is, self.mut_unknown_fields())?;
-                },
+                    ::protobuf::rt::read_unknown_or_skip_group(
+                        field_number,
+                        wire_type,
+                        is,
+                        self.mut_unknown_fields(),
+                    )?;
+                }
             };
         }
         ::std::result::Result::Ok(())
@@ -3709,7 +4092,10 @@ impl ::protobuf::Message for Metadata {
         my_size
     }
 
-    fn write_to_with_cached_sizes(&self, os: &mut ::protobuf::CodedOutputStream<'_>) -> ::protobuf::ProtobufResult<()> {
+    fn write_to_with_cached_sizes(
+        &self,
+        os: &mut ::protobuf::CodedOutputStream<'_>,
+    ) -> ::protobuf::ProtobufResult<()> {
         if let Some(ref v) = self.field_type.as_ref() {
             os.write_string(1, &v)?;
         }
@@ -3751,27 +4137,38 @@ impl ::protobuf::Message for Metadata {
     }
 
     fn descriptor_static() -> &'static ::protobuf::reflect::MessageDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::MessageDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::MessageDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 let mut fields = ::std::vec::Vec::new();
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "type",
-                    |m: &Metadata| { &m.field_type },
-                    |m: &mut Metadata| { &mut m.field_type },
-                ));
-                fields.push(::protobuf::reflect::accessor::make_singular_field_accessor::<_, ::protobuf::types::ProtobufTypeString>(
-                    "metadata",
-                    |m: &Metadata| { &m.metadata },
-                    |m: &mut Metadata| { &mut m.metadata },
-                ));
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "type",
+                        |m: &Metadata| &m.field_type,
+                        |m: &mut Metadata| &mut m.field_type,
+                    ),
+                );
+                fields.push(
+                    ::protobuf::reflect::accessor::make_singular_field_accessor::<
+                        _,
+                        ::protobuf::types::ProtobufTypeString,
+                    >(
+                        "metadata",
+                        |m: &Metadata| &m.metadata,
+                        |m: &mut Metadata| &mut m.metadata,
+                    ),
+                );
                 ::protobuf::reflect::MessageDescriptor::new::<Metadata>(
                     "Metadata",
                     fields,
-                    file_descriptor_proto()
+                    file_descriptor_proto(),
                 )
             })
         }
@@ -3782,9 +4179,7 @@ impl ::protobuf::Message for Metadata {
             lock: ::protobuf::lazy::ONCE_INIT,
             ptr: 0 as *const Metadata,
         };
-        unsafe {
-            instance.get(Metadata::new)
-        }
+        unsafe { instance.get(Metadata::new) }
     }
 }
 
@@ -3808,7 +4203,7 @@ impl ::protobuf::reflect::ProtobufValue for Metadata {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum MessageType {
     kMessageTypeHello = 1,
     kMessageTypeGoodbye = 2,
@@ -3861,7 +4256,7 @@ impl ::protobuf::ProtobufEnum for MessageType {
             35 => ::std::option::Option::Some(MessageType::kMessageTypeAction),
             36 => ::std::option::Option::Some(MessageType::kMessageTypeRename),
             128 => ::std::option::Option::Some(MessageType::kMessageTypeUpdateMetadata),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -3893,10 +4288,11 @@ impl ::protobuf::ProtobufEnum for MessageType {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("MessageType", file_descriptor_proto())
@@ -3905,8 +4301,7 @@ impl ::protobuf::ProtobufEnum for MessageType {
     }
 }
 
-impl ::std::marker::Copy for MessageType {
-}
+impl ::std::marker::Copy for MessageType {}
 
 // Note, `Default` is implemented although default value is not 0
 impl ::std::default::Default for MessageType {
@@ -3921,7 +4316,7 @@ impl ::protobuf::reflect::ProtobufValue for MessageType {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum CapabilityType {
     kSupportedContexts = 1,
     kCanBePlayer = 2,
@@ -3960,7 +4355,7 @@ impl ::protobuf::ProtobufEnum for CapabilityType {
             12 => ::std::option::Option::Some(CapabilityType::kHidden),
             13 => ::std::option::Option::Some(CapabilityType::kSupportsPlaylistV2),
             14 => ::std::option::Option::Some(CapabilityType::kSupportsExternalEpisodes),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -3985,10 +4380,11 @@ impl ::protobuf::ProtobufEnum for CapabilityType {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("CapabilityType", file_descriptor_proto())
@@ -3997,8 +4393,7 @@ impl ::protobuf::ProtobufEnum for CapabilityType {
     }
 }
 
-impl ::std::marker::Copy for CapabilityType {
-}
+impl ::std::marker::Copy for CapabilityType {}
 
 // Note, `Default` is implemented although default value is not 0
 impl ::std::default::Default for CapabilityType {
@@ -4013,7 +4408,7 @@ impl ::protobuf::reflect::ProtobufValue for CapabilityType {
     }
 }
 
-#[derive(Clone,PartialEq,Eq,Debug,Hash)]
+#[derive(Clone, PartialEq, Eq, Debug, Hash)]
 pub enum PlayStatus {
     kPlayStatusStop = 0,
     kPlayStatusPlay = 1,
@@ -4032,7 +4427,7 @@ impl ::protobuf::ProtobufEnum for PlayStatus {
             1 => ::std::option::Option::Some(PlayStatus::kPlayStatusPlay),
             2 => ::std::option::Option::Some(PlayStatus::kPlayStatusPause),
             3 => ::std::option::Option::Some(PlayStatus::kPlayStatusLoading),
-            _ => ::std::option::Option::None
+            _ => ::std::option::Option::None,
         }
     }
 
@@ -4047,10 +4442,11 @@ impl ::protobuf::ProtobufEnum for PlayStatus {
     }
 
     fn enum_descriptor_static() -> &'static ::protobuf::reflect::EnumDescriptor {
-        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> = ::protobuf::lazy::Lazy {
-            lock: ::protobuf::lazy::ONCE_INIT,
-            ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
-        };
+        static mut descriptor: ::protobuf::lazy::Lazy<::protobuf::reflect::EnumDescriptor> =
+            ::protobuf::lazy::Lazy {
+                lock: ::protobuf::lazy::ONCE_INIT,
+                ptr: 0 as *const ::protobuf::reflect::EnumDescriptor,
+            };
         unsafe {
             descriptor.get(|| {
                 ::protobuf::reflect::EnumDescriptor::new("PlayStatus", file_descriptor_proto())
@@ -4059,8 +4455,7 @@ impl ::protobuf::ProtobufEnum for PlayStatus {
     }
 }
 
-impl ::std::marker::Copy for PlayStatus {
-}
+impl ::std::marker::Copy for PlayStatus {}
 
 impl ::std::default::Default for PlayStatus {
     fn default() -> Self {
@@ -4143,7 +4538,9 @@ static file_descriptor_proto_data: &'static [u8] = b"\
     se\x10\x02\x12\x16\n\x12kPlayStatusLoading\x10\x03\x1a\0B\0b\x06proto2\
 ";
 
-static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<::protobuf::descriptor::FileDescriptorProto> = ::protobuf::lazy::Lazy {
+static mut file_descriptor_proto_lazy: ::protobuf::lazy::Lazy<
+    ::protobuf::descriptor::FileDescriptorProto,
+> = ::protobuf::lazy::Lazy {
     lock: ::protobuf::lazy::ONCE_INIT,
     ptr: 0 as *const ::protobuf::descriptor::FileDescriptorProto,
 };
@@ -4153,9 +4550,5 @@ fn parse_descriptor_proto() -> ::protobuf::descriptor::FileDescriptorProto {
 }
 
 pub fn file_descriptor_proto() -> &'static ::protobuf::descriptor::FileDescriptorProto {
-    unsafe {
-        file_descriptor_proto_lazy.get(|| {
-            parse_descriptor_proto()
-        })
-    }
+    unsafe { file_descriptor_proto_lazy.get(|| parse_descriptor_proto()) }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,4 @@
 #![crate_name = "librespot"]
-#![cfg_attr(feature = "cargo-clippy", allow(unused_io_amount))]
 
 pub extern crate librespot_audio as audio;
 pub extern crate librespot_connect as connect;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 #![crate_name = "librespot"]
 #![deny(rust_2018_idioms)]
 
-pub extern crate librespot_audio as audio;
-pub extern crate librespot_connect as connect;
-pub extern crate librespot_core as core;
-pub extern crate librespot_metadata as metadata;
-pub extern crate librespot_playback as playback;
-pub extern crate librespot_protocol as protocol;
+pub use librespot_audio as audio;
+pub use librespot_connect as connect;
+pub use librespot_core as core;
+pub use librespot_metadata as metadata;
+pub use librespot_playback as playback;
+pub use librespot_protocol as protocol;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![crate_name = "librespot"]
+#![deny(rust_2018_idioms)]
 
 pub extern crate librespot_audio as audio;
 pub extern crate librespot_connect as connect;

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,13 +190,11 @@ fn setup(args: &[String]) -> Setup {
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
-            writeln!(
-                stderr(),
+            eprintln!(
                 "error: {}\n{}",
                 f.to_string(),
                 usage(&args[0], &opts)
-            )
-            .unwrap();
+            );
             exit(1);
         }
     };
@@ -232,8 +230,8 @@ fn setup(args: &[String]) -> Setup {
     let mixer_config = MixerConfig {
         card: matches
             .opt_str("mixer-card")
-            .unwrap_or(String::from("default")),
-        mixer: matches.opt_str("mixer-name").unwrap_or(String::from("PCM")),
+            .unwrap_or_else(|| String::from("default")),
+        mixer: matches.opt_str("mixer-name").unwrap_or_else(|| String::from("PCM")),
         index: matches
             .opt_str("mixer-index")
             .map(|index| index.parse::<u32>().unwrap())
@@ -269,7 +267,7 @@ fn setup(args: &[String]) -> Setup {
         let cached_credentials = cache.as_ref().and_then(Cache::credentials);
 
         let password = |username: &String| -> String {
-            write!(stderr(), "Password for {}: ", username).unwrap();
+            eprint!("Password for {}: ", username);
             stderr().flush().unwrap();
             rpassword::read_password().unwrap()
         };
@@ -287,8 +285,8 @@ fn setup(args: &[String]) -> Setup {
 
         SessionConfig {
             user_agent: version::version_string(),
-            device_id: device_id,
-            proxy: matches.opt_str("proxy").or(std::env::var("http_proxy").ok()).map(
+            device_id,
+            proxy: matches.opt_str("proxy").or_else(|| std::env::var("http_proxy").ok()).map(
                 |s| {
                     match Url::parse(&s) {
                         Ok(url) => {
@@ -316,9 +314,9 @@ fn setup(args: &[String]) -> Setup {
             .opt_str("b")
             .as_ref()
             .map(|bitrate| Bitrate::from_str(bitrate).expect("Invalid bitrate"))
-            .unwrap_or(Bitrate::default());
+            .unwrap_or_default();
         PlayerConfig {
-            bitrate: bitrate,
+            bitrate,
             gapless: !matches.opt_present("disable-gapless"),
             normalisation: matches.opt_present("enable-volume-normalisation"),
             normalisation_pregain: matches
@@ -333,11 +331,11 @@ fn setup(args: &[String]) -> Setup {
             .opt_str("device-type")
             .as_ref()
             .map(|device_type| DeviceType::from_str(device_type).expect("Invalid device type"))
-            .unwrap_or(DeviceType::default());
+            .unwrap_or_default();
 
         ConnectConfig {
-            name: name,
-            device_type: device_type,
+            name,
+            device_type,
             volume: initial_volume,
             linear_volume: matches.opt_present("linear-volume"),
             autoplay: matches.opt_present("autoplay"),
@@ -347,17 +345,17 @@ fn setup(args: &[String]) -> Setup {
     let enable_discovery = !matches.opt_present("disable-discovery");
 
     Setup {
-        backend: backend,
-        cache: cache,
-        session_config: session_config,
-        player_config: player_config,
-        connect_config: connect_config,
-        credentials: credentials,
-        device: device,
-        enable_discovery: enable_discovery,
-        zeroconf_port: zeroconf_port,
-        mixer: mixer,
-        mixer_config: mixer_config,
+        backend,
+        cache,
+        session_config,
+        player_config,
+        connect_config,
+        credentials,
+        device,
+        enable_discovery,
+        zeroconf_port,
+        mixer,
+        mixer_config,
         player_event_program: matches.opt_str("onevent"),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -192,11 +192,7 @@ fn setup(args: &[String]) -> Setup {
     let matches = match opts.parse(&args[1..]) {
         Ok(m) => m,
         Err(f) => {
-            eprintln!(
-                "error: {}\n{}",
-                f.to_string(),
-                usage(&args[0], &opts)
-            );
+            eprintln!("error: {}\n{}", f.to_string(), usage(&args[0], &opts));
             exit(1);
         }
     };
@@ -233,7 +229,9 @@ fn setup(args: &[String]) -> Setup {
         card: matches
             .opt_str("mixer-card")
             .unwrap_or_else(|| String::from("default")),
-        mixer: matches.opt_str("mixer-name").unwrap_or_else(|| String::from("PCM")),
+        mixer: matches
+            .opt_str("mixer-name")
+            .unwrap_or_else(|| String::from("PCM")),
         index: matches
             .opt_str("mixer-index")
             .map(|index| index.parse::<u32>().unwrap())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+#![deny(rust_2018_idioms)]
+
 use futures::sync::mpsc::UnboundedReceiver;
 use futures::{Async, Future, Poll, Stream};
 use log::{error, info, trace, warn};


### PR DESCRIPTION
Mostly removing `extern crate` and replacing struct field initialization `Foo { bar: bar }` with the `Foo { bar }` shorthand, but there are a few other changes simplifying logic and removing inefficiencies.

To test, run `cargo +stable clippy --all-features`