### PR TITLE
Feature split cache folders, resolves #505

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -11,7 +11,8 @@ use crate::volume::Volume;
 
 #[derive(Clone)]
 pub struct Cache {
-    root: PathBuf,
+    audio_root: PathBuf,
+    system_root: PathBuf,
     use_audio_cache: bool,
 }
 
@@ -26,12 +27,14 @@ fn mkdir_existing(path: &Path) -> io::Result<()> {
 }
 
 impl Cache {
-    pub fn new(location: PathBuf, use_audio_cache: bool) -> Cache {
-        mkdir_existing(&location).unwrap();
-        mkdir_existing(&location.join("files")).unwrap();
+    pub fn new(audio_location: PathBuf, system_location: PathBuf, use_audio_cache: bool) -> Cache {
+        mkdir_existing(&audio_location).unwrap();
+        mkdir_existing(&audio_location.join("files")).unwrap();
+        mkdir_existing(&system_location).unwrap();
 
         Cache {
-            root: location,
+            audio_root: audio_location,
+            system_root: system_location,
             use_audio_cache: use_audio_cache,
         }
     }
@@ -39,7 +42,7 @@ impl Cache {
 
 impl Cache {
     fn credentials_path(&self) -> PathBuf {
-        self.root.join("credentials.json")
+        self.system_root.join("credentials.json")
     }
 
     pub fn credentials(&self) -> Option<Credentials> {
@@ -53,10 +56,10 @@ impl Cache {
     }
 }
 
-// cache volume to root/volume
+// cache volume to system_root/volume
 impl Cache {
     fn volume_path(&self) -> PathBuf {
-        self.root.join("volume")
+        self.system_root.join("volume")
     }
 
     pub fn volume(&self) -> Option<u16> {
@@ -73,7 +76,7 @@ impl Cache {
 impl Cache {
     fn file_path(&self, file: FileId) -> PathBuf {
         let name = file.to_base16();
-        self.root.join("files").join(&name[0..2]).join(&name[2..])
+        self.audio_root.join("files").join(&name[0..2]).join(&name[2..])
     }
 
     pub fn file(&self, file: FileId) -> Option<File> {

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -28,8 +28,10 @@ fn mkdir_existing(path: &Path) -> io::Result<()> {
 
 impl Cache {
     pub fn new(audio_location: PathBuf, system_location: PathBuf, use_audio_cache: bool) -> Cache {
-        mkdir_existing(&audio_location).unwrap();
-        mkdir_existing(&audio_location.join("files")).unwrap();
+        if use_audio_cache == true {
+            mkdir_existing(&audio_location).unwrap();
+            mkdir_existing(&audio_location.join("files")).unwrap();
+        }
         mkdir_existing(&system_location).unwrap();
 
         Cache {

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -76,7 +76,10 @@ impl Cache {
 impl Cache {
     fn file_path(&self, file: FileId) -> PathBuf {
         let name = file.to_base16();
-        self.audio_root.join("files").join(&name[0..2]).join(&name[2..])
+        self.audio_root
+            .join("files")
+            .join(&name[0..2])
+            .join(&name[2..])
     }
 
     pub fn file(&self, file: FileId) -> Option<File> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,11 +250,15 @@ fn setup(args: &[String]) -> Setup {
     let use_audio_cache = !matches.opt_present("disable-audio-cache");
 
     let cache_directory = matches.opt_str("c").unwrap_or(String::from(""));
-    let system_cache_directory = matches.opt_str("system-cache").unwrap_or(String::from(cache_directory.clone()));
+    let system_cache_directory = matches
+        .opt_str("system-cache")
+        .unwrap_or(String::from(cache_directory.clone()));
+
     let cache = Some(Cache::new(
         PathBuf::from(cache_directory),
         PathBuf::from(system_cache_directory),
-        use_audio_cache));
+        use_audio_cache,
+    ));
 
     let initial_volume = matches
         .opt_str("initial-volume")

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,8 +250,8 @@ fn setup(args: &[String]) -> Setup {
     let use_audio_cache = !matches.opt_present("disable-audio-cache");
 
     let cache_directory = matches.opt_str("c").unwrap_or(String::from(""));
-    let system_cache_directory = matches.opt_str("system-cache").unwrap_or(String::from(cache_directory))
-    let cache = Cache::new(
+    let system_cache_directory = matches.opt_str("system-cache").unwrap_or(String::from(cache_directory.clone()));
+    let cache = Some(Cache::new(
         PathBuf::from(cache_directory),
         PathBuf::from(system_cache_directory),
         use_audio_cache));

--- a/src/main.rs
+++ b/src/main.rs
@@ -97,6 +97,11 @@ fn setup(args: &[String]) -> Setup {
         "cache",
         "Path to a directory where files will be cached.",
         "CACHE",
+    ).optopt(
+        "",
+        "system-cache",
+        "Path to a directory where system files (credentials, volume) will be cached. Can be different from cache option value",
+        "SYTEMCACHE",
     ).optflag("", "disable-audio-cache", "Disable caching of the audio data.")
         .reqopt("n", "name", "Device name", "NAME")
         .optopt("", "device-type", "Displayed device type", "DEVICE_TYPE")
@@ -244,9 +249,12 @@ fn setup(args: &[String]) -> Setup {
 
     let use_audio_cache = !matches.opt_present("disable-audio-cache");
 
-    let cache = matches
-        .opt_str("c")
-        .map(|cache_location| Cache::new(PathBuf::from(cache_location), use_audio_cache));
+    let cache_directory = matches.opt_str("c").unwrap_or(String::from(""))
+    let system_cache_directory = matches.opt_str("system-cache").unwrap_or(String::from(cache_directory))
+    let cache = Cache::new(
+        PathBuf::from(cache_directory),
+        PathBuf::from(system_cache_directory),
+        use_audio_cache));
 
     let initial_volume = matches
         .opt_str("initial-volume")

--- a/src/main.rs
+++ b/src/main.rs
@@ -249,7 +249,7 @@ fn setup(args: &[String]) -> Setup {
 
     let use_audio_cache = !matches.opt_present("disable-audio-cache");
 
-    let cache_directory = matches.opt_str("c").unwrap_or(String::from(""))
+    let cache_directory = matches.opt_str("c").unwrap_or(String::from(""));
     let system_cache_directory = matches.opt_str("system-cache").unwrap_or(String::from(cache_directory))
     let cache = Cache::new(
         PathBuf::from(cache_directory),


### PR DESCRIPTION
Cache split for system files (credentials and volume) and audio files. Retro-compatible by making the system cache the same as the audio cache if the option is not specified.

I kept the same directory tree for the audio cache by keeping the `files` directory, might not be needed. 

Use case for this new option : splitting the cache into two : audio cache in a temporary directory, for example a `tmpfs` in RAM to minimize writes to the SD card when used on a Raspberry, but system cache in a "permanent" directory, to be available across reboots. Even on a normal PC, you may want to use the HDD for the audio cache and the SSD for system cache to minimize the number of writes on your SSD.

Happy to change anything if needed, this is my first time writing some Rust  