### PR TITLE
Handle corrupt cache files

### DIFF
--- a/audio/src/fetch.rs
+++ b/audio/src/fetch.rs
@@ -461,7 +461,10 @@ impl AudioFile {
     }
 
     pub fn is_cached(&self) -> bool {
-        matches!(self, AudioFile::Cached { .. })
+        match self {
+            AudioFile::Cached { .. } => true,
+            _ => false,
+        }
     }
 }
 

--- a/audio/src/fetch.rs
+++ b/audio/src/fetch.rs
@@ -459,6 +459,10 @@ impl AudioFile {
             }
         }
     }
+
+    pub fn is_cached(&self) -> bool {
+        matches!(self, AudioFile::Cached { .. })
+    }
 }
 
 fn request_range(session: &Session, file: FileId, offset: usize, length: usize) -> Channel {

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -162,4 +162,17 @@ impl Cache {
             warn!("Cannot save file to cache: {}", e)
         }
     }
+
+    pub fn remove_file(&self, file: FileId) -> bool {
+        if let Some(path) = self.file_path(file) {
+            if let Err(err) = fs::remove_file(path) {
+                warn!("Unable to remove file from cache: {}", err);
+                false
+            } else {
+                true
+            }
+        } else {
+            false
+        }
+    }
 }


### PR DESCRIPTION
Fixes #591.

If an `VorbisError` occurs while opening a cached file, the cache file will be deleted and the track will be loaded again. 

I also refactored a piece of code above my fix which didn't make sense to me. The warning `<{}> in not available in format {:?}` would never occur, would it?