### PR TITLE
Throttle playback

### DIFF
--- a/audio/src/lewton_decoder.rs
+++ b/audio/src/lewton_decoder.rs
@@ -38,7 +38,7 @@ where
         use self::lewton::VorbisError::OggError;
         loop {
             match self.0.read_dec_packet_itl() {
-                Ok(Some(packet)) => return Ok(Some(AudioPacket::Samples(packet))),
+                Ok(Some(packet)) => return Ok(Some(AudioPacket::Samples { data: packet })),
                 Ok(None) => return Ok(None),
 
                 Err(BadAudio(AudioIsHeader)) => (),

--- a/audio/src/lib.rs
+++ b/audio/src/lib.rs
@@ -33,29 +33,36 @@ pub use fetch::{
 use std::fmt;
 
 pub enum AudioPacket {
-    Samples(Vec<i16>),
-    OggData(Vec<u8>),
+    Samples { data: Vec<i16> },
+    OggData { data: Vec<u8>, num_samples: u64 },
 }
 
 impl AudioPacket {
     pub fn samples(&self) -> &[i16] {
         match self {
-            AudioPacket::Samples(s) => s,
-            AudioPacket::OggData(_) => panic!("can't return OggData on samples"),
+            AudioPacket::Samples { data } => data,
+            _ => panic!("can't return OggData on samples"),
         }
     }
 
     pub fn oggdata(&self) -> &[u8] {
         match self {
-            AudioPacket::Samples(_) => panic!("can't return samples on OggData"),
-            AudioPacket::OggData(d) => d,
+            AudioPacket::OggData { data, .. } => data,
+            _ => panic!("can't return samples on OggData"),
         }
     }
 
     pub fn is_empty(&self) -> bool {
         match self {
-            AudioPacket::Samples(s) => s.is_empty(),
-            AudioPacket::OggData(d) => d.is_empty(),
+            AudioPacket::Samples { data } => data.is_empty(),
+            AudioPacket::OggData { data, .. } => data.is_empty(),
+        }
+    }
+
+    pub fn num_samples(&self) -> u64 {
+        match self {
+            AudioPacket::Samples { data } => data.len() as u64 / 2,
+            AudioPacket::OggData { num_samples, .. } => *num_samples,
         }
     }
 }

--- a/playback/src/audio_backend/pipe.rs
+++ b/playback/src/audio_backend/pipe.rs
@@ -29,13 +29,13 @@ impl Sink for StdoutSink {
 
     fn write(&mut self, packet: &AudioPacket) -> io::Result<()> {
         let data: &[u8] = match packet {
-            AudioPacket::Samples(data) => unsafe {
+            AudioPacket::Samples { data } => unsafe {
                 slice::from_raw_parts(
                     data.as_ptr() as *const u8,
                     data.len() * mem::size_of::<i16>(),
                 )
             },
-            AudioPacket::OggData(data) => data,
+            AudioPacket::OggData { data, .. } => data,
         };
 
         self.0.write_all(data)?;

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -888,14 +888,12 @@ impl Future for PlayerInternal {
                     if let Some(packet) = &packet {
                         *stream_position_pcm += packet.num_samples();
                         let stream_position_millis = Self::position_pcm_to_ms(*stream_position_pcm);
-                        let lag_ms = reported_nominal_start_time
-                            .as_ref()
-                            .map(|start_time| {
-                                let reported_position =
-                                    (Instant::now() - *start_time).as_millis() as i64;
-                                reported_position - stream_position_millis as i64
-                            });
-                        
+                        let lag_ms = reported_nominal_start_time.as_ref().map(|start_time| {
+                            let reported_position =
+                                (Instant::now() - *start_time).as_millis() as i64;
+                            reported_position - stream_position_millis as i64
+                        });
+
                         if lag_ms.map_or(false, |lag| lag < -1000) {
                             // We're too fast
                             std::thread::sleep(Duration::from_millis(500));


### PR DESCRIPTION
This is a quick attempt to fix #521. If the player is too far ahead, it lets the thread sleep for a while. 

I'm not sure at which treshold and how long I should sleep, and I don't know if this works with every backend and with `--passthrough`. Nevertheless I would like to hear your opinions.