### PR TITLE
Add a preload event to warn about new track coming soon

### DIFF
--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -101,6 +101,10 @@ pub enum PlayerEvent {
         track_id: SpotifyId,
         position_ms: u32,
     },
+    // The player is preloading a track.
+    Preloading {
+        track_id: SpotifyId,
+    },
     // The player is playing a track.
     // This event is issued at the start of playback of whenever the position must be communicated
     // because it is out of sync. This includes:
@@ -173,7 +177,7 @@ impl PlayerEvent {
             | Stopped {
                 play_request_id, ..
             } => Some(*play_request_id),
-            Changed { .. } | VolumeSet { .. } => None,
+            Changed { .. } | Preloading { .. } | VolumeSet { .. } => None,
         }
     }
 }
@@ -799,6 +803,7 @@ impl Future for PlayerInternal {
             {
                 match loader.poll() {
                     Ok(Async::Ready(loaded_track)) => {
+                        self.send_event(PlayerEvent::Preloading { track_id });
                         self.preload = PlayerPreload::Ready {
                             track_id,
                             loaded_track,

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -58,6 +58,10 @@ pub fn run_program_on_events(event: PlayerEvent, onevent: &str) -> Option<io::Re
             env_vars.insert("DURATION_MS", duration_ms.to_string());
             env_vars.insert("POSITION_MS", position_ms.to_string());
         }
+        PlayerEvent::Preloading { track_id, .. } => {
+            env_vars.insert("PLAYER_EVENT", "preloading".to_string());
+            env_vars.insert("TRACK_ID", track_id.to_base62());
+        }
         PlayerEvent::VolumeSet { volume } => {
             env_vars.insert("PLAYER_EVENT", "volume_set".to_string());
             env_vars.insert("VOLUME", volume.to_string());


### PR DESCRIPTION
Hi,

I'm building a display for my sytsem running librespot and want to show the cover of the current track.
For this, I'm using the `onevent` option.

To minimize the delay between the track change and the cover being displayed, I need to preload the next cover picture.
I've added a new `Preloading` event that is triggered when librespot starts its own preload.

Please let me know if there's anything that needs to be fixed or improved.