### PR TITLE
Refactored the implementation of RangeSet.

### DIFF
--- a/audio/src/range_set.rs
+++ b/audio/src/range_set.rs
@@ -1,124 +1,146 @@
-use std::cmp::{max, min};
-use std::fmt;
-use std::slice::Iter;
+#![allow(clippy::suspicious_operation_groupings)]
 
-#[derive(Copy, Clone, Debug)]
-pub struct Range {
-    pub start: usize,
-    pub length: usize,
-}
+use std::{convert::TryInto, fmt};
 
-impl fmt::Display for Range {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        return write!(f, "[{}, {}]", self.start, self.start + self.length - 1);
-    }
-}
+mod range;
+pub(crate) use range::Range;
 
-impl Range {
-    pub fn new(start: usize, length: usize) -> Range {
-        Range { start, length }
-    }
-
-    pub fn end(&self) -> usize {
-        self.start + self.length
-    }
-}
-
-#[derive(Clone)]
-pub struct RangeSet {
+// An ordered set of ranges. These *must* be  upheld for the implementation to be correct.
+//
+// ### Invariants:
+// 1. `ranges` is ordered by `range.start()`.
+// 2. The ranges do not touch. Upon insertion of a range that touches another, instead, those
+// ranges are merged.
+// 3. None of the ranges are empty.
+#[derive(Clone, Default, Debug, PartialEq)]
+pub(crate) struct RangeSet {
     ranges: Vec<Range>,
 }
 
 impl fmt::Display for RangeSet {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "(").unwrap();
-        for range in self.ranges.iter() {
-            write!(f, "{}", range).unwrap();
+        write!(f, "(")?;
+        for range in &self.ranges {
+            write!(f, "{}", range)?;
         }
         write!(f, ")")
     }
 }
 
