### PR TITLE
fix: map authentication errors to a custom error type

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -3,7 +3,7 @@ use futures::{Async, Future, Poll, Stream};
 use log::{error, info, trace, warn};
 use sha1::{Digest, Sha1};
 use std::env;
-use std::io::{self, stderr, Write};
+use std::io::{stderr, Write};
 use std::mem;
 use std::path::PathBuf;
 use std::process::exit;
@@ -16,7 +16,7 @@ use url::Url;
 use librespot::core::authentication::{get_credentials, Credentials};
 use librespot::core::cache::Cache;
 use librespot::core::config::{ConnectConfig, DeviceType, SessionConfig, VolumeCtrl};
-use librespot::core::session::Session;
+use librespot::core::session::{AuthenticationError, Session};
 use librespot::core::version;
 
 use librespot::connect::discovery::{discovery, DiscoveryStream};
@@ -406,7 +406,7 @@ struct Main {
 
     spirc: Option<Spirc>,
     spirc_task: Option<SpircTask>,
-    connect: Box<dyn Future<Item = Session, Error = io::Error>>,
+    connect: Box<dyn Future<Item = Session, Error = AuthenticationError>>,
 
     shutdown: bool,
     last_credentials: Option<Credentials>,


### PR DESCRIPTION
Fixes #565 

Errors encountered during authenticate() are mapped to a custom error type with an ErrorKind enum (`BadCredentials`, `PremiumAccountRequired`, `Io` (wraps io errors) and `Msg` (generated, used as a default kind to keep unmapped errors readable)) instead of panicking. 

I am not sure how backward compatibility is usually handled here however! I was thinking about adding this error mapping to a new Session::try_connect (not sure about the naming) function, while keeping the same behavior for Session::connect 