### PR TITLE
[Tokio migration] Add back hyper-proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,12 +582,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f55667319111d593ba876406af7c409c0ebb44dc4be6132a783ccf163ea14c1"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8c2dd2df839b57db9ab69c2c9d8f3e8c81984781937fe2807dc6dcf3b2ad2939"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -606,6 +622,12 @@ dependencies = [
  "futures-task",
  "futures-util",
 ]
+
+[[package]]
+name = "futures-io"
+version = "0.3.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d71c2c65c57704c32f5241c1223167c2c3294fd34ac020c807ddbe6db287ba59"
 
 [[package]]
 name = "futures-macro"
@@ -637,10 +659,13 @@ version = "0.3.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1812c7ab8aedf8d6f2701a43e1243acdbcc2b36ab26e2ad421eb99ac963d96d1"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
  "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "proc-macro-hack",
@@ -851,30 +876,29 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.3.0"
+name = "headers"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b67e66362108efccd8ac053abafc8b7a8d86a37e6e48fc4f6f7485eb5e9e6a5"
+checksum = "f0b7591fb62902706ae8e7aaff416b1b0fa2c0fd0878b46dc13baa3712d8a855"
 dependencies = [
+ "base64",
+ "bitflags",
  "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
+ "headers-core",
  "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
- "tracing-futures",
+ "mime",
+ "sha-1",
+ "time 0.1.43",
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.9.1"
+name = "headers-core"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+checksum = "e7f66481bfee273957b1f20485a4ff3362987f85b2c236580d81b4eb7a326429"
+dependencies = [
+ "http",
+]
 
 [[package]]
 name = "heck"
@@ -970,7 +994,6 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -982,6 +1005,21 @@ dependencies = [
  "tower-service",
  "tracing",
  "want",
+]
+
+[[package]]
+name = "hyper-proxy"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca815a891b24fdfb243fa3239c86154392b0953ee584aa1a2a1f66d20cbe75cc"
+dependencies = [
+ "bytes",
+ "futures",
+ "headers",
+ "http",
+ "hyper",
+ "tokio",
+ "tower-service",
 ]
 
 [[package]]
@@ -1020,16 +1058,6 @@ checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
 dependencies = [
  "cc",
  "libc",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1fa934250de4de8aef298d81c729a7d33d8c239daa3a7575e6b92bfc7313b"
-dependencies = [
- "autocfg",
- "hashbrown",
 ]
 
 [[package]]
@@ -1333,13 +1361,14 @@ dependencies = [
  "base64",
  "byteorder",
  "bytes",
- "cfg-if 1.0.0",
  "env_logger",
  "futures-core",
  "futures-util",
  "hmac",
+ "http",
  "httparse",
  "hyper",
+ "hyper-proxy",
  "librespot-protocol",
  "log",
  "num-bigint",
@@ -1468,6 +1497,12 @@ name = "memchr"
 version = "2.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee1c47aaa256ecabcaea351eae4a9b01ef39ed810004e298d2511ed284b1525"
+
+[[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
 
 [[package]]
 name = "miniz_oxide"
@@ -2689,16 +2724,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f50de3927f93d202783f4513cda820ab47ef17f624b03c096e86ef00c67e6b5f"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "tracing-futures"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97d095ae15e245a057c8e8451bab9b3ee1e1f68e9ba2b4fbc18d0ac5237835f2"
-dependencies = [
- "pin-project",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,7 +59,6 @@ sha-1 = "0.9"
 
 [features]
 apresolve = ["librespot-core/apresolve"]
-apresolve-http2 = ["librespot-core/apresolve-http2"]
 
 alsa-backend = ["librespot-playback/alsa-backend"]
 portaudio-backend = ["librespot-playback/portaudio-backend"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -17,12 +17,13 @@ aes = "0.6"
 base64 = "0.13"
 byteorder = "1.4"
 bytes = "1.0"
-cfg-if = "1"
 futures-core = { version = "0.3", default-features = false }
 futures-util = { version = "0.3", default-features = false, features = ["alloc", "bilock", "unstable", "sink"] }
 hmac = "0.10"
 httparse = "1.3"
+http = "0.2"
 hyper = { version = "0.14", optional = true, features = ["client", "tcp", "http1"] }
+hyper-proxy = { version = "0.9.1", optional = true, default-features = false }
 log = "0.4"
 num-bigint = "0.3"
 num-integer = "0.1"
@@ -50,5 +51,4 @@ env_logger = "*"
 tokio = {version = "1.0", features = ["macros"] }
 
 [features]
-apresolve = ["hyper"]
-apresolve-http2 = ["apresolve", "hyper/http2"]
+apresolve = ["hyper", "hyper-proxy"]

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -2,15 +2,12 @@
 
 #[macro_use]
 extern crate log;
-#[macro_use]
-extern crate cfg_if;
 
 use librespot_protocol as protocol;
 
 #[macro_use]
 mod component;
 
-mod apresolve;
 pub mod audio_key;
 pub mod authentication;
 pub mod cache;
@@ -25,3 +22,15 @@ pub mod session;
 pub mod spotify_id;
 pub mod util;
 pub mod version;
+
+const AP_FALLBACK: &str = "ap.spotify.com:443";
+
+#[cfg(feature = "apresolve")]
+mod apresolve;
+
+#[cfg(not(feature = "apresolve"))]
+mod apresolve {
+    pub async fn apresolve(_: Option<&url::Url>, _: Option<u16>) -> String {
+        return super::AP_FALLBACK.into();
+    }
+}

--- a/core/src/proxytunnel.rs
+++ b/core/src/proxytunnel.rs
@@ -2,16 +2,16 @@ use std::io;
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
-pub async fn connect<T: AsyncRead + AsyncWrite + Unpin>(
+pub async fn proxy_connect<T: AsyncRead + AsyncWrite + Unpin>(
     mut proxy_connection: T,
     connect_host: &str,
-    connect_port: u16,
+    connect_port: &str,
 ) -> io::Result<T> {
     let mut buffer = Vec::new();
     buffer.extend_from_slice(b"CONNECT ");
     buffer.extend_from_slice(connect_host.as_bytes());
     buffer.push(b':');
-    buffer.extend_from_slice(connect_port.to_string().as_bytes());
+    buffer.extend_from_slice(connect_port.as_bytes());
     buffer.extend_from_slice(b" HTTP/1.1\r\n\r\n");
 
     proxy_connection.write_all(buffer.as_ref()).await?;
@@ -49,61 +49,7 @@ pub async fn connect<T: AsyncRead + AsyncWrite + Unpin>(
         }
 
         if offset >= buffer.len() {
-            buffer.resize(buffer.len() * 2, 0);
-        }
-    }
-}
-
-cfg_if! {
-    if #[cfg(feature = "apresolve")] {
-        use std::future::Future;
-        use std::net::{SocketAddr, ToSocketAddrs};
-        use std::pin::Pin;
-        use std::task::Poll;
-
-        use hyper::service::Service;
-        use hyper::Uri;
-        use tokio::net::TcpStream;
-
-        #[derive(Clone)]
-        pub struct ProxyTunnel {
-            proxy_addr: SocketAddr,
-        }
-
-        impl ProxyTunnel {
-            pub fn new<T: ToSocketAddrs>(addr: T) -> io::Result<Self> {
-                let addr = addr.to_socket_addrs()?.next().ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::InvalidInput, "No socket address given")
-                })?;
-                Ok(Self { proxy_addr: addr })
-            }
-        }
-
-        impl Service<Uri> for ProxyTunnel {
-            type Response = TcpStream;
-            type Error = io::Error;
-            type Future = Pin<Box<dyn Future<Output = io::Result<TcpStream>> + Send>>;
-
-            fn poll_ready(&mut self, _: &mut std::task::Context<'_>) -> Poll<io::Result<()>> {
-                Poll::Ready(Ok(()))
-            }
-
-            fn call(&mut self, url: Uri) -> Self::Future {
-                let proxy_addr = self.proxy_addr;
-                let fut = async move {
-                    let host = url
-                        .host()
-                        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Host is missing"))?;
-                    let port = url
-                        .port()
-                        .ok_or_else(|| io::Error::new(io::ErrorKind::InvalidInput, "Port is missing"))?;
-
-                    let conn = TcpStream::connect(proxy_addr).await?;
-                    connect(conn, host, port.as_u16()).await
-                };
-
-                Box::pin(fut)
-            }
+            buffer.resize(buffer.len() + 100, 0);
         }
     }
 }

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 use tokio::sync::mpsc;
 use tokio_stream::wrappers::UnboundedReceiverStream;
 
-use crate::apresolve::apresolve_or_fallback;
+use crate::apresolve::apresolve;
 use crate::audio_key::AudioKeyManager;
 use crate::authentication::Credentials;
 use crate::cache::Cache;
@@ -67,10 +67,10 @@ impl Session {
         credentials: Credentials,
         cache: Option<Cache>,
     ) -> Result<Session, SessionError> {
-        let ap = apresolve_or_fallback(&config.proxy, &config.ap_port).await;
+        let ap = apresolve(config.proxy.as_ref(), config.ap_port).await;
 
         info!("Connecting to AP \"{}\"", ap);
-        let mut conn = connection::connect(ap, &config.proxy).await?;
+        let mut conn = connection::connect(ap, config.proxy.as_ref()).await?;
 
         let reusable_credentials =
             connection::authenticate(&mut conn, credentials, &config.device_id).await?;


### PR DESCRIPTION
This PR adds back the latest version of hyper-proxy. (It was removed as the migration to tokio was not finished yet). I also restored the old behaviour in some places I believe my refactoring was too eager.

I think it is the last major step before #665 is ready. ~Unfortunately, it is blocked by tafia/hyper-proxy#23.~