### PR TITLE
Fix warnings

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -272,7 +272,7 @@ impl Spirc {
                 .flatten_stream()
                 .map(|response| -> Frame {
                     let data = response.payload.first().unwrap();
-                    protobuf::parse_from_bytes(data).unwrap()
+                    Frame::parse_from_bytes(data).unwrap()
                 }),
         );
 

--- a/core/src/connection/handshake.rs
+++ b/core/src/connection/handshake.rs
@@ -102,7 +102,7 @@ where
     let header = read_into_accumulator(connection, 4, acc).await?;
     let size = BigEndian::read_u32(header) as usize;
     let data = read_into_accumulator(connection, size - 4, acc).await?;
-    let message = protobuf::parse_from_bytes(data).unwrap();
+    let message = M::parse_from_bytes(data).unwrap();
     Ok(message)
 }
 

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -146,7 +146,7 @@ pub async fn authenticate(
     let (cmd, data) = transport.next().await.expect("EOF")?;
     match cmd {
         0xac => {
-            let welcome_data: APWelcome = protobuf::parse_from_bytes(data.as_ref())?;
+            let welcome_data = APWelcome::parse_from_bytes(data.as_ref())?;
 
             let reusable_credentials = Credentials {
                 username: welcome_data.get_canonical_username().to_owned(),
@@ -157,7 +157,7 @@ pub async fn authenticate(
             Ok(reusable_credentials)
         }
         0xad => {
-            let error_data: APLoginFailed = protobuf::parse_from_bytes(data.as_ref())?;
+            let error_data = APLoginFailed::parse_from_bytes(data.as_ref())?;
             Err(error_data.into())
         }
         _ => {

--- a/core/src/mercury/mod.rs
+++ b/core/src/mercury/mod.rs
@@ -8,6 +8,7 @@ use std::task::Poll;
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
 use futures_util::FutureExt;
+use protobuf::Message;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::protocol;
@@ -123,8 +124,8 @@ impl MercuryManager {
                     if !response.payload.is_empty() {
                         // Old subscription protocol, watch the provided list of URIs
                         for sub in response.payload {
-                            let mut sub: protocol::pubsub::Subscription =
-                                protobuf::parse_from_bytes(&sub).unwrap();
+                            let mut sub =
+                                protocol::pubsub::Subscription::parse_from_bytes(&sub).unwrap();
                             let sub_uri = sub.take_uri();
 
                             debug!("subscribed sub_uri={}", sub_uri);
@@ -192,7 +193,7 @@ impl MercuryManager {
 
     fn complete_request(&self, cmd: u8, mut pending: MercuryPending) {
         let header_data = pending.parts.remove(0);
-        let header: protocol::mercury::Header = protobuf::parse_from_bytes(&header_data).unwrap();
+        let header = protocol::mercury::Header::parse_from_bytes(&header_data).unwrap();
 
         let response = MercuryResponse {
             uri: header.get_uri().to_string(),

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::wrong_self_convention)]
+
 use std::convert::TryInto;
 use std::fmt;
 

--- a/examples/playlist_tracks.rs
+++ b/examples/playlist_tracks.rs
@@ -1,4 +1,3 @@
-use env_logger;
 use std::env;
 
 use librespot::core::authentication::Credentials;

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -14,6 +14,7 @@ use librespot_core::mercury::MercuryError;
 use librespot_core::session::Session;
 use librespot_core::spotify_id::{FileId, SpotifyAudioType, SpotifyId};
 use librespot_protocol as protocol;
+use protobuf::Message;
 
 pub use crate::protocol::metadata::AudioFile_Format as FileFormat;
 
@@ -123,7 +124,7 @@ pub trait Metadata: Send + Sized + 'static {
         let uri = Self::request_url(id);
         let response = session.mercury().get(uri).await?;
         let data = response.payload.first().expect("Empty payload");
-        let msg: Self::Message = protobuf::parse_from_bytes(data).unwrap();
+        let msg = Self::Message::parse_from_bytes(data).unwrap();
 
         Ok(Self::parse(&msg, &session))
     }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -538,10 +538,10 @@ impl PlayerState {
                     play_request_id,
                     loaded_track: PlayerLoadedTrackData {
                         decoder,
-                        duration_ms,
-                        bytes_per_second,
                         normalisation_factor,
                         stream_loader_controller,
+                        bytes_per_second,
+                        duration_ms,
                         stream_position_pcm,
                     },
                 };


### PR DESCRIPTION
Fixes the protobuf deprecation warnings (closes #723), and fixes some new clippy warnings.

I disabled the `wrong_self_convention` lint. There are two possible fixes: Rename some functions of `SpotifyId` and `FileId` or remove the `Copy` trait for those structs. 

I would tend to prefer the latter, as they're quite big. 17 bytes and 20 bytes are 3 registers on 64-bit machines and requiring explicit clones wouldn't be that bad. But that's not in the scope of this little PR.

I will merge it right away if the tests pass, @sashahilton00 