### PR TITLE
Remove feature gate around `apresolve`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ version = "0.2.0"
 [dependencies.librespot-core]
 path = "core"
 version = "0.2.0"
-features = ["apresolve"]
 
 [dependencies.librespot-discovery]
 path = "discovery"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,8 +23,8 @@ futures-util = { version = "0.3", default-features = false, features = ["alloc",
 hmac = "0.11"
 httparse = "1.3"
 http = "0.2"
-hyper = { version = "0.14", optional = true, features = ["client", "tcp", "http1"] }
-hyper-proxy = { version = "0.9.1", optional = true, default-features = false }
+hyper = { version = "0.14", features = ["client", "tcp", "http1"] }
+hyper-proxy = { version = "0.9.1", default-features = false }
 log = "0.4"
 num-bigint = { version = "0.4", features = ["rand"] }
 num-integer = "0.1"
@@ -52,6 +52,3 @@ vergen = "3.0.4"
 [dev-dependencies]
 env_logger = "0.8"
 tokio = {version = "1.0", features = ["macros"] }
-
-[features]
-apresolve = ["hyper", "hyper-proxy"]

--- a/core/src/apresolve.rs
+++ b/core/src/apresolve.rs
@@ -6,9 +6,8 @@ use hyper_proxy::{Intercept, Proxy, ProxyConnector};
 use serde::Deserialize;
 use url::Url;
 
-use super::AP_FALLBACK;
-
 const APRESOLVE_ENDPOINT: &str = "http://apresolve.spotify.com:80";
+const AP_FALLBACK: &str = "ap.spotify.com:443";
 
 #[derive(Clone, Debug, Deserialize)]
 struct ApResolveData {

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -8,6 +8,7 @@ use librespot_protocol as protocol;
 #[macro_use]
 mod component;
 
+mod apresolve;
 pub mod audio_key;
 pub mod authentication;
 pub mod cache;
@@ -24,15 +25,3 @@ pub mod spotify_id;
 #[doc(hidden)]
 pub mod util;
 pub mod version;
-
-const AP_FALLBACK: &str = "ap.spotify.com:443";
-
-#[cfg(feature = "apresolve")]
-mod apresolve;
-
-#[cfg(not(feature = "apresolve"))]
-mod apresolve {
-    pub async fn apresolve(_: Option<&url::Url>, _: Option<u16>) -> String {
-        return super::AP_FALLBACK.into();
-    }
-}


### PR DESCRIPTION
The feature gate around `apresolve` made it so downstream packages had to opt-in, and always fell back to `ap.spotify.com`. It was enabled by default in `librespot` though.

 See: https://github.com/hrkfdn/ncspot/issues/535.
