### PR TITLE
Add size limit to cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,6 +1147,7 @@ dependencies = [
  "log",
  "rpassword",
  "sha-1",
+ "thiserror",
  "tokio",
  "url",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7afe4a420e3fe79967a00898cc1f4db7c8a49a9333a29f8a4bd76a253d5cd04"
+
+[[package]]
 name = "headers"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -910,6 +916,16 @@ checksum = "de74b9dd780476e837e5eb5ab7c88b49ed304126e412030a0adba99c8efe79ea"
 dependencies = [
  "cc",
  "libc",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824845a0bf897a9042383849b02c1bc219c2383772efcd5c6f9766fa4b81aef3"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -1207,6 +1223,7 @@ dependencies = [
  "num-traits",
  "once_cell",
  "pbkdf2",
+ "priority-queue",
  "protobuf",
  "rand",
  "serde",
@@ -1722,6 +1739,16 @@ name = "pretty-hex"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc5c99d529f0d30937f6f4b8a86d988047327bb88d04d2c4afc356de74722131"
+
+[[package]]
+name = "priority-queue"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f16f1277a63996195ef38361e2c909314614c6f25f2ac4968f87dfd94a625d3d"
+dependencies = [
+ "autocfg",
+ "indexmap",
+]
 
 [[package]]
 name = "proc-macro-crate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,7 @@ hex = "0.4"
 hyper = "0.14"
 log = "0.4"
 rpassword = "5.0"
+thiserror = "1.0"
 tokio = { version = "1", features = ["rt", "rt-multi-thread", "macros", "signal", "sync", "process"] }
 url = "2.1"
 sha-1 = "0.9"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -31,6 +31,7 @@ num-integer = "0.1"
 num-traits = "0.2"
 once_cell = "1.5.2"
 pbkdf2 = { version = "0.7", default-features = false, features = ["hmac"] }
+priority-queue = "1.1"
 protobuf = "~2.14.0"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -793,8 +793,7 @@ impl PlayerTrackLoader {
                         e
                     );
 
-                    // unwrap safety: The file is cached, so session must have a cache
-                    if !self.session.cache().unwrap().remove_file(file_id) {
+                    if self.session.cache().unwrap().remove_file(file_id).is_err() {
                         return None;
                     }
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -793,7 +793,13 @@ impl PlayerTrackLoader {
                         e
                     );
 
-                    if self.session.cache().unwrap().remove_file(file_id).is_err() {
+                    if self
+                        .session
+                        .cache()
+                        .expect("If the audio file is cached, a cache should exist")
+                        .remove_file(file_id)
+                        .is_err()
+                    {
                         return None;
                     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -367,7 +367,7 @@ fn get_setup(args: &[String]) -> Setup {
                 .map(|p| p.into());
         }
 
-        match Cache::new(system_dir, audio_dir) {
+        match Cache::new(system_dir, audio_dir, Some(50_000_000)) {
             Ok(cache) => Some(cache),
             Err(e) => {
                 warn!("Cannot create cache: {}", e);

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use futures_util::{future, FutureExt, StreamExt};
 use librespot_playback::player::PlayerEvent;
 use log::{error, info, warn};
 use sha1::{Digest, Sha1};
+use thiserror::Error;
 use tokio::sync::mpsc::UnboundedReceiver;
 use url::Url;
 
@@ -98,6 +99,66 @@ pub fn get_credentials<F: FnOnce(&String) -> Option<String>>(
     }
 }
 
+#[derive(Debug, Error)]
+pub enum ParseFileSizeError {
+    #[error("empty argument")]
+    EmptyInput,
+    #[error("invalid suffix")]
+    InvalidSuffix,
+    #[error("invalid number: {0}")]
+    InvalidNumber(#[from] std::num::ParseFloatError),
+    #[error("non-finite number specified")]
+    NotFinite(f64),
+}
+
+pub fn parse_file_size(input: &str) -> Result<u64, ParseFileSizeError> {
+    use ParseFileSizeError::*;
+
+    let mut iter = input.chars();
+    let mut suffix = iter.next_back().ok_or(EmptyInput)?;
+    let mut suffix_len = 0;
+
+    let iec = matches!(suffix, 'i' | 'I');
+
+    if iec {
+        suffix_len += 1;
+        suffix = iter.next_back().ok_or(InvalidSuffix)?;
+    }
+
+    let base: u64 = if iec { 1024 } else { 1000 };
+
+    suffix_len += 1;
+    let exponent = match suffix.to_ascii_uppercase() {
+        '0'..='9' if !iec => {
+            suffix_len -= 1;
+            0
+        }
+        'K' => 1,
+        'M' => 2,
+        'G' => 3,
+        'T' => 4,
+        'P' => 5,
+        'E' => 6,
+        'Z' => 7,
+        'Y' => 8,
+        _ => return Err(InvalidSuffix),
+    };
+
+    let num = {
+        let mut iter = input.chars();
+
+        for _ in (&mut iter).rev().take(suffix_len) {}
+
+        iter.as_str().parse::<f64>()?
+    };
+
+    if !num.is_finite() {
+        return Err(NotFinite(num));
+    }
+
+    Ok((num * base.pow(exponent) as f64) as u64)
+}
+
 fn print_version() {
     println!(
         "librespot {semver} {sha} (Built on {build_date}, Build ID: {build_id})",
@@ -140,6 +201,11 @@ fn get_setup(args: &[String]) -> Setup {
         "system-cache",
         "Path to a directory where system files (credentials, volume) will be cached. Can be different from cache option value",
         "SYTEMCACHE",
+    ).optopt(
+        "",
+        "cache-size-limit",
+        "Limits the size of the cache for audio files.",
+        "CACHE_SIZE_LIMIT"
     ).optflag("", "disable-audio-cache", "Disable caching of the audio data.")
         .optopt("n", "name", "Device name", "NAME")
         .optopt("", "device-type", "Displayed device type", "DEVICE_TYPE")
@@ -367,7 +433,22 @@ fn get_setup(args: &[String]) -> Setup {
                 .map(|p| p.into());
         }
 
-        match Cache::new(system_dir, audio_dir, Some(50_000_000)) {
+        let limit = if audio_dir.is_some() {
+            matches
+                .opt_str("cache-size-limit")
+                .as_deref()
+                .map(parse_file_size)
+                .map(|e| {
+                    e.unwrap_or_else(|e| {
+                        eprintln!("Invalid argument passed as cache size limit: {}", e);
+                        exit(1);
+                    })
+                })
+        } else {
+            None
+        };
+
+        match Cache::new(system_dir, audio_dir, limit) {
             Ok(cache) => Some(cache),
             Err(e) => {
                 warn!("Cannot create cache: {}", e);


### PR DESCRIPTION
Limits cache size by calculating the size of the directory on loading of the application and keeping track of additions and removals. As soon as the limit is exceeded, the least recently accessed files are deleted.

Resolves #642.