### PR TITLE
compiling.md: fixup table formatting

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -39,15 +39,15 @@ Depending on the chosen backend, specific development libraries are required.
 
 *_Note this is an non-exhaustive list, open a PR to add to it!_*
 
-| Audio backend               | Debian/Ubuntu                    | Fedora  | macOS |
-|--------------------|------------------------------| ------------------------------| -- |
-|Rodio (default)| `libasound2-dev` | `alsa-lib-devel` | 
-|ALSA| `libasound2-dev, pkg-config` |`alsa-lib-devel` |
-|PortAudio| `portaudio19-dev`| `portaudio-devel`| `portaudio`
-|PulseAudio| `libpulse-dev`| `pulseaudio-libs-devel` | 
-|JACK| `libjack-dev` | `jack-audio-connection-kit-devel` | 
-|SDL| `libsdl2-dev`| `SDL2-devel` | 
-|Pipe| - | - | - |
+| Audio backend      | Debian/Ubuntu                | Fedora                            | macOS       |
+|--------------------|------------------------------|-----------------------------------|-------------|
+|Rodio (default)     | `libasound2-dev`             | `alsa-lib-devel`                  |             |
+|ALSA                | `libasound2-dev, pkg-config` | `alsa-lib-devel`                  |             |
+|PortAudio           | `portaudio19-dev`            | `portaudio-devel`                 | `portaudio` |
+|PulseAudio          | `libpulse-dev`               | `pulseaudio-libs-devel`           |             |
+|JACK                | `libjack-dev`                | `jack-audio-connection-kit-devel` |             |
+|SDL                 | `libsdl2-dev`                | `SDL2-devel`                      |             |
+|Pipe                |  -                           |  -                                |  -          |
 
 ###### For example, to build an ALSA based backend, you would need to run the following to install the required dependencies:
 


### PR DESCRIPTION
such that it is readable as a text file, not only in "rendered" markdown
form on the web.