### PR TITLE
Fix state toggling in SpircCommand::PlayPause

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -828,7 +828,7 @@ impl SpircTask {
                 self.handle_play()
             }
             SpircPlayStatus::Playing { .. } | SpircPlayStatus::LoadingPlay { .. } => {
-                self.handle_play()
+                self.handle_pause()
             }
             _ => (),
         }


### PR DESCRIPTION
Fix play/pause toggling in `handle_play_pause()` to correctly call `handle_play()`/`handle_pause()` based on the state.

Currently for both playing and paused states `handle_play()` is called.