### PR TITLE
Snapcraft recipe to auto build snap package of Librespot example app

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: librespot
 base: core18
-adopt-info: librespot
+version: git
 summary: Librespot is an open source client library for Spotify
 description: |
   Librespot is an open source client library for Spotify written in Rust. It enables    
@@ -31,8 +31,8 @@ apps:
       - network-bind
       - unity7
       - audio-playback
-      - pulseaudio
-      - alsa
+      - pulseaudio #works without it but keeping it
+      - alsa #works without it but keeping it
 
 
 parts:
@@ -47,36 +47,16 @@ parts:
     stage-packages:
       - libasound2
       - libasound2-plugins
-      - yad
+#      - yad   #we are using ALWAYS_USE_PULSEAUDIO: '1' env var, so do not need yad prompts. Also adding this increasing size of snap by 38+Mb
       
   librespot:
     plugin: rust
     source: https://github.com/librespot-org/librespot.git
-    source-type: git
     source-branch: dev
-    override-pull: |
-      snapcraftctl pull
-      last_committed_tag="$(git tag -l --sort=version:refname | tail -n 1 | tr -d 'v')"
-      echo $last_committed_tag
-      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "latest/beta:" { print $2 }')"
-      echo $last_released_tag
-      # If the latest tag from the upstream project has not been released to
-      # beta, build that tag instead of master.
-      if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
-        git fetch
-        git checkout "v${last_committed_tag}"
-        echo "Setting version to $last_committed_tag"
-        snapcraftctl set-version "$(echo $last_committed_tag)"
-      else
-        echo "Setting version to $(git rev-parse --short HEAD)"
-        snapcraftctl set-version "$(git rev-parse --short HEAD)"
-      fi
+    source-depth: 1 #git shallow clone
     build-packages:
       - libasound2-dev
       - build-essential
       - pkg-config
-      - libpulse-dev
-    stage-packages:
-      - libpulse0
     after:
       - alsa-mixin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,10 +11,19 @@ description: |
 grade: stable
 confinement: strict
 
+#alsa fix from https://snapcraft-alsa.readthedocs.io/en/latest/snapcraft_usage.html
+layout:
+  /usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib:
+    bind: $SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/alsa-lib
+  /usr/share/alsa:
+    bind: $SNAP/usr/share/alsa
+
 apps:
   librespot:
+    command-chain: ["snap/command-chain/alsa-launch"]
     environment:
       LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
+      ALWAYS_USE_PULSEAUDIO: '1'
       LC_ALL: "C.UTF-8"
     command: librespot
     plugs:
@@ -22,13 +31,29 @@ apps:
       - network-bind
       - unity7
       - audio-playback
+      - pulseaudio
+      - alsa
+
 
 parts:
+#issue with alsa > ALSA lib conf.c:3916:(snd_config_update_r) Cannot access file /usr/share/alsa/alsa.conf
+#alsa fix from https://snapcraft-alsa.readthedocs.io/en/latest/snapcraft_usage.html
+  alsa-mixin:
+    plugin: dump
+    source: https://github.com/diddlesnaps/snapcraft-alsa.git
+    source-subdir: snapcraft-assets
+    build-packages:
+      - libasound2-dev
+    stage-packages:
+      - libasound2
+      - libasound2-plugins
+      - yad
+      
   librespot:
     plugin: rust
     source: https://github.com/librespot-org/librespot.git
     source-type: git
-    source-branch: master
+    source-branch: dev
     override-pull: |
       snapcraftctl pull
       last_committed_tag="$(git tag -l --sort=version:refname | tail -n 1 | tr -d 'v')"
@@ -52,4 +77,6 @@ parts:
       - pkg-config
       - libpulse-dev
     stage-packages:
-      - libasound2
+      - libpulse0
+    after:
+      - alsa-mixin

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,3 +49,7 @@ parts:
     build-packages:
       - libasound2-dev
       - build-essential
+      - pkg-config
+      - libpulse-dev
+    stage-packages:
+      - libasound2

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,51 @@
+name: librespot
+base: core18
+adopt-info: librespot
+summary: Librespot is an open source client library for Spotify
+description: |
+  Librespot is an open source client library for Spotify written in Rust. It enables    
+  applications to use Spotify's service to control and play music via various backends, 
+  and to act as a Spotify Connect receiver. It is an alternative to the official and now 
+  deprecated closed-source libspotify. Additionally, it will provide extra features which 
+  are not available in the official library.
+grade: stable
+confinement: strict
+
+apps:
+  librespot:
+    environment:
+      LD_LIBRARY_PATH: "$SNAP/usr/lib/$SNAPCRAFT_ARCH_TRIPLET/pulseaudio"
+      LC_ALL: "C.UTF-8"
+    command: librespot
+    plugs:
+      - network
+      - network-bind
+      - unity7
+      - audio-playback
+
+parts:
+  librespot:
+    plugin: rust
+    source: https://github.com/librespot-org/librespot.git
+    source-type: git
+    source-branch: master
+    override-pull: |
+      snapcraftctl pull
+      last_committed_tag="$(git tag -l --sort=version:refname | tail -n 1 | tr -d 'v')"
+      echo $last_committed_tag
+      last_released_tag="$(snap info $SNAPCRAFT_PROJECT_NAME | awk '$1 == "latest/beta:" { print $2 }')"
+      echo $last_released_tag
+      # If the latest tag from the upstream project has not been released to
+      # beta, build that tag instead of master.
+      if [ "${last_committed_tag}" != "${last_released_tag}" ]; then
+        git fetch
+        git checkout "v${last_committed_tag}"
+        echo "Setting version to $last_committed_tag"
+        snapcraftctl set-version "$(echo $last_committed_tag)"
+      else
+        echo "Setting version to $(git rev-parse --short HEAD)"
+        snapcraftctl set-version "$(git rev-parse --short HEAD)"
+      fi
+    build-packages:
+      - libasound2-dev
+      - build-essential


### PR DESCRIPTION
Hello! I added snapcraft recipe to build librespot example app snap to the snap store - see https://snapcraft.io/docs/releasing-your-app if you want publish librespot client app to snap store and reach million more Linux users :)

This merge simply adds the snap build recipe to your repo which will be picked up by the auto-build system of snapcraft.io if you register a namespace librespot there.

If you want me to publish on your behalf and manage the snap for your repo in Snapstore let me know. The published app can be transferred to the real owner(you) anytime. 

Thanks for making a great Spotify client library & app <3  