### PR TITLE
Add timeout to connection test

### DIFF
--- a/core/tests/connect.rs
+++ b/core/tests/connect.rs
@@ -1,18 +1,26 @@
+use std::time::Duration;
+
 use librespot_core::authentication::Credentials;
 use librespot_core::config::SessionConfig;
 use librespot_core::session::Session;
 
+use tokio::time::timeout;
+
 #[tokio::test]
 async fn test_connection() {
-    let result = Session::connect(
-        SessionConfig::default(),
-        Credentials::with_password("test", "test"),
-        None,
-    )
-    .await;
+    timeout(Duration::from_secs(30), async {
+        let result = Session::connect(
+            SessionConfig::default(),
+            Credentials::with_password("test", "test"),
+            None,
+        )
+        .await;
 
-    match result {
-        Ok(_) => panic!("Authentication succeeded despite of bad credentials."),
-        Err(e) => assert_eq!(e.to_string(), "Login failed with reason: Bad credentials"),
-    };
+        match result {
+            Ok(_) => panic!("Authentication succeeded despite of bad credentials."),
+            Err(e) => assert_eq!(e.to_string(), "Login failed with reason: Bad credentials"),
+        }
+    })
+    .await
+    .unwrap();
 }


### PR DESCRIPTION
Adds a timeout of 30 secs to the test in `core/tests/connect.rs`. I don't know how often and why this test hangs up, but it happened once in #675.