### PR TITLE
Replace version functions by constants

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -102,7 +102,7 @@ fn initial_state() -> State {
 fn initial_device_state(config: ConnectConfig) -> DeviceState {
     {
         let mut msg = DeviceState::new();
-        msg.set_sw_version(version::version_string());
+        msg.set_sw_version(version::VERSION_STRING.to_string());
         msg.set_is_active(false);
         msg.set_can_play(true);
         msg.set_volume(0);

--- a/core/build.rs
+++ b/core/build.rs
@@ -15,5 +15,6 @@ fn main() {
         .map(|()| rng.sample(Alphanumeric))
         .take(8)
         .collect();
-    println!("cargo:rustc-env=VERGEN_BUILD_ID={}", build_id);
+
+    println!("cargo:rustc-env=LIBRESPOT_BUILD_ID={}", build_id);
 }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -17,7 +17,7 @@ impl Default for SessionConfig {
     fn default() -> SessionConfig {
         let device_id = Uuid::new_v4().to_hyphenated().to_string();
         SessionConfig {
-            user_agent: version::version_string(),
+            user_agent: version::VERSION_STRING.to_string(),
             device_id: device_id,
             proxy: None,
             ap_port: None,

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -88,11 +88,11 @@ pub fn authenticate(
         .mut_system_info()
         .set_system_information_string(format!(
             "librespot_{}_{}",
-            version::short_sha(),
-            version::build_id()
+            version::SHA_SHORT,
+            version::BUILD_ID
         ));
     packet.mut_system_info().set_device_id(device_id);
-    packet.set_version_string(version::version_string());
+    packet.set_version_string(version::VERSION_STRING.to_string());
 
     let cmd = 0xab;
     let data = packet.write_to_bytes().unwrap();

--- a/core/src/version.rs
+++ b/core/src/version.rs
@@ -10,5 +10,8 @@ pub const SHA_SHORT: &str = env!("VERGEN_SHA_SHORT");
 /// Date of the latest git commit.
 pub const COMMIT_DATE: &str = env!("VERGEN_COMMIT_DATE");
 
+/// Librespot crate version.
+pub const SEMVER: &str = env!("CARGO_PKG_VERSION");
+
 /// A random build id.
-pub const BUILD_ID: &str = env!("VERGEN_BUILD_ID");
+pub const BUILD_ID: &str = env!("LIBRESPOT_BUILD_ID");

--- a/core/src/version.rs
+++ b/core/src/version.rs
@@ -1,44 +1,14 @@
-pub fn version_string() -> String {
-    format!("librespot-{}", short_sha())
-}
+/// Version string of the form "librespot-<sha>"
+pub const VERSION_STRING: &str = concat!("librespot-", env!("VERGEN_SHA_SHORT"));
 
-// Generate a timestamp representing now (UTC) in RFC3339 format.
-pub fn now() -> &'static str {
-    env!("VERGEN_BUILD_TIMESTAMP")
-}
+/// Generate a timstamp string representing now (UTC).
+pub const BUILD_DATE: &str = env!("VERGEN_BUILD_DATE");
 
-// Generate a timstamp string representing now (UTC).
-pub fn short_now() -> &'static str {
-    env!("VERGEN_BUILD_DATE")
-}
+/// Short sha of the latest git commit.
+pub const SHA_SHORT: &str = env!("VERGEN_SHA_SHORT");
 
-// Generate a SHA string
-pub fn sha() -> &'static str {
-    env!("VERGEN_SHA")
-}
+/// Date of the latest git commit.
+pub const COMMIT_DATE: &str = env!("VERGEN_COMMIT_DATE");
 
-// Generate a short SHA string
-pub fn short_sha() -> &'static str {
-    env!("VERGEN_SHA_SHORT")
-}
-
-// Generate the commit date string
-pub fn commit_date() -> &'static str {
-    env!("VERGEN_COMMIT_DATE")
-}
-
-// Generate the target triple string
-pub fn target() -> &'static str {
-    env!("VERGEN_TARGET_TRIPLE")
-}
-
-// Generate a semver string
-pub fn semver() -> &'static str {
-    // env!("VERGEN_SEMVER")
-    env!("CARGO_PKG_VERSION")
-}
-
-// Generate a random build id.
-pub fn build_id() -> &'static str {
-    env!("VERGEN_BUILD_ID")
-}
+/// A random build id.
+pub const BUILD_ID: &str = env!("VERGEN_BUILD_ID");

--- a/core/src/version.rs
+++ b/core/src/version.rs
@@ -1,7 +1,7 @@
 /// Version string of the form "librespot-<sha>"
 pub const VERSION_STRING: &str = concat!("librespot-", env!("VERGEN_SHA_SHORT"));
 