-impl RangeSet {
-    pub fn new() -> RangeSet {
-        RangeSet {
-            ranges: Vec::<Range>::new(),
+/// `RangeSet` can implement `Index`, but not `IndexMut`, since that would allow the user to modify
+/// the ranges in the set, which may fail to uphold the invariant around ordering.
+impl std::ops::Index<usize> for RangeSet {
+    type Output = Range;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.ranges[index]
+    }
+}
+
+impl IntoIterator for RangeSet {
+    type Item = Range;
+
+    type IntoIter = <Vec<Range> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.ranges.into_iter()
+    }
+}
+
+impl From<Vec<Range>> for RangeSet {
+    fn from(mut ranges: Vec<Range>) -> Self {
+        ranges.sort_unstable_by_key(|r| r.start());
+        let mut result: Vec<Range> = Vec::with_capacity(ranges.len()); // asssume worst case
+        for range in ranges {
+            match result.last_mut() {
+                Some(r) if r.touches(range) => *r = r.union(range),
+                _ => result.push(range),
+            }
         }
+
+        Self { ranges: result }
+    }
+}
+
+impl RangeSet {
+    /// Construct a new `RangeSet`. Equivalent to `RangeSet::default()`.
+    pub fn new() -> RangeSet {
+        Self::default()
     }
 
+    /// Checks whether this `RangeSet` contains no values.
     pub fn is_empty(&self) -> bool {
         self.ranges.is_empty()
     }
 
+    /// Returns the total length of all ranges contained in this `RangeSet`.
     pub fn len(&self) -> usize {
-        self.ranges.iter().map(|r| r.length).sum()
+        self.ranges.iter().map(Range::len).sum()
     }
 
-    pub fn get_range(&self, index: usize) -> Range {
-        self.ranges[index]
-    }
-
-    pub fn iter(&self) -> Iter<Range> {
+    /// Returns a borrowed iterator over the ranges in this `RangeSet`.
+    pub fn iter(&self) -> impl Iterator<Item = &Range> {
         self.ranges.iter()
     }
 
+    /// Returns `true` if the value is contained, returns `false` otherwise.
     pub fn contains(&self, value: usize) -> bool {
-        for range in self.ranges.iter() {
-            if value < range.start {
-                return false;
-            } else if range.start <= value && value < range.end() {
-                return true;
-            }
-        }
-        false
+        // implemented using a binary search, since that is faster than naively iterating on our
+        // sorted data.
+        self.ranges
+            .binary_search_by(|r| match (r.start() <= value, r.end() > value) {
+                (true, true) => std::cmp::Ordering::Equal,
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => unreachable!(),
+            })
+            .is_ok()
     }
 
+    /// Finds the first `Range` in `self.ranges` which contains `value`, and returns the number of
+    /// elements that are left in that `Range`.
     pub fn contained_length_from_value(&self, value: usize) -> usize {
-        for range in self.ranges.iter() {
-            if value < range.start {
-                return 0;
-            } else if range.start <= value && value < range.end() {
-                return range.end() - value;
-            }
-        }
-        0
+        self.iter()
+            .take_while(|r| value >= r.start()) // stop once the ranges no longer contain this value
+            .find(|r| r.contains(value)) // find the first range that contains this value
+            .map(|r| r.end() - value) // calculate the remaining elements in that range
+            .unwrap_or(0) // return zero otherwise
     }
 
     #[allow(dead_code)]
     pub fn contains_range_set(&self, other: &RangeSet) -> bool {
-        for range in other.ranges.iter() {
-            if self.contained_length_from_value(range.start) < range.length {
-                return false;
-            }
-        }
-        true
+        other
+            .iter()
+            .all(|r| self.contained_length_from_value(r.start()) >= r.len())
     }
 
-    pub fn add_range(&mut self, range: &Range) {
-        if range.length == 0 {
+    pub fn add_range(&mut self, range: Range) {
+        if range.is_empty() {
             // the interval is empty -> nothing to do.
             return;
         }
 
         for index in 0..self.ranges.len() {
-            // the new range is clear of any ranges we already iterated over.
-            if range.end() < self.ranges[index].start {
-                // the new range starts after anything we already passed and ends before the next range starts (they don't touch) -> insert it.
-                self.ranges.insert(index, *range);
+            let mut cur = self[index];
+            // Note that the new range is clear of any ranges we already iterated over since
+            // `self.ranges` is ordered.
+            if range < cur {
+                // The new range starts after anything we already passed and ends before the next
+                // range starts (they don't touch) -> insert it.
+                self.ranges.insert(index, range);
                 return;
-            } else if range.start <= self.ranges[index].end()
-                && self.ranges[index].start <= range.end()
-            {
-                // the new range overlaps (or touches) the first range. They are to be merged.
+            } else if range.touches(cur) {
+                // The new range overlaps (or touches) the first range. They are to be merged.
                 // In addition we might have to merge further ranges in as well.
 
-                let mut new_range = *range;
-
-                while index < self.ranges.len() && self.ranges[index].start <= new_range.end() {
-                    let new_end = max(new_range.end(), self.ranges[index].end());
-                    new_range.start = min(new_range.start, self.ranges[index].start);
-                    new_range.length = new_end - new_range.start;
+                let mut new_range = range;
+                while cur.start() <= new_range.end() {
+                    new_range = new_range.union(cur);
                     self.ranges.remove(index);
+                    if index >= self.ranges.len() {
+                        break;
+                    }
+                    cur = self[index];
                 }
 
                 self.ranges.insert(index, new_range);
@@ -127,73 +149,73 @@ impl RangeSet {
         }
 
         // the new range is after everything else -> just add it
-        self.ranges.push(*range);
+        self.ranges.push(range);
     }
 
     #[allow(dead_code)]
     pub fn add_range_set(&mut self, other: &RangeSet) {
-        for range in other.ranges.iter() {
+        for &range in other.ranges.iter() {
             self.add_range(range);
         }
     }
 
-    #[allow(dead_code)]
+    /// Returns a new `RangeSet` that contains all values with are contained in either of the
+    /// original `RangeSet`s.
     pub fn union(&self, other: &RangeSet) -> RangeSet {
         let mut result = self.clone();
         result.add_range_set(other);
         result
     }
 
-    pub fn subtract_range(&mut self, range: &Range) {
-        if range.length == 0 {
+    pub fn subtract_range(&mut self, to_sub: Range) {
+        if to_sub.is_empty() {
             return;
         }
 
         for index in 0..self.ranges.len() {
-            // the ranges we already passed don't overlap with the range to remove
-
-            if range.end() <= self.ranges[index].start {
+            let cur = self[index];
+            // The ranges we already passed don't overlap with the range to remove
+            if to_sub <= cur {
                 // the remaining ranges are past the one to subtract. -> we're done.
                 return;
-            } else if range.start <= self.ranges[index].start
-                && self.ranges[index].start < range.end()
-            {
-                // the range to subtract started before the current range and reaches into the current range
-                // -> we have to remove the beginning of the range or the entire range and do the same for following ranges.
+            }
+            if to_sub.start() <= cur.start() && cur.start() < to_sub.end() {
+                // The range to subtract started before the current range and reaches into the
+                // current range -> We have to remove the beginning of the range or the entire range
+                // and do the same for following ranges.
 
-                while index < self.ranges.len() && self.ranges[index].end() <= range.end() {
-                    self.ranges.remove(index);
+                while index < self.ranges.len() && self[index].end() <= to_sub.end() {
+                    self.ranges.remove(index); // todo: O(n) operation in a loop may be bad?
                 }
 
-                if index < self.ranges.len() && self.ranges[index].start < range.end() {
-                    self.ranges[index].length -= range.end() - self.ranges[index].start;
-                    self.ranges[index].start = range.end();
+                if index < self.ranges.len() && self[index].start() < to_sub.end() {
+                    // since our while loop ran as long as `self[index].end() <= to_sub.end()`, we
+                    // know that `to_sub.end() < self[index].end()`, and therefore the conversion
+                    // is safe.
+                    self.ranges[index] = (to_sub.end()..self[index].end()).try_into().unwrap();
                 }
-
                 return;
-            } else if range.end() < self.ranges[index].end() {
-                // the range to subtract punches a hole into the current range -> we need to create two smaller ranges.
-
-                let first_range = Range {
-                    start: self.ranges[index].start,
-                    length: range.start - self.ranges[index].start,
-                };
-
-                self.ranges[index].length -= range.end() - self.ranges[index].start;
-                self.ranges[index].start = range.end();
-
+            } else if to_sub.end() < cur.end() {
+                // The range to subtract punches a hole into the current range. This means we need
+                // to create two smaller ranges. It also means we can safely assume that the current
+                // range starts before `to_sub`, and that it ends after `to_sub`. Therefore the
+                // following two unwraps are safe.
+                let first_range = (cur.start()..to_sub.start()).try_into().unwrap();
+                self.ranges[index] = (to_sub.end()..cur.end()).try_into().unwrap();
                 self.ranges.insert(index, first_range);
-
                 return;
-            } else if range.start < self.ranges[index].end() {
-                // the range truncates the existing range -> truncate the range. Let the for loop take care of overlaps with other ranges.
-                self.ranges[index].length = range.start - self.ranges[index].start;
+            } else if to_sub.start() < cur.end() {
+                // The range truncates the existing range -> Truncate the range. Let the next
+                // iteration take care of overlaps with other ranges. This overlap also means that
+                // the current range must begin before `to_sub` begins, and therefore that
+                // `self[index].start() < to_sub.start()`. Then we can safely construct this range.
+                self.ranges[index] = (self[index].start()..to_sub.start()).try_into().unwrap();
             }
         }
     }
 
     pub fn subtract_range_set(&mut self, other: &RangeSet) {
-        for range in other.ranges.iter() {
+        for &range in other.ranges.iter() {
             self.subtract_range(range);
         }
     }
@@ -204,32 +226,25 @@ impl RangeSet {
         result
     }
 
-    pub fn intersection(&self, other: &RangeSet) -> RangeSet {
+    /// Returns a new `RangeSet` that contains all values with are contained in both original
+    /// `RangeSet`s.
+    pub fn intersection(&self, other: &Self) -> Self {
         let mut result = RangeSet::new();
-
         let mut self_index: usize = 0;
         let mut other_index: usize = 0;
 
         while self_index < self.ranges.len() && other_index < other.ranges.len() {
-            if self.ranges[self_index].end() <= other.ranges[other_index].start {
-                // skip the interval
-                self_index += 1;
-            } else if other.ranges[other_index].end() <= self.ranges[self_index].start {
-                // skip the interval
-                other_index += 1;
+            let self_range = self[self_index];
+            let other_range = other[other_index];
+            if self_range <= other_range {
+                self_index += 1; // skip the interval
+            } else if other_range <= self_range {
+                other_index += 1; // skip the interval
             } else {
-                // the two intervals overlap. Add the union and advance the index of the one that ends first.
-                let new_start = max(
-                    self.ranges[self_index].start,
-                    other.ranges[other_index].start,
-                );
-                let new_end = min(
-                    self.ranges[self_index].end(),
-                    other.ranges[other_index].end(),
-                );
-                assert!(new_start <= new_end);
-                result.add_range(&Range::new(new_start, new_end - new_start));
-                if self.ranges[self_index].end() <= other.ranges[other_index].end() {
+                // the two intervals overlap. Add the union and advance the index of the one that
+                // ends first.
+                result.add_range(self_range.union(other_range));
+                if self_range.end() <= other_range.end() {
                     self_index += 1;
                 } else {
                     other_index += 1;
@@ -238,5 +253,136 @@ impl RangeSet {
         }
 
         result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::convert::TryInto;
+
+    fn test_set1() -> RangeSet {
+        vec![(0..10).try_into().unwrap(), (20..30).try_into().unwrap()].into()
+    }
+
+    fn test_set2() -> RangeSet {
+        vec![(0..20).try_into().unwrap(), (20..30).try_into().unwrap()].into()
+    }
+
+    fn test_set3() -> RangeSet {
+        vec![
+            (0..10).try_into().unwrap(),
+            (10..20).try_into().unwrap(),
+            (20..30).try_into().unwrap(),
+        ]
+        .into()
+    }
+
+    fn test_set4() -> RangeSet {
+        vec![(20..30).try_into().unwrap()].into()
+    }
+
+    fn is_sorted(rs: &RangeSet) -> bool {
+        let first = rs[0];
+        rs.ranges[1..]
+            .iter()
+            .fold((true, first), |(is_sorted, prev), &r| {
+                (is_sorted && prev.start() <= r.start(), r)
+            })
+            .0
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let empty_set: RangeSet = Vec::new().into();
+        assert!(empty_set.is_empty());
+    }
+
+    #[test]
+    fn test_len() {
+        assert_eq!(test_set1().len(), 20);
+        assert_eq!(test_set2().len(), 30);
+        assert_eq!(test_set3().len(), 30);
+    }
+
+    #[test]
+    fn test_contains() {
+        assert!(test_set1().contains(0));
+        assert!(test_set1().contains(5));
+        assert!(!test_set1().contains(10));
+
+        assert!(test_set2().contains(0));
+        assert!(test_set2().contains(20));
+        assert!(!test_set2().contains(30));
+
+        assert!(test_set3().contains(0));
+        assert!(test_set3().contains(5));
+        assert!(test_set3().contains(10));
+    }
+
+    #[test]
+    fn contained_length_from_value() {
+        assert_eq!(test_set1().contained_length_from_value(0), 10);
+        assert_eq!(test_set1().contained_length_from_value(10), 0);
+        assert_eq!(test_set1().contained_length_from_value(20), 10);
+
+        // todo: should these tests pass?
+        assert_eq!(test_set2().contained_length_from_value(0), 30);
+        assert_eq!(test_set2().contained_length_from_value(30), 0);
+
+        assert_eq!(test_set3().contained_length_from_value(0), 30);
+        assert_eq!(test_set3().contained_length_from_value(10), 20);
+        assert_eq!(test_set3().contained_length_from_value(20), 10);
+        assert_eq!(test_set3().contained_length_from_value(30), 0);
+    }
+
+    #[test]
+    fn test_contains_range_set() {
+        assert!(test_set1().contains_range_set(&test_set1()));
+        assert!(!test_set1().contains_range_set(&test_set2()));
+        assert!(!test_set1().contains_range_set(&test_set3()));
+
+        assert!(test_set2().contains_range_set(&test_set1()));
+        assert!(test_set2().contains_range_set(&test_set2()));
+        assert!(test_set2().contains_range_set(&test_set3()));
+
+        assert!(test_set3().contains_range_set(&test_set1()));
+        assert!(test_set3().contains_range_set(&test_set2()));
+        assert!(test_set3().contains_range_set(&test_set3()));
+    }
+
+    #[test]
+    fn test_add() {
+        let mut test1 = test_set1();
+        let to_add: Range = (0..10).try_into().unwrap();
+        test1.add_range(to_add);
+        assert_eq!(test_set1(), test1);
+        let to_add: Range = (10..20).try_into().unwrap();
+        test1.add_range(to_add);
+        assert_eq!(test_set2(), test1);
+        let to_add: Range = (5..15).try_into().unwrap();
+        test1.add_range(to_add);
+        assert_eq!(test_set2(), test1);
+
+        assert!(is_sorted(&test1));
+    }
+
+    #[test]
+    fn test_sub() {
+        let mut test1 = test_set1();
+        let to_sub: Range = (0..10).try_into().unwrap();
+        test1.subtract_range(to_sub);
+        assert_eq!(test_set4(), test1);
+
+        let mut test3 = test_set3();
+        let to_sub: Range = (10..20).try_into().unwrap();
+        test3.subtract_range(to_sub);
+        assert_eq!(test_set1(), test3);
+
+        let mut test4: RangeSet = vec![(0..221184).try_into().unwrap()].into();
+        let to_sub: Range = (0..69632).try_into().unwrap();
+        test4.subtract_range(to_sub);
+        let res: RangeSet = vec![(69632..221184).try_into().unwrap()].into();
+        assert_eq!(res, test4);
     }
 }

--- a/audio/src/range_set/range.rs
+++ b/audio/src/range_set/range.rs
@@ -1,0 +1,319 @@
+use std::{
+    cmp::{self, max, min},
+    convert::{TryFrom, TryInto},
+    fmt,
+};
+
+/// A struct that represents a range between two values. The lower boundary is closed, and the upper
+/// boundary is open. This means that a `Range` from 2 to 5 includes 2, 3 and 4, but not 5.
+/// `std::ops::Range` is not used since it is not `Copy`, which uglifies the resulting code
+/// significantly. For more info, see [this](https://github.com/rust-lang/rust/issues/18045).
+///
+/// ### Invariants
+/// For a range type to be valid, the end must be greater than or equal to the start. For this
+/// reason the following code panics:
+/// ```ignore
+/// let r: Range = (2..0).into();
+/// ```
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Range {
+    start: usize,
+    len: usize,
+}
+
+impl fmt::Display for Range {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "[{}, {}]", self.start, self.end() - 1)
+    }
+}
+
+impl TryFrom<std::ops::Range<usize>> for Range {
+    type Error = &'static str;
+
+    fn try_from(r: std::ops::Range<usize>) -> Result<Self, Self::Error> {
+        if r.start <= r.end {
+            Ok(Self {
+                start: r.start,
+                len: r.end - r.start,
+            })
+        } else {
+            Err("`start` must be less than or equal to `end`")
+        }
+    }
+}
+
+impl Range {
+    /// Construct a new `Range` from a given `start` and `len`.
+    pub const fn new(start: usize, len: usize) -> Range {
+        Self { start, len }
+    }
+
+    /// Returns the start of the range.
+    pub const fn start(&self) -> usize {
+        self.start
+    }
+
+    /// Returns the end of the range.
+    pub const fn end(&self) -> usize {
+        self.start + self.len
+    }
+
+    /// Returns the length of the range.
+    pub const fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns `true` if the range contains no values, that is, the start is equal to the end, and
+    /// returns `false` otherwise.
+    pub const fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+
+    /// Clears the range, making it contain no values by setting the end of the range equal to the
+    /// start of the range.
+    pub fn clear(&mut self) {
+        self.len = 0;
+    }
+
+    /// Sets the length of the range to the provided value.
+    pub fn set_len(&mut self, len: usize) {
+        self.len = len;
+    }
+
+    /// Returns `true` if `val` is inside the range, returns `false` otherwise.
+    pub const fn contains(&self, val: usize) -> bool {
+        val >= self.start() && val < self.end()
+    }
+
+    /// Returns `true` if the range overlaps anywhere with the other provided range, and returns
+    /// `false` otherwise.
+    pub const fn overlaps(&self, other: Self) -> bool {
+        self.start() < other.end() && self.end() > other.start()
+    }
+
+    /// Returns `true` if the range touches or overlaps anywhere with the other provided range, and
+    /// returns `false` otherwise.
+    pub const fn touches(&self, other: Self) -> bool {
+        self.start() <= other.end() && self.end() >= other.start()
+    }
+
+    /// Returns the union of the two ranges. Since the union of two ranges can only be represented
+    /// as a single range when the two ranges touch, it is assumed that this is the case.
+    pub fn union(&self, other: Self) -> Self {
+        let start = min(self.start(), other.start());
+        let end = max(self.end(), other.end());
+        // this is safe because `self` and `other` both uphold their respective invariants
+        (start..end).try_into().unwrap()
+    }
+
+    pub fn intersection(&self, other: Self) -> Option<Self> {
+        let start = max(self.start(), other.start());
+        let end = min(self.end(), other.end());
+        if start <= end {
+            (start..end).try_into().ok() // should be Some because we just checked this
+        } else {
+            None
+        }
+    }
+}
+
+impl PartialOrd for Range {
+    /// The `Range` type forms a partial order, not a total order, since for overlapping `Range`s
+    /// there is no meaningful comparison to be made.
+    fn partial_cmp(&self, other: &Self) -> Option<cmp::Ordering> {
+        if self.end() <= other.start() {
+            Some(cmp::Ordering::Less)
+        } else if self.start() >= other.end() {
+            Some(cmp::Ordering::Greater)
+        } else {
+            None
+        }
+    }
+
+    /// Override the `<=` function, because it defaults to using equality, which is not relevant for
+    /// ranges.
+    fn le(&self, other: &Self) -> bool {
+        self.end() <= other.start()
+    }
+
+    /// Override the `>=` function, because it defaults to using equality, which is not relevant for
+    /// ranges.
+    fn ge(&self, other: &Self) -> bool {
+        self.start() >= other.end()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{cmp, convert::TryInto};
+
+    use super::Range;
+
+    fn range1() -> Range {
+        (0..2).try_into().unwrap()
+    }
+
+    fn range2() -> Range {
+        (1..3).try_into().unwrap()
+    }
+
+    fn range3() -> Range {
+        (2..10).try_into().unwrap()
+    }
+
+    fn range4() -> Range {
+        (3..5).try_into().unwrap()
+    }
+
+    #[test]
+    fn test_compare() {
+        assert!(!(range1() > range2())); // overlapping ranges should be neither greater nor smaller
+        assert!(!(range2() > range1())); // overlapping ranges should be neither greater nor smaller
+        assert!(!(range1() > range4()));
+        assert!(range1() < range4());
+    }
+
+    #[test]
+    fn test_new() {
+        let new = Range::new(1, 2);
+        assert_eq!(range2(), new)
+    }
+
+    #[test]
+    fn test_start() {
+        assert_eq!(range1().start(), 0);
+        assert_eq!(range2().start(), 1);
+        assert_eq!(range3().start(), 2);
+        assert_eq!(range4().start(), 3);
+    }
+
+    #[test]
+    fn test_end() {
+        assert_eq!(range1().end(), 2);
+        assert_eq!(range2().end(), 3);
+        assert_eq!(range3().end(), 10);
+        assert_eq!(range4().end(), 5);
+    }
+
+    #[test]
+    fn test_len() {
+        assert_eq!(range1().len(), 2);
+        assert_eq!(range2().len(), 2);
+        assert_eq!(range3().len(), 8);
+        assert_eq!(range4().len(), 2);
+    }
+
+    #[test]
+    fn test_is_empty() {
+        let range: Range = (10..10).try_into().unwrap();
+        assert!(range.is_empty());
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut r1 = range1();
+        r1.clear();
+        assert_eq!(r1, (0..0).try_into().unwrap());
+
+        let mut r2 = range2();
+        r2.clear();
+        assert_eq!(r2, (1..1).try_into().unwrap());
+    }
+
+    #[test]
+    fn test_set_len() {
+        let mut r1 = range1();
+        r1.set_len(20);
+        assert_eq!(r1, (0..20).try_into().unwrap());
+    }
+
+    #[test]
+    fn test_contains() {
+        assert!(!range2().contains(0));
+        assert!(range2().contains(1));
+        assert!(range2().contains(2));
+        assert!(!range2().contains(3));
+        assert!(!range2().contains(4));
+    }
+
+    #[test]
+    fn test_overlaps() {
+        assert!(range1().overlaps(range2()));
+        assert!(!range1().overlaps(range3()));
+        assert!(!range1().overlaps(range4()));
+
+        assert!(range2().overlaps(range1()));
+        assert!(range2().overlaps(range3()));
+        assert!(!range2().overlaps(range4()));
+
+        assert!(!range3().overlaps(range1()));
+        assert!(range3().overlaps(range2()));
+        assert!(range3().overlaps(range4()));
+
+        assert!(!range4().overlaps(range1()));
+        assert!(!range4().overlaps(range2()));
+        assert!(range4().overlaps(range3()));
+    }
+
+    #[test]
+    fn test_touches() {
+        assert!(range1().touches(range2()));
+        assert!(range1().touches(range3()));
+        assert!(!range1().touches(range4()));
+
+        assert!(range2().touches(range1()));
+        assert!(range2().touches(range3()));
+        assert!(range2().touches(range4()));
+
+        assert!(range3().touches(range1()));
+        assert!(range3().touches(range2()));
+        assert!(range3().touches(range4()));
+
+        assert!(!range4().touches(range1()));
+        assert!(range4().touches(range2()));
+        assert!(range4().touches(range3()));
+    }
+
+    #[test]
+    fn test_union() {
+        assert_eq!(range1().union(range2()), (0..3).try_into().unwrap());
+        assert_eq!(range1().union(range4()), (0..5).try_into().unwrap()); // breaking the invariant should not panic
+    }
+
+    #[test]
+    fn test_intersection() {
+        assert_eq!(
+            range1().intersection(range2()),
+            Some((1..2).try_into().unwrap())
+        );
+        assert!(range1().intersection(range4()).is_none());
+    }
+
+    #[test]
+    fn test_ord() {
+        assert_eq!(range1().partial_cmp(&range2()), None);
+        assert_eq!(range1().partial_cmp(&range3()), Some(cmp::Ordering::Less));
+        assert_eq!(range1().partial_cmp(&range4()), Some(cmp::Ordering::Less));
+
+        assert_eq!(range2().partial_cmp(&range1()), None);
+        assert_eq!(range2().partial_cmp(&range3()), None);
+        assert_eq!(range2().partial_cmp(&range4()), Some(cmp::Ordering::Less));
+
+        assert_eq!(
+            range3().partial_cmp(&range1()),
+            Some(cmp::Ordering::Greater)
+        );
+        assert_eq!(range3().partial_cmp(&range2()), None);
+        assert_eq!(range3().partial_cmp(&range4()), None);
+
+        assert_eq!(
+            range4().partial_cmp(&range1()),
+            Some(cmp::Ordering::Greater)
+        );
+        assert_eq!(
+            range4().partial_cmp(&range2()),
+            Some(cmp::Ordering::Greater)
+        );
+        assert_eq!(range4().partial_cmp(&range3()), None);
+    }
+}


### PR DESCRIPTION
Refactored the implementation of RangeSet. The original implementation did not enforce privacy of the fields of `Range`, which meant that the implementation of `Range` could not be easily swapped out. I also added tests for all functions of RangeSet and Range. I also added several extra functions to Range that make the implementation of RangeSet a bit more legible (thing like writing `range1.touches(range2)` instead of `range1.start() <= range2.end() && range1.end() >= range2.start()`). I also favoured operator overloading over method calls, so instead of `range1.minus(range2)` we can write `range1 - range2`. I hope this PR is welcome! Let me know what you think.