### PR TITLE
Adjust arg types of `Credentials::with_blob`

### DIFF
--- a/discovery/src/server.rs
+++ b/discovery/src/server.rs
@@ -129,11 +129,10 @@ impl RequestHandler {
                 GenericArray::from_slice(iv),
             );
             cipher.apply_keystream(&mut data);
-            String::from_utf8(data).unwrap()
+            data
         };
 
-        let credentials =
-            Credentials::with_blob(username.to_string(), &decrypted, &self.config.device_id);
+        let credentials = Credentials::with_blob(username, &decrypted, &self.config.device_id);
 
         self.tx.send(credentials).unwrap();
 


### PR DESCRIPTION
... to avoid redundant utf-8 checking