### PR TITLE
Revert "Use `ready!` macro to reduce boilerplate"

### DIFF
--- a/core/src/mercury/mod.rs
+++ b/core/src/mercury/mod.rs
@@ -7,7 +7,6 @@ use std::task::Poll;
 
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
-use futures_util::FutureExt;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::protocol;
@@ -42,7 +41,11 @@ impl<T> Future for MercuryFuture<T> {
     type Output = Result<T, MercuryError>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        self.receiver.poll_unpin(cx).map_err(|_| MercuryError)?
+        match Pin::new(&mut self.receiver).poll(cx) {
+            Poll::Ready(Ok(x)) => Poll::Ready(x),
+            Poll::Ready(Err(_)) => Poll::Ready(Err(MercuryError)),
+            Poll::Pending => Poll::Pending,
+        }
     }
 }
 

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -10,7 +10,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
 use futures_core::TryStream;
-use futures_util::{future, ready, StreamExt, TryStreamExt};
+use futures_util::{future, StreamExt, TryStreamExt};
 use once_cell::sync::OnceCell;
 use thiserror::Error;
 use tokio::sync::mpsc;
@@ -287,17 +287,18 @@ where
         };
 
         loop {
-            let (cmd, data) = match ready!(self.0.try_poll_next_unpin(cx)) {
-                Some(Ok(t)) => t,
-                None => {
+            let (cmd, data) = match self.0.try_poll_next_unpin(cx) {
+                Poll::Ready(Some(Ok(t))) => t,
+                Poll::Ready(None) => {
                     warn!("Connection to server closed.");
                     session.shutdown();
                     return Poll::Ready(Ok(()));
                 }
-                Some(Err(e)) => {
+                Poll::Ready(Some(Err(e))) => {
                     session.shutdown();
                     return Poll::Ready(Err(e));
                 }
+                Poll::Pending => return Poll::Pending,
             };
 
             session.dispatch(cmd, data);


### PR DESCRIPTION
Reverts librespot-org/librespot#699. Same mistake as #708.