### PR TITLE
Add indirect dependencies to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,5 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    allow:
+      dependency-type: "all"


### PR DESCRIPTION
Currently, dependabot will only check dependencies that are explicitly mentioned in a Cargo.toml file. Therefore, indirect dependencies contained in Cargo.lock will never be updated. This is an attempt to fix it.