### PR TITLE
Fix missing repo links in sub-crates

### DIFF
--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.3"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description="The discovery and Spotify Connect logic for librespot"
 license="MIT"
+repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 
 [dependencies.librespot-core]

--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -2,8 +2,8 @@
 name = "librespot-connect"
 version = "0.1.3"
 authors = ["Paul Lietar <paul@lietar.net>"]
-description="The discovery and Spotify Connect logic for librespot"
-license="MIT"
+description = "The discovery and Spotify Connect logic for librespot"
+license = "MIT"
 repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -3,8 +3,8 @@ name = "librespot-core"
 version = "0.1.3"
 authors = ["Paul Lietar <paul@lietar.net>"]
 build = "build.rs"
-description="The core functionality provided by librespot"
-license="MIT"
+description = "The core functionality provided by librespot"
+license = "MIT"
 repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Paul Lietar <paul@lietar.net>"]
 build = "build.rs"
 description="The core functionality provided by librespot"
 license="MIT"
+repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 
 [dependencies.librespot-protocol]

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -2,8 +2,8 @@
 name = "librespot-metadata"
 version = "0.1.3"
 authors = ["Paul Lietar <paul@lietar.net>"]
-description="The metadata logic for librespot"
-license="MIT"
+description = "The metadata logic for librespot"
+license = "MIT"
 repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.3"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description="The metadata logic for librespot"
 license="MIT"
+repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 
 [dependencies]

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -2,8 +2,8 @@
 name = "librespot-playback"
 version = "0.1.3"
 authors = ["Sasha Hilton <sashahilton00@gmail.com>"]
-description="The audio playback logic for librespot"
-license="MIT"
+description = "The audio playback logic for librespot"
+license = "MIT"
 repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.3"
 authors = ["Sasha Hilton <sashahilton00@gmail.com>"]
 description="The audio playback logic for librespot"
 license="MIT"
+repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 
 [dependencies.librespot-audio]

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -3,8 +3,8 @@ name = "librespot-protocol"
 version = "0.1.3"
 authors = ["Paul Liétar <paul@lietar.net>"]
 build = "build.rs"
-description="The protobuf logic for communicating with Spotify servers"
-license="MIT"
+description = "The protobuf logic for communicating with Spotify servers"
+license = "MIT"
 repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Paul Liétar <paul@lietar.net>"]
 build = "build.rs"
 description="The protobuf logic for communicating with Spotify servers"
 license="MIT"
+repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
It's very unhelpful to not have links to the repo from the crates.io pages of the sub-crates.

I also threw in a trivial formatting fix.