-/// Generate a timstamp string representing now (UTC).
+/// Generate a timestamp string representing the build date (UTC).
 pub const BUILD_DATE: &str = env!("VERGEN_BUILD_DATE");
 
 /// Short sha of the latest git commit.

--- a/src/main.rs
+++ b/src/main.rs
@@ -71,6 +71,16 @@ fn list_backends() {
     }
 }
 
+fn print_version() {
+    println!(
+        "librespot {semver} {sha} (Built on {build_date}, Build ID: {build_id})",
+        semver = version::SEMVER,
+        sha = version::SHA_SHORT,
+        build_date = version::BUILD_DATE,
+        build_id = version::BUILD_ID
+    );
+}
+
 #[derive(Clone)]
 struct Setup {
     backend: fn(Option<String>) -> Box<dyn Sink>,
@@ -103,7 +113,7 @@ fn setup(args: &[String]) -> Setup {
         "Path to a directory where system files (credentials, volume) will be cached. Can be different from cache option value",
         "SYTEMCACHE",
     ).optflag("", "disable-audio-cache", "Disable caching of the audio data.")
-        .reqopt("n", "name", "Device name", "NAME")
+        .optopt("n", "name", "Device name", "NAME")
         .optopt("", "device-type", "Displayed device type", "DEVICE_TYPE")
         .optopt(
             "b",
@@ -119,6 +129,7 @@ fn setup(args: &[String]) -> Setup {
         )
         .optflag("", "emit-sink-events", "Run program set by --onevent before sink is opened and after it is closed.")
         .optflag("v", "verbose", "Enable verbose output")
+        .optflag("V", "version", "Display librespot version string")
         .optopt("u", "username", "Username to sign in with", "USERNAME")
         .optopt("p", "password", "Password", "PASSWORD")
         .optopt("", "proxy", "HTTP proxy to use when connecting", "PROXY")
@@ -220,6 +231,11 @@ fn setup(args: &[String]) -> Setup {
         }
     };
 
+    if matches.opt_present("version") {
+        print_version();
+        exit(0);
+    }
+
     let verbose = matches.opt_present("verbose");
     setup_logging(verbose);
 
@@ -306,7 +322,7 @@ fn setup(args: &[String]) -> Setup {
         .map(|port| port.parse::<u16>().unwrap())
         .unwrap_or(0);
 
-    let name = matches.opt_str("name").unwrap();
+    let name = matches.opt_str("name").unwrap_or("Librespot".to_string());
 
     let credentials = {
         let cached_credentials = cache.as_ref().and_then(Cache::credentials);

--- a/src/main.rs
+++ b/src/main.rs
@@ -225,10 +225,10 @@ fn setup(args: &[String]) -> Setup {
 
     info!(
         "librespot {} ({}). Built on {}. Build ID: {}",
-        version::short_sha(),
-        version::commit_date(),
-        version::short_now(),
-        version::build_id()
+        version::SHA_SHORT,
+        version::COMMIT_DATE,
+        version::BUILD_DATE,
+        version::BUILD_ID
     );
 
     let backend_name = matches.opt_str("backend");
@@ -329,7 +329,7 @@ fn setup(args: &[String]) -> Setup {
         let device_id = device_id(&name);
 
         SessionConfig {
-            user_agent: version::version_string(),
+            user_agent: version::VERSION_STRING.to_string(),
             device_id: device_id,
             proxy: matches.opt_str("proxy").or(std::env::var("http_proxy").ok()).map(
                 |s| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -224,11 +224,11 @@ fn setup(args: &[String]) -> Setup {
     setup_logging(verbose);
 
     info!(
-        "librespot {} ({}). Built on {}. Build ID: {}",
-        version::SHA_SHORT,
-        version::COMMIT_DATE,
-        version::BUILD_DATE,
-        version::BUILD_ID
+        "librespot {semver} {sha} (Built on {build_date}, Build ID: {build_id})",
+        semver = version::SEMVER,
+        sha = version::SHA_SHORT,
+        build_date = version::BUILD_DATE,
+        build_id = version::BUILD_ID
     );
 
     let backend_name = matches.opt_str("backend");


### PR DESCRIPTION
Since a breaking change is coming anyway, we could also replace the `fn`s in the version module by `const`s, which is closer to their actual purpose I think. I removed those strings that weren't used, but they could be added anytime. Removing them would be a breaking change.

Before merging it, the following questions should be answered.
1. Are the names and the documentation ok?
2. Is really every of the used constants necessary?
3. Shouldn't the cargo package version be used somewhere?
4. Is an own module for those five `const`s really necessary?
5. Are there any dependent crates using one of the strings I removed?