### PR TITLE
Optimize volume control logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since v0.2.0.
 
 ## [Unreleased]
+### Added
+- [playback] Add `--volume-range` option to set dB range and control `log` and `cubic` volume control curves
+- [playback] `alsamixer`: support for querying dB range from Alsa softvol
+
+### Changed
+* [audio, playback] Moved `VorbisDecoder`, `VorbisError`, `AudioPacket`, `PassthroughDecoder`, `PassthroughError`, `AudioError`, `AudioDecoder` and the `convert` module from `librespot-audio` to `librespot-playback`. The underlying crates `vorbis`, `librespot-tremor`, `lewton` and `ogg` should be used directly. (breaking)
+- [connect, playback] Moved volume controls from `connect` to `playback` crate
+* [connect] Synchronize player volume with mixer volume on playback
+- [playback] Make cubic volume control available to all mixers with `--volume-ctrl cubic`
+- [playback] Normalize volumes to `[0.0..1.0]` instead of `[0..65535]` for greater precision and performance (breaking)
+- [playback] `alsamixer`: complete rewrite (breaking)
+- [playback] `alsamixer`: query card dB range for the `log` volume control unless specified otherwise
+- [playback] `alsamixer`: use `--device` name for `--mixer-card` unless specified otherwise
+
+### Fixed
+- [connect] Fix step size on volume up/down events
+- [playback] Fix `log` and `cubic` volume controls to be mute at zero volume
+- [playback] `alsamixer`: make `cubic` consistent between cards that report minimum volume as mute, and cards that report some dB value
+- [playback] `alsamixer`: make `--volume-ctrl {linear|log}` work as expected
 
 ### Removed
-
-* [librespot-audio] Removed `VorbisDecoder`, `VorbisError`, `AudioPacket`, `PassthroughDecoder`, `PassthroughError`, `AudioError`, `AudioDecoder` and the `convert` module from `librespot_audio`. The underlying crates `vorbis`, `librespot-tremor`, `lewton` and `ogg` should be used directly.
+- [connect] Removed no-op mixer started/stopped logic
+- [playback] `alsamixer`: removed `--mixer-linear-volume` option; use `--volume-ctrl linear` instead
 
 ### Fixed
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -3,7 +3,7 @@ use std::pin::Pin;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::context::StationContext;
-use crate::core::config::{ConnectConfig, VolumeCtrl};
+use crate::core::config::ConnectConfig;
 use crate::core::mercury::{MercuryError, MercurySender};
 use crate::core::session::Session;
 use crate::core::spotify_id::{SpotifyAudioType, SpotifyId, SpotifyIdError};
