### PR TITLE
Proxy support in tokio migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -996,31 +996,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
-name = "headers"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62689dc57c7456e69712607ffcbd0aa1dfcccf9af73727e9b25bc1825375cac3"
-dependencies = [
- "base64 0.13.0",
- "bitflags 1.2.1",
- "bytes",
- "headers-core",
- "http",
- "mime",
- "sha-1",
- "time 0.1.43",
-]
-
-[[package]]
-name = "headers-core"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
-dependencies = [
- "http",
-]
-
-[[package]]
 name = "heck"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1109,20 +1084,6 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
-]
-
-[[package]]
-name = "hyper-proxy"
-version = "0.8.0"
-source = "git+https://github.com/e00E/hyper-proxy.git?branch=upgrade-tokio#4be706f2f0297bd3d14f301b6ea0be8f3078bb17"
-dependencies = [
- "bytes",
- "futures",
- "headers",
- "http",
- "hyper",
- "tokio",
- "tower-service",
 ]
 
 [[package]]
@@ -1402,7 +1363,6 @@ dependencies = [
  "hmac",
  "httparse",
  "hyper",
- "hyper-proxy",
  "librespot-protocol",
  "log",
  "num-bigint",
@@ -1420,6 +1380,7 @@ dependencies = [
  "shannon",
  "tokio",
  "tokio-util",
+ "tower-service",
  "url 1.7.2",
  "uuid",
  "vergen",
@@ -1531,12 +1492,6 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
-
-[[package]]
-name = "mime"
-version = "0.3.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "alsa"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +159,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
 ]
 
 [[package]]
@@ -566,6 +586,19 @@ name = "either"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e78d4f1cc4ae33bbfc157ed5d5a5ef3bc29227303d595861deb238fcec4e9457"
+
+[[package]]
+name = "env_logger"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26ecb66b4bdca6c1409b40fb255eefc2bd4f6d135dab3c3124f80ffa2a9661e"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
 
 [[package]]
 name = "error-chain"
@@ -1049,6 +1082,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "494b4d60369511e7dea41cf646832512a94e542f68bb9c49e54518e0f468eb47"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "hyper"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1358,6 +1397,7 @@ dependencies = [
  "base64 0.13.0",
  "byteorder",
  "bytes",
+ "env_logger",
  "futures",
  "hmac",
  "httparse",
@@ -2172,7 +2212,10 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
+ "thread_local",
 ]
 
 [[package]]
@@ -2599,6 +2642,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "termcolor"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dfed899f0eb03f32ee8c6a0aabdb8a7949659e3466561fc0adf54e26d88c5f4"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2616,6 +2668,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8208a331e1cb318dd5bd76951d2b8fc48ca38a69f5f4e4af1b6a9f8c6236915"
+dependencies = [
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,6 +963,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
 
 [[package]]
+name = "headers"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62689dc57c7456e69712607ffcbd0aa1dfcccf9af73727e9b25bc1825375cac3"
+dependencies = [
+ "base64 0.13.0",
+ "bitflags 1.2.1",
+ "bytes",
+ "headers-core",
+ "http",
+ "mime",
+ "sha-1",
+ "time 0.1.43",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
+
+[[package]]
 name = "heck"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1045,6 +1070,20 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-proxy"
+version = "0.8.0"
+source = "git+https://github.com/e00E/hyper-proxy.git?branch=upgrade-tokio#4be706f2f0297bd3d14f301b6ea0be8f3078bb17"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1323,6 +1362,7 @@ dependencies = [
  "hmac",
  "httparse",
  "hyper",
+ "hyper-proxy",
  "librespot-protocol",
  "log",
  "num-bigint",
@@ -1451,6 +1491,12 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"

--- a/audio/src/range_set.rs
+++ b/audio/src/range_set.rs
@@ -54,7 +54,7 @@ impl RangeSet {
     }
 
     pub fn len(&self) -> usize {
-        self.ranges.iter().map(|r| r.length).fold(0, std::ops::Add::add)
+        self.ranges.iter().map(|r| r.length).sum()
     }
 
     pub fn get_range(&self, index: usize) -> Range {

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,7 +21,6 @@ futures = { version = "0.3", features = ["bilock", "unstable"] }
 hmac = "0.7"
 httparse = "1.3"
 hyper = { version = "0.14", features = ["client", "tcp", "http1", "http2"] }
-hyper-proxy = { git = "https://github.com/e00E/hyper-proxy.git", branch="upgrade-tokio", default_features = false }
 log = "0.4"
 num-bigint = "0.3"
 num-integer = "0.1"
@@ -38,6 +37,7 @@ sha-1 = "~0.8"
 shannon = "0.2.0"
 tokio = { version = "1.0", features = ["io-util", "rt-multi-thread"] }
 tokio-util = { version = "0.6", features = ["codec"] }
+tower-service = "0.3"
 url = "1.7"
 uuid = { version = "0.8", features = ["v4"] }
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -21,6 +21,7 @@ futures = { version = "0.3", features = ["bilock", "unstable"] }
 hmac = "0.7"
 httparse = "1.3"
 hyper = { version = "0.14", features = ["client", "tcp", "http1", "http2"] }
+hyper-proxy = { git = "https://github.com/e00E/hyper-proxy.git", branch="upgrade-tokio", default_features = false }
 log = "0.4"
 num-bigint = "0.3"
 num-integer = "0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -46,4 +46,5 @@ rand = "0.7"
 vergen = "3.0.4"
 
 [dev-dependencies]
+env_logger = "*"
 tokio = {version = "1.0", features = ["macros"] }

--- a/core/src/apresolve.rs
+++ b/core/src/apresolve.rs
@@ -1,7 +1,8 @@
 const AP_FALLBACK: &'static str = "ap.spotify.com:443";
 const APRESOLVE_ENDPOINT: &'static str = "http://apresolve.spotify.com/";
 
-use hyper::{Body, Client, Method, Request, Uri};
+use hyper::{client::HttpConnector, Body, Client, Method, Request, Uri};
+use hyper_proxy::{Intercept, Proxy, ProxyConnector};
 use std::error::Error;
 use url::Url;
 
@@ -13,7 +14,7 @@ pub struct APResolveData {
 async fn apresolve(proxy: &Option<Url>, ap_port: &Option<u16>) -> Result<String, Box<dyn Error>> {
     let port = ap_port.unwrap_or(443);
 
-    let req = Request::builder()
+    let mut req = Request::builder()
         .method(Method::GET)
         .uri(
             APRESOLVE_ENDPOINT
@@ -22,25 +23,22 @@ async fn apresolve(proxy: &Option<Url>, ap_port: &Option<u16>) -> Result<String,
         )
         .body(Body::empty())?;
 
-    let client = if proxy.is_some() {
-        todo!("proxies not yet supported")
-        /*let proxy = {
-            let proxy_url = val.as_str().parse().expect("invalid http proxy");
-            let mut proxy = Proxy::new(Intercept::All, proxy_url);
+    let response = if let Some(url) = proxy {
+        let proxy = {
+            let proxy_url = url.as_str().parse().expect("invalid http proxy");
+            let proxy = Proxy::new(Intercept::All, proxy_url);
             let connector = HttpConnector::new();
-            let proxy_connector = ProxyConnector::from_proxy_unsecured(connector, proxy);
-            proxy_connector
+            ProxyConnector::from_proxy_unsecured(connector, proxy)
         };
 
         if let Some(headers) = proxy.http_headers(&APRESOLVE_ENDPOINT.parse().unwrap()) {
             req.headers_mut().extend(headers.clone());
         };
-        Client::builder().build(proxy)*/
-    } else {
-        Client::new()
-    };
 
-    let response = client.request(req).await?;
+        Client::builder().build(proxy).request(req).await?
+    } else {
+        Client::new().request(req).await?
+    };
 
     let body = hyper::body::to_bytes(response.into_body()).await?;
     let data: APResolveData = serde_json::from_slice(body.as_ref())?;
@@ -57,6 +55,7 @@ async fn apresolve(proxy: &Option<Url>, ap_port: &Option<u16>) -> Result<String,
         data.ap_list.into_iter().next()
     }
     .ok_or("empty AP List")?;
+
     Ok(ap)
 }
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,7 +14,6 @@ extern crate futures;
 extern crate hmac;
 extern crate httparse;
 extern crate hyper;
-extern crate hyper_proxy;
 extern crate num_bigint;
 extern crate num_integer;
 extern crate num_traits;
@@ -28,6 +27,7 @@ extern crate sha1;
 extern crate shannon;
 pub extern crate tokio;
 extern crate tokio_util;
+extern crate tower_service;
 extern crate url;
 extern crate uuid;
 

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -14,6 +14,7 @@ extern crate futures;
 extern crate hmac;
 extern crate httparse;
 extern crate hyper;
+extern crate hyper_proxy;
 extern crate num_bigint;
 extern crate num_integer;
 extern crate num_traits;

--- a/core/tests/connect.rs
+++ b/core/tests/connect.rs
@@ -7,6 +7,7 @@ mod tests {
     use apresolve::apresolve_or_fallback;
     #[tokio::test]
     async fn test_ap_resolve() {
+        env_logger::init();
         let ap = apresolve_or_fallback(&None, &None).await;
         println!("AP: {:?}", ap);
     }


### PR DESCRIPTION
Adding a git dependency of a hyper_proxy version with tokio 1.0 support. It is not yet merged, and as far as I see there was no reaction of the maintainer: tafia/hyper-proxy#18. 