### PR TITLE
Remove warning for Rodio on Alsa (fixed upstream)

### DIFF
--- a/playback/src/audio_backend/rodio.rs
+++ b/playback/src/audio_backend/rodio.rs
@@ -152,19 +152,14 @@ fn create_sink(
 }
 
 pub fn open(host: cpal::Host, device: Option<String>, format: AudioFormat) -> RodioSink {
-    debug!(
-        "Using rodio sink with format {:?} and cpal host: {}",
+    info!(
+        "Using Rodio sink with format {:?} and cpal host: {}",
         format,
         host.id().name()
     );
 
-    match format {
-        AudioFormat::F32 => {
-            #[cfg(target_os = "linux")]
-            warn!("Rodio output to Alsa is known to cause garbled sound, consider using `--backend alsa`")
-        }
-        AudioFormat::S16 => (),
-        _ => unimplemented!("Rodio currently only supports F32 and S16 formats"),
+    if format != AudioFormat::S16 && format != AudioFormat::F32 {
+        unimplemented!("Rodio currently only supports F32 and S16 formats");
     }
 
     let (sink, stream) = create_sink(&host, device).unwrap();


### PR DESCRIPTION
Fixed with the recent bump of the Rodio and cpal crates.