### PR TITLE
Fix basic normalisation

### DIFF
--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1161,8 +1161,8 @@ impl PlayerInternal {
                         }
 
                         if self.config.normalisation
-                            && (f32::abs(normalisation_factor - 1.0) < f32::EPSILON
-                                || self.config.normalisation_method != NormalisationMethod::Basic)
+                            && !(f32::abs(normalisation_factor - 1.0) <= f32::EPSILON
+                                && self.config.normalisation_method == NormalisationMethod::Basic)
                         {
                             for sample in data.iter_mut() {
                                 let mut actual_normalisation_factor = normalisation_factor;

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -246,7 +246,7 @@ impl NormalisationData {
             let limited_normalisation_power = Self::ratio_to_db(limited_normalisation_factor);
 
             if config.normalisation_method == NormalisationMethod::Basic {
-                warn!("Limiting gain to {:.2} for the duration of this track to stay under normalisation threshold.", limited_normalisation_power);
+                warn!("Limiting gain to {:.2} dB for the duration of this track to stay under normalisation threshold.", limited_normalisation_power);
                 normalisation_factor = limited_normalisation_factor;
             } else {
                 warn!(


### PR DESCRIPTION
b4f9ae31e2832ba6c0bd753eeb36902dd2cb07cc unintentionally broke the basic limiter by testing for equality instead of inequality. In case of the basic limiter, it should confirm that `normalisation_factor <> 1.0` or else don't bother iterating over the samples. This fixes that and slightly changes the `if` statement to better state that intention.