### PR TITLE
Unpin protobuf version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1270,7 +1270,6 @@ version = "0.2.0"
 dependencies = [
  "glob",
  "protobuf",
- "protobuf-codegen",
  "protobuf-codegen-pure",
 ]
 
@@ -1789,24 +1788,24 @@ dependencies = [
 
 [[package]]
 name = "protobuf"
-version = "2.14.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e86d370532557ae7573551a1ec8235a0f8d6cb276c7c9e6aa490b511c447485"
+checksum = "45604fc7a88158e7d514d8e22e14ac746081e7a70d7690074dd0029ee37458d6"
 
 [[package]]
 name = "protobuf-codegen"
-version = "2.14.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de113bba758ccf2c1ef816b127c958001b7831136c9bc3f8e9ec695ac4e82b0c"
+checksum = "cb87f342b585958c1c086313dbc468dcac3edf5e90362111c26d7a58127ac095"
 dependencies = [
  "protobuf",
 ]
 
 [[package]]
 name = "protobuf-codegen-pure"
-version = "2.14.0"
+version = "2.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d1a4febc73bf0cada1d77c459a0c8e5973179f1cfd5b0f1ab789d45b17b6440"
+checksum = "8ca6e0e2f898f7856a6328650abc9b2df71b7c1a5f39be0800d19051ad0214b2"
 dependencies = [
  "protobuf",
  "protobuf-codegen",

--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -17,7 +17,7 @@ hmac = "0.11"
 hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
 libmdns = "0.6"
 log = "0.4"
-protobuf = "~2.14.0"
+protobuf = "2.14.0"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0.25"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,7 +32,7 @@ num-traits = "0.2"
 once_cell = "1.5.2"
 pbkdf2 = { version = "0.8", default-features = false, features = ["hmac"] }
 priority-queue = "1.1"
-protobuf = "~2.14.0"
+protobuf = "2.14.0"
 rand = "0.8"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -10,7 +10,7 @@ edition = "2018"
 [dependencies]
 async-trait = "0.1"
 byteorder = "1.3"
-protobuf = "~2.14.0"
+protobuf = "2.14.0"
 log = "0.4"
 
 [dependencies.librespot-core]

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -9,9 +9,8 @@ repository = "https://github.com/librespot-org/librespot"
 edition = "2018"
 
 [dependencies]
-protobuf = "~2.14.0"
+protobuf = "2.14.0"
 
 [build-dependencies]
-protobuf-codegen-pure = "~2.14.0"
-protobuf-codegen = "~2.14.0"
+protobuf-codegen-pure = "2.14.0"
 glob = "0.3.0"

--- a/protocol/build.rs
+++ b/protocol/build.rs
@@ -1,5 +1,3 @@
-extern crate glob;
-
 use std::{
     env, fs,
     ops::Deref,


### PR DESCRIPTION
The version of protobuf was unnecessarily pinned. There were some issues (#460), but e97911e3cfcb85b524e844d0ef5417bbee1e4970 fixed them. It remained pinned only because of the MSRV 1.40 at that time. 