### PR TITLE
Add empty changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since v0.2.0.
+
+## [Unreleased]
+
+## [0.2.0] - 2021-05-04
+
+## [0.1.6] - 2021-02-22
+
+## [0.1.5] - 2021-02-21
+
+## [0.1.3] - 2020-07-29
+
+## [0.1.2] - 2020-07-22
+
+## [0.1.1] - 2020-01-30
+
+## [0.1.0] - 2019-11-06
+
+[unreleased]: https://github.com/librespot-org/librespot/compare/v0.2.0..HEAD
+[0.2.0]: https://github.com/librespot-org/librespot/compare/v0.1.6..v0.2.0
+[0.1.6]: https://github.com/librespot-org/librespot/compare/v0.1.5..v0.1.6
+[0.1.5]: https://github.com/librespot-org/librespot/compare/v0.1.3..v0.1.5
+[0.1.3]: https://github.com/librespot-org/librespot/compare/v0.1.2..v0.1.3
+[0.1.2]: https://github.com/librespot-org/librespot/compare/v0.1.1..v0.1.2
+[0.1.1]: https://github.com/librespot-org/librespot/compare/v0.1.0..v0.1.1
+[0.1.0]: https://github.com/librespot-org/librespot/releases/tag/v0.1.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,8 @@ In order to prepare for a PR, you will need to do a couple of things first:
 
 Make any changes that you are going to make to the code, but do not commit yet.
 
+Unless your changes are negligible, please add an entry in the "Unreleased" section of `CHANGELOG.md`. Refer to [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) for instructions on how this entry should look like.
+
 Make sure that the code is correctly formatted by running:
 ```bash
 cargo +stable fmt --all
@@ -43,7 +45,7 @@ cargo build
 Once it has built, and you have confirmed there are no warnings or errors, you should commit your changes.
 
 ```bash
-git commit -a -m “My fancy fix”
+git commit -a -m "My fancy fix"
 ```
 
 **N.B.** Please, for the sake of a readable history, do not bundle multiple major changes into a single commit. Instead, break it up into multiple commits.


### PR DESCRIPTION
Adds a `CHANGELOG.md` file to this repository. The format is based on "Keep a changelog", the link in the file contains more information. 

If this kind of changelog is added, every PR that makes a somewhat bigger change should also update the changelog accordingly. With this policy it should be possible to have a comprehensive changelog for every release.