@@ -54,7 +54,6 @@ struct SpircTask {
     device: DeviceState,
     state: State,
     play_request_id: Option<u64>,
-    mixer_started: bool,
     play_status: SpircPlayStatus,
 
     subscription: BoxedStream<Frame>,
@@ -82,12 +81,14 @@ pub enum SpircCommand {
 }
 
 struct SpircTaskConfig {
-    volume_ctrl: VolumeCtrl,
     autoplay: bool,
 }
 
 const CONTEXT_TRACKS_HISTORY: usize = 10;
 const CONTEXT_FETCH_THRESHOLD: u32 = 5;
+
+const VOLUME_STEPS: i64 = 64;
+const VOLUME_STEP_SIZE: u16 = 1024; // (std::u16::MAX + 1) / VOLUME_STEPS
 
 pub struct Spirc {
     commands: mpsc::UnboundedSender<SpircCommand>,
@@ -163,10 +164,10 @@ fn initial_device_state(config: ConnectConfig) -> DeviceState {
                 msg.set_typ(protocol::spirc::CapabilityType::kVolumeSteps);
                 {
                     let repeated = msg.mut_intValue();
-                    if let VolumeCtrl::Fixed = config.volume_ctrl {
-                        repeated.push(0)
+                    if config.has_volume_ctrl {
+                        repeated.push(VOLUME_STEPS)
                     } else {
-                        repeated.push(64)
+                        repeated.push(0)
                     }
                 };
                 msg
@@ -214,36 +215,6 @@ fn initial_device_state(config: ConnectConfig) -> DeviceState {
     }
 }
 
-fn calc_logarithmic_volume(volume: u16) -> u16 {
-    // Volume conversion taken from https://www.dr-lex.be/info-stuff/volumecontrols.html#ideal2
-    // Convert the given volume [0..0xffff] to a dB gain
-    // We assume a dB range of 60dB.
-    // Use the equation: a * exp(b * x)
-    // in which a = IDEAL_FACTOR, b = 1/1000
-    const IDEAL_FACTOR: f64 = 6.908;
-    let normalized_volume = volume as f64 / std::u16::MAX as f64; // To get a value between 0 and 1
-
-    let mut val = std::u16::MAX;
-    // Prevent val > std::u16::MAX due to rounding errors
-    if normalized_volume < 0.999 {
-        let new_volume = (normalized_volume * IDEAL_FACTOR).exp() / 1000.0;
-        val = (new_volume * std::u16::MAX as f64) as u16;
-    }
-
-    debug!("input volume:{} to mixer: {}", volume, val);
-
-    // return the scale factor (0..0xffff) (equivalent to a voltage multiplier).
-    val
-}
-
-fn volume_to_mixer(volume: u16, volume_ctrl: &VolumeCtrl) -> u16 {
-    match volume_ctrl {
-        VolumeCtrl::Linear => volume,
-        VolumeCtrl::Log => calc_logarithmic_volume(volume),
-        VolumeCtrl::Fixed => volume,
-    }
-}
-
 fn url_encode(bytes: impl AsRef<[u8]>) -> String {
     form_urlencoded::byte_serialize(bytes.as_ref()).collect()
 }
@@ -280,9 +251,8 @@ impl Spirc {
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
 
-        let volume = config.volume;
+        let initial_volume = config.initial_volume;
         let task_config = SpircTaskConfig {
-            volume_ctrl: config.volume_ctrl.to_owned(),
             autoplay: config.autoplay,
         };
 
@@ -302,7 +272,6 @@ impl Spirc {
             device,
             state: initial_state(),
             play_request_id: None,
-            mixer_started: false,
             play_status: SpircPlayStatus::Stopped,
 
             subscription,
@@ -318,7 +287,12 @@ impl Spirc {
             context: None,
         };
 
-        task.set_volume(volume);
+        if let Some(volume) = initial_volume {
+            task.set_volume(volume);
+        } else {
+            let current_volume = task.mixer.volume();
+            task.set_volume(current_volume);
+        }
 
         let spirc = Spirc { commands: cmd_tx };
 
@@ -435,20 +409,6 @@ impl SpircTask {
         };
 
         dur.as_millis() as i64 + 1000 * self.session.time_delta()
-    }
-
-    fn ensure_mixer_started(&mut self) {
-        if !self.mixer_started {
-            self.mixer.start();
-            self.mixer_started = true;
-        }
-    }
-
-    fn ensure_mixer_stopped(&mut self) {
-        if self.mixer_started {
-            self.mixer.stop();
-            self.mixer_started = false;
-        }
     }
 
     fn update_state_position(&mut self, position_ms: u32) {
@@ -600,7 +560,6 @@ impl SpircTask {
                         _ => {
                             warn!("The player has stopped unexpectedly.");
                             self.state.set_status(PlayStatus::kPlayStatusStop);
-                            self.ensure_mixer_stopped();
                             self.notify(None, true);
                             self.play_status = SpircPlayStatus::Stopped;
                         }
@@ -659,7 +618,6 @@ impl SpircTask {
                     info!("No more tracks left in queue");
                     self.state.set_status(PlayStatus::kPlayStatusStop);
                     self.player.stop();
-                    self.mixer.stop();
                     self.play_status = SpircPlayStatus::Stopped;
                 }
 
@@ -767,7 +725,6 @@ impl SpircTask {
                     self.device.set_is_active(false);
                     self.state.set_status(PlayStatus::kPlayStatusStop);
                     self.player.stop();
-                    self.ensure_mixer_stopped();
                     self.play_status = SpircPlayStatus::Stopped;
                 }
             }
@@ -782,7 +739,11 @@ impl SpircTask {
                 position_ms,
                 preloading_of_next_track_triggered,
             } => {
-                self.ensure_mixer_started();
+                // Synchronize the volume from the mixer. This is useful on
+                // systems that can switch sources from and back to librespot.
+                let current_volume = self.mixer.volume();
+                self.set_volume(current_volume);
+
                 self.player.play();
                 self.state.set_status(PlayStatus::kPlayStatusPlay);
                 self.update_state_position(position_ms);
@@ -792,7 +753,6 @@ impl SpircTask {
                 };
             }
             SpircPlayStatus::LoadingPause { position_ms } => {
-                self.ensure_mixer_started();
                 self.player.play();
                 self.play_status = SpircPlayStatus::LoadingPlay { position_ms };
             }
@@ -962,7 +922,6 @@ impl SpircTask {
             self.state.set_playing_track_index(0);
             self.state.set_status(PlayStatus::kPlayStatusStop);
             self.player.stop();
-            self.ensure_mixer_stopped();
             self.play_status = SpircPlayStatus::Stopped;
         }
     }
@@ -1007,19 +966,13 @@ impl SpircTask {
     }
 
     fn handle_volume_up(&mut self) {
-        let mut volume: u32 = self.device.get_volume() as u32 + 4096;
-        if volume > 0xFFFF {
-            volume = 0xFFFF;
-        }
-        self.set_volume(volume as u16);
+        let volume = (self.device.get_volume() as u16).saturating_add(VOLUME_STEP_SIZE);
+        self.set_volume(volume);
     }
 
     fn handle_volume_down(&mut self) {
-        let mut volume: i32 = self.device.get_volume() as i32 - 4096;
-        if volume < 0 {
-            volume = 0;
-        }
-        self.set_volume(volume as u16);
+        let volume = (self.device.get_volume() as u16).saturating_sub(VOLUME_STEP_SIZE);
+        self.set_volume(volume);
     }
 
     fn handle_end_of_track(&mut self) {
@@ -1243,7 +1196,6 @@ impl SpircTask {
             None => {
                 self.state.set_status(PlayStatus::kPlayStatusStop);
                 self.player.stop();
-                self.ensure_mixer_stopped();
                 self.play_status = SpircPlayStatus::Stopped;
             }
         }
@@ -1273,8 +1225,7 @@ impl SpircTask {
 
     fn set_volume(&mut self, volume: u16) {
         self.device.set_volume(volume as u32);
-        self.mixer
-            .set_volume(volume_to_mixer(volume, &self.config.volume_ctrl));
+        self.mixer.set_volume(volume);
         if let Some(cache) = self.session.cache() {
             cache.save_volume(volume)
         }

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -108,33 +108,7 @@ impl Default for DeviceType {
 pub struct ConnectConfig {
     pub name: String,
     pub device_type: DeviceType,
-    pub volume: u16,
-    pub volume_ctrl: VolumeCtrl,
+    pub initial_volume: Option<u16>,
+    pub has_volume_ctrl: bool,
     pub autoplay: bool,
-}
-
-#[derive(Clone, Debug)]
-pub enum VolumeCtrl {
-    Linear,
-    Log,
-    Fixed,
-}
-
-impl FromStr for VolumeCtrl {
-    type Err = ();
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        use self::VolumeCtrl::*;
-        match s.to_lowercase().as_ref() {
-            "linear" => Ok(Linear),
-            "log" => Ok(Log),
-            "fixed" => Ok(Fixed),
-            _ => Err(()),
-        }
-    }
-}
-
-impl Default for VolumeCtrl {
-    fn default() -> VolumeCtrl {
-        VolumeCtrl::Log
-    }
 }

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -1,4 +1,4 @@
-use super::player::NormalisationData;
+use super::player::db_to_ratio;
 use crate::convert::i24;
 
 use std::convert::TryFrom;
@@ -80,7 +80,7 @@ pub enum NormalisationType {
 impl FromStr for NormalisationType {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_lowercase().as_ref() {
             "album" => Ok(Self::Album),
             "track" => Ok(Self::Track),
             _ => Err(()),
@@ -103,7 +103,7 @@ pub enum NormalisationMethod {
 impl FromStr for NormalisationMethod {
     type Err = ();
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        match s {
+        match s.to_lowercase().as_ref() {
             "basic" => Ok(Self::Basic),
             "dynamic" => Ok(Self::Dynamic),
             _ => Err(()),
@@ -120,6 +120,7 @@ impl Default for NormalisationMethod {
 #[derive(Clone, Debug)]
 pub struct PlayerConfig {
     pub bitrate: Bitrate,
+    pub gapless: bool,
     pub normalisation: bool,
     pub normalisation_type: NormalisationType,
     pub normalisation_method: NormalisationMethod,
@@ -128,7 +129,6 @@ pub struct PlayerConfig {
     pub normalisation_attack: f32,
     pub normalisation_release: f32,
     pub normalisation_knee: f32,
-    pub gapless: bool,
     pub passthrough: bool,
 }
 
@@ -136,16 +136,56 @@ impl Default for PlayerConfig {
     fn default() -> PlayerConfig {
         PlayerConfig {
             bitrate: Bitrate::default(),
+            gapless: true,
             normalisation: false,
             normalisation_type: NormalisationType::default(),
             normalisation_method: NormalisationMethod::default(),
             normalisation_pregain: 0.0,
-            normalisation_threshold: NormalisationData::db_to_ratio(-1.0),
+            normalisation_threshold: db_to_ratio(-1.0),
             normalisation_attack: 0.005,
             normalisation_release: 0.1,
             normalisation_knee: 1.0,
-            gapless: true,
             passthrough: false,
+        }
+    }
+}
+
+// fields are intended for volume control range in dB
+#[derive(Clone, Copy, Debug)]
+pub enum VolumeCtrl {
+    Cubic(f32),
+    Fixed,
+    Linear,
+    Log(f32),
+}
+
+impl FromStr for VolumeCtrl {
+    type Err = ();
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_str_with_range(s, Self::DEFAULT_DB_RANGE)
+    }
+}
+
+impl Default for VolumeCtrl {
+    fn default() -> VolumeCtrl {
+        VolumeCtrl::Log(Self::DEFAULT_DB_RANGE)
+    }
+}
+
+impl VolumeCtrl {
+    pub const MAX_VOLUME: u16 = std::u16::MAX;
+
+    // Taken from: https://www.dr-lex.be/info-stuff/volumecontrols.html
+    pub const DEFAULT_DB_RANGE: f32 = 60.0;
+
+    pub fn from_str_with_range(s: &str, db_range: f32) -> Result<Self, <Self as FromStr>::Err> {
+        use self::VolumeCtrl::*;
+        match s.to_lowercase().as_ref() {
+            "cubic" => Ok(Cubic(db_range)),
+            "fixed" => Ok(Fixed),
+            "linear" => Ok(Linear),
+            "log" => Ok(Log(db_range)),
+            _ => Err(()),
         }
     }
 }

--- a/playback/src/mixer/mappings.rs
+++ b/playback/src/mixer/mappings.rs
@@ -1,0 +1,163 @@
+use super::VolumeCtrl;
+use crate::player::db_to_ratio;
+
+pub trait MappedCtrl {
+    fn to_mapped(&self, volume: u16) -> f32;
+    fn from_mapped(&self, mapped_volume: f32) -> u16;
+
+    fn db_range(&self) -> f32;
+    fn set_db_range(&mut self, new_db_range: f32);
+    fn range_ok(&self) -> bool;
+}
+
+impl MappedCtrl for VolumeCtrl {
+    fn to_mapped(&self, volume: u16) -> f32 {
+        // More than just an optimization, this ensures that zero volume is
+        // really mute (both the log and cubic equations would otherwise not
+        // reach zero).
+        if volume == 0 {
+            return 0.0;
+        } else if volume == 1 {
+            // And limit in case of rounding errors (as is the case for log).
+            return 1.0;
+        }
+
+        let normalized_volume = volume as f32 / Self::MAX_VOLUME as f32;
+        let mapped_volume = if self.range_ok() {
+            match *self {
+                Self::Cubic(db_range) => {
+                    CubicMapping::linear_to_mapped(normalized_volume, db_range)
+                }
+                Self::Log(db_range) => LogMapping::linear_to_mapped(normalized_volume, db_range),
+                _ => normalized_volume,
+            }
+        } else {
+            // Ensure not to return -inf or NaN due to division by zero.
+            error!(
+                "{:?} does not work with 0 dB range, using linear mapping instead",
+                self
+            );
+            normalized_volume
+        };
+
+        debug!(
+            "Input volume {} mapped to: {:.2}%",
+            volume,
+            mapped_volume * 100.0
+        );
+
+        mapped_volume
+    }
+
+    fn from_mapped(&self, mapped_volume: f32) -> u16 {
+        // More than just an optimization, this ensures that zero mapped volume
+        // is unmapped to non-negative real numbers (otherwise the log and cubic
+        // equations would respectively return -inf and -1/9.)
+        if f32::abs(mapped_volume - 0.0) <= f32::EPSILON {
+            return 0;
+        } else if f32::abs(mapped_volume - 1.0) <= f32::EPSILON {
+            return Self::MAX_VOLUME;
+        }
+
+        let unmapped_volume = if self.range_ok() {
+            match *self {
+                Self::Cubic(db_range) => CubicMapping::mapped_to_linear(mapped_volume, db_range),
+                Self::Log(db_range) => LogMapping::mapped_to_linear(mapped_volume, db_range),
+                _ => mapped_volume,
+            }
+        } else {
+            // Ensure not to return -inf or NaN due to division by zero.
+            error!(
+                "{:?} does not work with 0 dB range, using linear mapping instead",
+                self
+            );
+            mapped_volume
+        };
+
+        (unmapped_volume * Self::MAX_VOLUME as f32) as u16
+    }
+
+    fn db_range(&self) -> f32 {
+        match *self {
+            Self::Fixed => 0.0,
+            Self::Linear => Self::DEFAULT_DB_RANGE, // arbitrary, could be anything > 0
+            Self::Log(db_range) | Self::Cubic(db_range) => db_range,
+        }
+    }
+
+    fn set_db_range(&mut self, new_db_range: f32) {
+        match self {
+            Self::Cubic(ref mut db_range) | Self::Log(ref mut db_range) => *db_range = new_db_range,
+            _ => error!("Invalid to set dB range for volume control type {:?}", self),
+        }
+
+        debug!("Volume control is now {:?}", self)
+    }
+
+    fn range_ok(&self) -> bool {
+        self.db_range() > 0.0 || matches!(self, Self::Fixed | Self::Linear)
+    }
+}
+
+pub trait VolumeMapping {
+    fn linear_to_mapped(unmapped_volume: f32, db_range: f32) -> f32;
+    fn mapped_to_linear(mapped_volume: f32, db_range: f32) -> f32;
+}
+
+// Volume conversion taken from: https://www.dr-lex.be/info-stuff/volumecontrols.html#ideal2
+//
+// As the human auditory system has a logarithmic sensitivity curve, this
+// mapping results in a near linear loudness experience with the listener.
+pub struct LogMapping {}
+impl VolumeMapping for LogMapping {
+    fn linear_to_mapped(normalized_volume: f32, db_range: f32) -> f32 {
+        let (db_ratio, ideal_factor) = Self::coefficients(db_range);
+        f32::exp(ideal_factor * normalized_volume) / db_ratio
+    }
+
+    fn mapped_to_linear(mapped_volume: f32, db_range: f32) -> f32 {
+        let (db_ratio, ideal_factor) = Self::coefficients(db_range);
+        f32::ln(db_ratio * mapped_volume) / ideal_factor
+    }
+}
+
+impl LogMapping {
+    fn coefficients(db_range: f32) -> (f32, f32) {
+        let db_ratio = db_to_ratio(db_range);
+        let ideal_factor = f32::ln(db_ratio);
+        (db_ratio, ideal_factor)
+    }
+}
+
+// Ported from: https://github.com/alsa-project/alsa-utils/blob/master/alsamixer/volume_mapping.c
+// which in turn was inspired by: https://www.robotplanet.dk/audio/audio_gui_design/
+//
+// Though this mapping is computationally less expensive than the logarithmic
+// mapping, it really does not matter as librespot memoizes the mapped value.
+// Use this mapping if you have some reason to mimic Alsa's native mixer or
+// prefer a more granular control in the upper volume range.
+//
+// Note: https://www.dr-lex.be/info-stuff/volumecontrols.html#ideal3 shows
+// better approximations to the logarithmic curve but because we only intend
+// to mimic Alsa here, we do not implement them. If your desire is to use a
+// logarithmic mapping, then use that volume control.
+pub struct CubicMapping {}
+impl VolumeMapping for CubicMapping {
+    fn linear_to_mapped(normalized_volume: f32, db_range: f32) -> f32 {
+        let min_norm = Self::min_norm(db_range);
+        f32::powi(normalized_volume * (1.0 - min_norm) + min_norm, 3)
+    }
+
+    fn mapped_to_linear(mapped_volume: f32, db_range: f32) -> f32 {
+        let min_norm = Self::min_norm(db_range);
+        (mapped_volume.powf(1.0 / 3.0) - min_norm) / (1.0 - min_norm)
+    }
+}
+
+impl CubicMapping {
+    fn min_norm(db_range: f32) -> f32 {
+        // Note that this 60.0 is unrelated to DEFAULT_DB_RANGE.
+        // Instead, it's the cubic voltage to dB ratio.
+        f32::powf(10.0, -1.0 * db_range / 60.0)
+    }
+}

--- a/playback/src/mixer/softmixer.rs
+++ b/playback/src/mixer/softmixer.rs
@@ -1,28 +1,40 @@
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::sync::Arc;
 
 use super::AudioFilter;
+use super::{MappedCtrl, VolumeCtrl};
 use super::{Mixer, MixerConfig};
 
 #[derive(Clone)]
 pub struct SoftMixer {
-    volume: Arc<AtomicUsize>,
+    // There is no AtomicF32, so we store the f32 as bits in a u32 field.
+    // It's much faster than a Mutex<f32>.
+    volume: Arc<AtomicU32>,
+    volume_ctrl: VolumeCtrl,
 }
 
 impl Mixer for SoftMixer {
-    fn open(_: Option<MixerConfig>) -> SoftMixer {
-        SoftMixer {
-            volume: Arc::new(AtomicUsize::new(0xFFFF)),
+    fn open(config: MixerConfig) -> Self {
+        let volume_ctrl = config.volume_ctrl;
+        info!("Mixing with softvol and volume control: {:?}", volume_ctrl);
+
+        Self {
+            volume: Arc::new(AtomicU32::new(f32::to_bits(0.5))),
+            volume_ctrl,
         }
     }
-    fn start(&self) {}
-    fn stop(&self) {}
+
     fn volume(&self) -> u16 {
-        self.volume.load(Ordering::Relaxed) as u16
+        let mapped_volume = f32::from_bits(self.volume.load(Ordering::Relaxed));
+        self.volume_ctrl.from_mapped(mapped_volume)
     }
+
     fn set_volume(&self, volume: u16) {
-        self.volume.store(volume as usize, Ordering::Relaxed);
+        let mapped_volume = self.volume_ctrl.to_mapped(volume);
+        self.volume
+            .store(mapped_volume.to_bits(), Ordering::Relaxed)
     }
+
     fn get_audio_filter(&self) -> Option<Box<dyn AudioFilter + Send>> {
         Some(Box::new(SoftVolumeApplier {
             volume: self.volume.clone(),
@@ -31,16 +43,15 @@ impl Mixer for SoftMixer {
 }
 
 struct SoftVolumeApplier {
-    volume: Arc<AtomicUsize>,
+    volume: Arc<AtomicU32>,
 }
 
 impl AudioFilter for SoftVolumeApplier {
     fn modify_stream(&self, data: &mut [f32]) {
-        let volume = self.volume.load(Ordering::Relaxed) as u16;
-        if volume != 0xFFFF {
-            let volume_factor = volume as f64 / 0xFFFF as f64;
+        let volume = f32::from_bits(self.volume.load(Ordering::Relaxed));
+        if volume < 1.0 {
             for x in data.iter_mut() {
-                *x = (*x as f64 * volume_factor) as f32;
+                *x = (*x as f64 * volume as f64) as f32;
             }
         }
     }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -30,7 +30,7 @@ pub const NUM_CHANNELS: u8 = 2;
 pub const SAMPLES_PER_SECOND: u32 = SAMPLE_RATE as u32 * NUM_CHANNELS as u32;
 
 const PRELOAD_NEXT_TRACK_BEFORE_END_DURATION_MS: u32 = 30000;
-const DB_VOLTAGE_RATIO: f32 = 20.0;
+pub const DB_VOLTAGE_RATIO: f32 = 20.0;
 
 pub struct Player {
     commands: Option<mpsc::UnboundedSender<PlayerCommand>>,
@@ -196,6 +196,14 @@ impl PlayerEvent {
 
 pub type PlayerEventChannel = mpsc::UnboundedReceiver<PlayerEvent>;
 
+pub fn db_to_ratio(db: f32) -> f32 {
+    f32::powf(10.0, db / DB_VOLTAGE_RATIO)
+}
+
+pub fn ratio_to_db(ratio: f32) -> f32 {
+    ratio.log10() * DB_VOLTAGE_RATIO
+}
+
 #[derive(Clone, Copy, Debug)]
 pub struct NormalisationData {
     track_gain_db: f32,
@@ -205,14 +213,6 @@ pub struct NormalisationData {
 }
 
 impl NormalisationData {
-    pub fn db_to_ratio(db: f32) -> f32 {
-        f32::powf(10.0, db / DB_VOLTAGE_RATIO)
-    }
-
-    pub fn ratio_to_db(ratio: f32) -> f32 {
-        ratio.log10() * DB_VOLTAGE_RATIO
-    }
-
     fn parse_from_file<T: Read + Seek>(mut file: T) -> io::Result<NormalisationData> {
         const SPOTIFY_NORMALIZATION_HEADER_START_OFFSET: u64 = 144;
         file.seek(SeekFrom::Start(SPOTIFY_NORMALIZATION_HEADER_START_OFFSET))?;
@@ -243,11 +243,11 @@ impl NormalisationData {
         };
 
         let normalisation_power = gain_db + config.normalisation_pregain;
-        let mut normalisation_factor = Self::db_to_ratio(normalisation_power);
+        let mut normalisation_factor = db_to_ratio(normalisation_power);
 
         if normalisation_factor * gain_peak > config.normalisation_threshold {
             let limited_normalisation_factor = config.normalisation_threshold / gain_peak;
-            let limited_normalisation_power = Self::ratio_to_db(limited_normalisation_factor);
+            let limited_normalisation_power = ratio_to_db(limited_normalisation_factor);
 
             if config.normalisation_method == NormalisationMethod::Basic {
                 warn!("Limiting gain to {:.2} dB for the duration of this track to stay under normalisation threshold.", limited_normalisation_power);
@@ -266,7 +266,7 @@ impl NormalisationData {
         debug!("Normalisation Type: {:?}", config.normalisation_type);
         debug!(
             "Normalisation Threshold: {:.1}",
-            Self::ratio_to_db(config.normalisation_threshold)
+            ratio_to_db(config.normalisation_threshold)
         );
         debug!("Normalisation Method: {:?}", config.normalisation_method);
         debug!("Normalisation Factor: {}", normalisation_factor);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,15 +9,16 @@ use url::Url;
 use librespot::connect::spirc::Spirc;
 use librespot::core::authentication::Credentials;
 use librespot::core::cache::Cache;
-use librespot::core::config::{ConnectConfig, DeviceType, SessionConfig, VolumeCtrl};
+use librespot::core::config::{ConnectConfig, DeviceType, SessionConfig};
 use librespot::core::session::Session;
 use librespot::core::version;
-use librespot::playback::audio_backend::{self, Sink, BACKENDS};
+use librespot::playback::audio_backend::{self, SinkBuilder, BACKENDS};
 use librespot::playback::config::{
-    AudioFormat, Bitrate, NormalisationMethod, NormalisationType, PlayerConfig,
+    AudioFormat, Bitrate, NormalisationMethod, NormalisationType, PlayerConfig, VolumeCtrl,
 };
-use librespot::playback::mixer::{self, Mixer, MixerConfig};
-use librespot::playback::player::{NormalisationData, Player};
+use librespot::playback::mixer::mappings::MappedCtrl;
+use librespot::playback::mixer::{self, MixerConfig, MixerFn};
+use librespot::playback::player::{db_to_ratio, Player};
 
 mod player_event_handler;
 use player_event_handler::{emit_sink_event, run_program_on_events};
@@ -66,7 +67,7 @@ fn setup_logging(verbose: bool) {
 }
 
 fn list_backends() {
-    println!("Available Backends : ");
+    println!("Available backends : ");
     for (&(name, _), idx) in BACKENDS.iter().zip(0..) {
         if idx == 0 {
             println!("- {} (default)", name);
@@ -172,11 +173,9 @@ fn print_version() {
 #[derive(Clone)]
 struct Setup {
     format: AudioFormat,
-    backend: fn(Option<String>, AudioFormat) -> Box<dyn Sink + 'static>,
+    backend: SinkBuilder,
     device: Option<String>,
-
-    mixer: fn(Option<MixerConfig>) -> Box<dyn Mixer>,
-
+    mixer: MixerFn,
     cache: Option<Cache>,
     player_config: PlayerConfig,
     session_config: SessionConfig,
@@ -266,11 +265,6 @@ fn get_setup(args: &[String]) -> Setup {
             "Alsa mixer index, Index of the cards mixer. Defaults to 0",
             "MIXER_INDEX",
         )
-        .optflag(
-            "",
-            "mixer-linear-volume",
-            "Disable alsa's mapped volume scale (cubic). Default false",
-        )
         .optopt(
             "",
             "initial-volume",
@@ -333,8 +327,14 @@ fn get_setup(args: &[String]) -> Setup {
         .optopt(
             "",
             "volume-ctrl",
-            "Volume control type - [linear, log, fixed]. Default is logarithmic",
+            "Volume control type - [cubic, fixed, linear, log]. Default is log.",
             "VOLUME_CTRL"
+        )
+		.optopt(
+ 			"",
+ 			"volume-range",
+ 			"Range of the volume control (dB). Defaults to 60 for softvol and for alsa what the mixer supports.",
+             "RANGE",
         )
         .optflag(
             "",
@@ -399,18 +399,55 @@ fn get_setup(args: &[String]) -> Setup {
     let mixer_name = matches.opt_str("mixer");
     let mixer = mixer::find(mixer_name.as_ref()).expect("Invalid mixer");
 
-    let mixer_config = MixerConfig {
-        card: matches
-            .opt_str("mixer-card")
-            .unwrap_or_else(|| String::from("default")),
-        mixer: matches
-            .opt_str("mixer-name")
-            .unwrap_or_else(|| String::from("PCM")),
-        index: matches
+    let mixer_config = {
+        let card = matches.opt_str("mixer-card").unwrap_or_else(|| {
+            if let Some(ref device_name) = device {
+                device_name.to_string()
+            } else {
+                String::from("default")
+            }
+        });
+        let index = matches
             .opt_str("mixer-index")
             .map(|index| index.parse::<u32>().unwrap())
-            .unwrap_or(0),
-        mapped_volume: !matches.opt_present("mixer-linear-volume"),
+            .unwrap_or(0);
+        let control = matches
+            .opt_str("mixer-name")
+            .unwrap_or_else(|| String::from("PCM"));
+        let mut volume_range = matches
+            .opt_str("volume-range")
+            .map(|range| range.parse::<f32>().unwrap())
+            .unwrap_or_else(|| match mixer_name.as_ref().map(AsRef::as_ref) {
+                Some("alsa") => 0.0, // let Alsa query the control
+                _ => VolumeCtrl::DEFAULT_DB_RANGE,
+            });
+        if volume_range < 0.0 {
+            // User might have specified range as minimum dB volume.
+            volume_range *= -1.0;
+            warn!(
+                "Please enter positive volume ranges only, assuming {:.2} dB",
+                volume_range
+            );
+        }
+        let volume_ctrl = matches
+            .opt_str("volume-ctrl")
+            .as_ref()
+            .map(|volume_ctrl| {
+                VolumeCtrl::from_str_with_range(volume_ctrl, volume_range)
+                    .expect("Invalid volume control type")
+            })
+            .unwrap_or_else(|| {
+                let mut volume_ctrl = VolumeCtrl::default();
+                volume_ctrl.set_db_range(volume_range);
+                volume_ctrl
+            });
+
+        MixerConfig {
+            card,
+            control,
+            index,
+            volume_ctrl,
+        }
     };
 
     let cache = {
@@ -459,15 +496,18 @@ fn get_setup(args: &[String]) -> Setup {
 
     let initial_volume = matches
         .opt_str("initial-volume")
-        .map(|volume| {
-            let volume = volume.parse::<u16>().unwrap();
+        .map(|initial_volume| {
+            let volume = initial_volume.parse::<u16>().unwrap();
             if volume > 100 {
-                panic!("Initial volume must be in the range 0-100");
+                error!("Initial volume must be in the range 0-100.");
+                // the cast will saturate, not necessary to take further action
             }
-            (volume as i32 * 0xFFFF / 100) as u16
+            (volume as f32 / 100.0 * VolumeCtrl::MAX_VOLUME as f32) as u16
         })
-        .or_else(|| cache.as_ref().and_then(Cache::volume))
-        .unwrap_or(0x8000);
+        .or_else(|| match mixer_name.as_ref().map(AsRef::as_ref) {
+            Some("alsa") => None,
+            _ => cache.as_ref().and_then(Cache::volume),
+        });
 
     let zeroconf_port = matches
         .opt_str("zeroconf-port")
@@ -506,15 +546,15 @@ fn get_setup(args: &[String]) -> Setup {
                     match Url::parse(&s) {
                         Ok(url) => {
                             if url.host().is_none() || url.port_or_known_default().is_none() {
-                                panic!("Invalid proxy url, only urls on the format \"http://host:port\" are allowed");
+                                panic!("Invalid proxy url, only URLs on the format \"http://host:port\" are allowed");
                             }
 
                             if url.scheme() != "http" {
-                                panic!("Only unsecure http:// proxies are supported");
+                                panic!("Only insecure http:// proxies are supported");
                             }
                             url
                         },
-                    Err(err) => panic!("Invalid proxy url: {}, only urls on the format \"http://host:port\" are allowed", err)
+                    Err(err) => panic!("Invalid proxy URL: {}, only URLs in the format \"http://host:port\" are allowed", err)
                     }
                 },
             ),
@@ -524,21 +564,14 @@ fn get_setup(args: &[String]) -> Setup {
         }
     };
 
-    let passthrough = matches.opt_present("passthrough");
-
     let player_config = {
         let bitrate = matches
             .opt_str("b")
             .as_ref()
             .map(|bitrate| Bitrate::from_str(bitrate).expect("Invalid bitrate"))
             .unwrap_or_default();
-        let gain_type = matches
-            .opt_str("normalisation-gain-type")
-            .as_ref()
-            .map(|gain_type| {
-                NormalisationType::from_str(gain_type).expect("Invalid normalisation type")
-            })
-            .unwrap_or_default();
+        let gapless = !matches.opt_present("disable-gapless");
+        let normalisation = matches.opt_present("enable-volume-normalisation");
         let normalisation_method = matches
             .opt_str("normalisation-method")
             .as_ref()
@@ -546,41 +579,52 @@ fn get_setup(args: &[String]) -> Setup {
                 NormalisationMethod::from_str(gain_type).expect("Invalid normalisation method")
             })
             .unwrap_or_default();
+        let normalisation_type = matches
+            .opt_str("normalisation-gain-type")
+            .as_ref()
+            .map(|gain_type| {
+                NormalisationType::from_str(gain_type).expect("Invalid normalisation type")
+            })
+            .unwrap_or_default();
+        let normalisation_pregain = matches
+            .opt_str("normalisation-pregain")
+            .map(|pregain| pregain.parse::<f32>().expect("Invalid pregain float value"))
+            .unwrap_or(PlayerConfig::default().normalisation_pregain);
+        let normalisation_threshold = matches
+            .opt_str("normalisation-threshold")
+            .map(|threshold| {
+                db_to_ratio(
+                    threshold
+                        .parse::<f32>()
+                        .expect("Invalid threshold float value"),
+                )
+            })
+            .unwrap_or(PlayerConfig::default().normalisation_threshold);
+        let normalisation_attack = matches
+            .opt_str("normalisation-attack")
+            .map(|attack| attack.parse::<f32>().expect("Invalid attack float value") / MILLIS)
+            .unwrap_or(PlayerConfig::default().normalisation_attack);
+        let normalisation_release = matches
+            .opt_str("normalisation-release")
+            .map(|release| release.parse::<f32>().expect("Invalid release float value") / MILLIS)
+            .unwrap_or(PlayerConfig::default().normalisation_release);
+        let normalisation_knee = matches
+            .opt_str("normalisation-knee")
+            .map(|knee| knee.parse::<f32>().expect("Invalid knee float value"))
+            .unwrap_or(PlayerConfig::default().normalisation_knee);
+        let passthrough = matches.opt_present("passthrough");
 
         PlayerConfig {
             bitrate,
-            gapless: !matches.opt_present("disable-gapless"),
-            normalisation: matches.opt_present("enable-volume-normalisation"),
+            gapless,
+            normalisation,
+            normalisation_type,
             normalisation_method,
-            normalisation_type: gain_type,
-            normalisation_pregain: matches
-                .opt_str("normalisation-pregain")
-                .map(|pregain| pregain.parse::<f32>().expect("Invalid pregain float value"))
-                .unwrap_or(PlayerConfig::default().normalisation_pregain),
-            normalisation_threshold: matches
-                .opt_str("normalisation-threshold")
-                .map(|threshold| {
-                    NormalisationData::db_to_ratio(
-                        threshold
-                            .parse::<f32>()
-                            .expect("Invalid threshold float value"),
-                    )
-                })
-                .unwrap_or(PlayerConfig::default().normalisation_threshold),
-            normalisation_attack: matches
-                .opt_str("normalisation-attack")
-                .map(|attack| attack.parse::<f32>().expect("Invalid attack float value") / MILLIS)
-                .unwrap_or(PlayerConfig::default().normalisation_attack),
-            normalisation_release: matches
-                .opt_str("normalisation-release")
-                .map(|release| {
-                    release.parse::<f32>().expect("Invalid release float value") / MILLIS
-                })
-                .unwrap_or(PlayerConfig::default().normalisation_release),
-            normalisation_knee: matches
-                .opt_str("normalisation-knee")
-                .map(|knee| knee.parse::<f32>().expect("Invalid knee float value"))
-                .unwrap_or(PlayerConfig::default().normalisation_knee),
+            normalisation_pregain,
+            normalisation_threshold,
+            normalisation_attack,
+            normalisation_release,
+            normalisation_knee,
             passthrough,
         }
     };
@@ -591,39 +635,37 @@ fn get_setup(args: &[String]) -> Setup {
             .as_ref()
             .map(|device_type| DeviceType::from_str(device_type).expect("Invalid device type"))
             .unwrap_or_default();
-
-        let volume_ctrl = matches
-            .opt_str("volume-ctrl")
-            .as_ref()
-            .map(|volume_ctrl| VolumeCtrl::from_str(volume_ctrl).expect("Invalid volume ctrl type"))
-            .unwrap_or_default();
+        let has_volume_ctrl = !matches!(mixer_config.volume_ctrl, VolumeCtrl::Fixed);
+        let autoplay = matches.opt_present("autoplay");
 
         ConnectConfig {
             name,
             device_type,
-            volume: initial_volume,
-            volume_ctrl,
-            autoplay: matches.opt_present("autoplay"),
+            initial_volume,
+            has_volume_ctrl,
+            autoplay,
         }
     };
 
     let enable_discovery = !matches.opt_present("disable-discovery");
+    let player_event_program = matches.opt_str("onevent");
+    let emit_sink_events = matches.opt_present("emit-sink-events");
 
     Setup {
         format,
         backend,
-        cache,
-        session_config,
-        player_config,
-        connect_config,
-        credentials,
         device,
+        mixer,
+        cache,
+        player_config,
+        session_config,
+        connect_config,
+        mixer_config,
+        credentials,
         enable_discovery,
         zeroconf_port,
-        mixer,
-        mixer_config,
-        player_event_program: matches.opt_str("onevent"),
-        emit_sink_events: matches.opt_present("emit-sink-events"),
+        player_event_program,
+        emit_sink_events,
     }
 }
 
@@ -697,7 +739,7 @@ async fn main() {
             session = &mut connecting, if !connecting.is_terminated() => match session {
                 Ok(session) => {
                     let mixer_config = setup.mixer_config.clone();
-                    let mixer = (setup.mixer)(Some(mixer_config));
+                    let mixer = (setup.mixer)(mixer_config);
                     let player_config = setup.player_config.clone();
                     let connect_config = setup.connect_config.clone();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -250,13 +250,13 @@ fn get_setup(args: &[String]) -> Setup {
         .optopt(
             "m",
             "mixer-name",
-            "Alsa mixer name, e.g \"PCM\" or \"Master\". Defaults to 'PCM'",
+            "Alsa mixer control, e.g. 'PCM' or 'Master'. Defaults to 'PCM'.",
             "MIXER_NAME",
         )
         .optopt(
             "",
             "mixer-card",
-            "Alsa mixer card, e.g \"hw:0\" or similar from `aplay -l`. Defaults to 'default' ",
+            "Alsa mixer card, e.g 'hw:0' or similar from `aplay -l`. Defaults to DEVICE if specified, 'default' otherwise.",
             "MIXER_CARD",
         )
         .optopt(
@@ -268,7 +268,7 @@ fn get_setup(args: &[String]) -> Setup {
         .optopt(
             "",
             "initial-volume",
-            "Initial volume in %, once connected (must be from 0 to 100)",
+            "Initial volume (%) once connected {0..100}. Defaults to 50 for softvol and for Alsa mixer the current volume.",
             "VOLUME",
         )
         .optopt(
@@ -327,14 +327,14 @@ fn get_setup(args: &[String]) -> Setup {
         .optopt(
             "",
             "volume-ctrl",
-            "Volume control type - [cubic, fixed, linear, log]. Default is log.",
+            "Volume control type {cubic|fixed|linear|log}. Defaults to log.",
             "VOLUME_CTRL"
         )
-		.optopt(
- 			"",
- 			"volume-range",
- 			"Range of the volume control (dB). Defaults to 60 for softvol and for alsa what the mixer supports.",
-             "RANGE",
+        .optopt(
+            "",
+            "volume-range",
+            "Range of the volume control (dB). Defaults to 60 for softvol and for Alsa mixer what the mixer supports.",
+            "RANGE",
         )
         .optflag(
             "",
@@ -423,7 +423,7 @@ fn get_setup(args: &[String]) -> Setup {
             });
         if volume_range < 0.0 {
             // User might have specified range as minimum dB volume.
-            volume_range *= -1.0;
+            volume_range = -volume_range;
             warn!(
                 "Please enter positive volume ranges only, assuming {:.2} dB",
                 volume_range
@@ -546,15 +546,15 @@ fn get_setup(args: &[String]) -> Setup {
                     match Url::parse(&s) {
                         Ok(url) => {
                             if url.host().is_none() || url.port_or_known_default().is_none() {
-                                panic!("Invalid proxy url, only URLs on the format \"http://host:port\" are allowed");
+                                panic!("Invalid proxy url, only urls on the format \"http://host:port\" are allowed");
                             }
 
                             if url.scheme() != "http" {
-                                panic!("Only insecure http:// proxies are supported");
+                                panic!("Only unsecure http:// proxies are supported");
                             }
                             url
                         },
-                    Err(err) => panic!("Invalid proxy URL: {}, only URLs in the format \"http://host:port\" are allowed", err)
+                    Err(err) => panic!("Invalid proxy url: {}, only urls on the format \"http://host:port\" are allowed", err)
                     }
                 },
             ),
@@ -575,8 +575,8 @@ fn get_setup(args: &[String]) -> Setup {
         let normalisation_method = matches
             .opt_str("normalisation-method")
             .as_ref()
-            .map(|gain_type| {
-                NormalisationMethod::from_str(gain_type).expect("Invalid normalisation method")
+            .map(|method| {
+                NormalisationMethod::from_str(method).expect("Invalid normalisation method")
             })
             .unwrap_or_default();
         let normalisation_type = matches


### PR DESCRIPTION
Well, what started as a couple of improvements to the log mapping, got me on the road to do a major refactoring of the volume control code after some inspiration by @ashthespy. I think there's quite a bit in here.

**Connect:**

 * Move volume computations from `connect` to `playback` crate. For `connect` it's only relevant if there's any sort of volume control so it can enable or disable volume sliders in Connect clients.

 * Fix volume step size on volume up/down events. Controlling an official Connect device with an official Connect client, I verified the number of steps (64) to be correct. Likewise the volume range from 0..65535 is correct. The volume step size then needs to be 1024 instead of 4096. The fact that this didn't bit us in the tail before, must be that these events are deprecated and official clients now first query the volume, then set the step size themselves.

 * Remove unused mixer started/stopped logic. They are no-ops for all of our mixers, so unless some downstream crate depends on this with a custom mixer, this should be safe. (At least Spotifyd doesn't.)

**Playback:**

 * Provide all four volume controls cubic, fixed, linear and log to both `softvol` and `alsamixer`. Previously, cubic was available only on `alsamixer`.

 * Fix log and cubic controls to be actually mute at zero setting (they weren't; `exp(0) != 0`).

 * Add a command line option `--volume-range` to set the dB range for cubic and log mappings. Defaults to 60 for `softvol` and 0 for `alsamixer` meaning to let Alsa query the device. This behavior can be overridden by specifying a custom volume range. _Edit: the default in `dev` for the log volume control already is 60._

 * The above point also means the log mapping is a bit more precise even for the default case.

 * Completely rewrite `alsamixer` for much more legible code. ~~The new `VolumeMapping` made it so we could largely eliminate dealing with both dB and raw values.~~ _Edit: dB API reintroduced because not all cards scale linearly._

 * _Edit:_ Make `--volume-ctrl {linear|cubic}` work as expected on `alsamixer` without the `--mixer-linear-volume` cruft.

 * _Edit:_ Get the initial volume from Alsa, if not specified otherwise.

 * _Edit:_ Fix the cubic mapping for cards that report their minimum volume is mute, instead of their actual lowest dB setting before that.
 
 * The new `alsamixer` also supports querying dB ranges for Alsa softvol controls (previously only hardware controls were supported). _Edit: the use for this is to match the curves of the log and cubic mappings with what was configured for Alsa softvol._

 * _Edit:_ If no `--mixer-card` is set on the command line, then `alsamixer` now first uses the device name that was configured for the backend, or 'default' otherwise (previously it did not use the backend device name).
  
 * Our own `softvol` now stores normalized values in `f32` so we spare the CPU cycles of normalizing for every packet.

 * Some minor code cleanups.

**Main:**

 * Improved consistency of the getopts descriptions. The parameters themselves remain unchanged other than removing the Alsa-only `--mixer-linear-volume` and adding the optional `--volume-range`.

 * Some code cleanups, in particular moving the struct variables above the instantiation.

Special thanks to: @JasonLG1979 for extensive testing and suggestions on Alsa