### PR TITLE
Remove dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    allow:
-      - dependency-type: "all"


### PR DESCRIPTION
As pointed out in #730, dependabot is not configurable enough to meet all the ideas I had, so I suggest removing it for now. It won't be too hard to check for updates once a week or month. Maybe some day, if some additional configurations methods are added, we could add it back.