### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
It's a bot by GitHub which checks for dependency updates and creates PRs if something is out of date. No need to check for updates manually all the time. Spotifyd and ncspot use it as well.