### PR TITLE
Handle cache full situation

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -86,8 +86,13 @@ impl Cache {
 
             mkdir_existing(path.parent().unwrap()).unwrap();
 
-            let mut cache_file = File::create(path).unwrap();
-            ::std::io::copy(contents, &mut cache_file).unwrap();
+            let mut cache_file = File::create(path)
+            match cache_file {
+                Ok(file) => ::std::io::copy(contents, &mut file).unwrap(),
+                Err(error) => {
+                    self.use_audio_cache = false
+                },
+            };
         }
     }
 }

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -85,21 +85,23 @@ impl Cache {
             let path = self.file_path(file);
             mkdir_existing(path.parent().unwrap()).unwrap();
 
-            let file_create = File::create(path);
-            match file_create {
-                Ok(mut cache_file) => {
-                    ::std::io::copy(contents, &mut cache_file).unwrap();
-                }
-                Err(_error) => {
-                    ::std::fs::remove_dir_all(&self.root.join("files")).unwrap();
-                    mkdir_existing(&self.root.join("files")).unwrap();
+            let mut cache_file = File::create(path).unwrap_or_else(|_e| {
+                ::std::fs::remove_dir_all(&self.root.join("files")).unwrap();
+                mkdir_existing(&self.root.join("files")).unwrap();
 
-                    let path = self.file_path(file);
-                    mkdir_existing(path.parent().unwrap()).unwrap();
-                    let mut cache_file = File::create(path).unwrap();
-                    ::std::io::copy(contents, &mut cache_file).unwrap();
-                }
-            };
+                let path = self.file_path(file);
+                mkdir_existing(path.parent().unwrap()).unwrap();
+                File::create(path).unwrap()
+            });
+            ::std::io::copy(contents, &mut cache_file).unwrap_or_else(|_e| {
+                ::std::fs::remove_dir_all(&self.root.join("files")).unwrap();
+                mkdir_existing(&self.root.join("files")).unwrap();
+
+                let path = self.file_path(file);
+                mkdir_existing(path.parent().unwrap()).unwrap();
+                let mut file = File::create(path).unwrap();
+                ::std::io::copy(contents, &mut file).unwrap()
+            });
         }
     }
 }


### PR DESCRIPTION
Automatically clean the audio cache when we encounter an error writing some file to the cache. Useful when used on a small target like the Pi or using the RAM as audio cache, which might get full quickly, especially if the Raspberry is always on