### PR TITLE
CI: Replace Travis with Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,98 @@
+# Note, this is used in the badge URL!
+name: test
+
+on:
+  push:
+    branches: [master, dev]
+  pull_request:
+    branches: [master, dev]
+
+jobs:
+  fmt:
+    name: 'Rust: format check'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only run the formatting check for stable
+        include:
+          - os: ubuntu-latest
+            toolchain: stable
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          # Use default profile to get rustfmt
+          profile: default
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - run: cargo fmt --verbose --all -- --check
+
+  test:
+    needs: fmt
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        toolchain:
+          - 1.40.0 # MSRV (Minimum supported rust version)
+          - stable
+          - beta
+        experimental: [false]
+        # Ignore failures in nightly, not ideal, but necessary
+        include:
+          - os: ubuntu-latest
+            toolchain: nightly
+            experimental: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - name: Install developer package dependencies
+        run: sudo apt-get install libpulse-dev portaudio19-dev libasound2-dev libsdl2-dev gstreamer1.0-dev libgstreamer-plugins-base1.0-dev
+      - run: cargo build --locked --no-default-features
+      - run: cargo build --locked --examples
+      - run: cargo build --locked --no-default-features --features "with-tremor"
+      - run: cargo build --locked --no-default-features --features "with-vorbis"
+      - run: cargo build --locked --no-default-features --features "alsa-backend"
+      - run: cargo build --locked --no-default-features --features "portaudio-backend"
+      - run: cargo build --locked --no-default-features --features "pulseaudio-backend"
+      - run: cargo build --locked --no-default-features --features "jackaudio-backend"
+      - run: cargo build --locked --no-default-features --features "rodio-backend"
+      - run: cargo build --locked --no-default-features --features "sdl-backend"
+      - run: cargo build --locked --no-default-features --features "gstreamer-backend"
+
+  test-cross-arm:
+    needs: fmt
+    runs-on: ${{ matrix.os }}
+    continue-on-error: false
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: armv7-unknown-linux-gnueabihf
+            toolchain: stable
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: ${{ matrix.target }}
+          toolchain: ${{ matrix.toolchain }}
+          override: true
+      - name: Install cross
+        run: cargo install cross || true
+      - name: Build
+        run: cross build --locked --target ${{ matrix.target }} --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,8 +4,10 @@ name: test
 on:
   push:
     branches: [master, dev]
+    paths: ['**.rs', '**.toml', '**.lock', '**.yml']
   pull_request:
     branches: [master, dev]
+    paths: ['**.rs', '**.toml', '**.lock', '**.yml']
 
 jobs:
   fmt:

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -13,7 +13,7 @@ curl https://sh.rustup.rs -sSf | sh
 
 Follow any prompts it gives you to install Rust. Once that’s done, Rust's standard tools should be setup and ready to use.
 
-*Note: The current minimum required Rust version at the time of writing is 1.40.0, you can find the current minimum version specified in the `.travis.yml` file.*
+*Note: The current minimum required Rust version at the time of writing is 1.40.0, you can find the current minimum version specified in the `.github/workflow/test.yml` file.*
 
 #### Additional Rust tools - `rustfmt`
 To ensure a consistent codebase, we utilise [`rustfmt`](https://github.com/rust-lang/rustfmt), which is installed by default with `rustup` these days, else it can be installed manually with:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://img.shields.io/github/workflow/status/librespot-org/librespot/test/dev)](https://github.com/librespot-org/librespot/actions)
 [![Build Status](https://travis-ci.org/librespot-org/librespot.svg?branch=dev)](https://travis-ci.org/librespot-org/librespot)
 [![Gitter chat](https://badges.gitter.im/librespot-org/librespot.png)](https://gitter.im/librespot-org/spotify-connect-resources)
 [![Crates.io](https://img.shields.io/crates/v/librespot.svg)](https://crates.io/crates/librespot)


### PR DESCRIPTION
Fixes: #428

I converted my own crates earlier today and being on a roll I took care of this for you too.

Example successful run (before I tidied up the final commits):
https://github.com/jnqnfe/librespot/actions/runs/422461988

Not done:
 - The caching stuff.
 - The webhook notifications, since I could not find a solution.
 - The `fast_finish` setting. There's a `fail-fast` setting which I've used, but this does not seem to do what `fast_finish` does.

I believe otherwise it's essentially equivalent.