### PR TITLE
Add CPAL backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b700ce4376041dcd0a327fd0097c41095743c4c8af8887265942faf1100bd040"
 
 [[package]]
+name = "cache-padded"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "631ae5198c9be5e753e5cc215e1bd73c2b466a3565173db433f52bb9d3e66dba"
+
+[[package]]
 name = "cc"
 version = "1.0.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,6 +1305,7 @@ dependencies = [
  "rand",
  "rand_distr",
  "rodio",
+ "rtrb",
  "sdl2",
  "shell-words",
  "thiserror",
@@ -1942,6 +1949,15 @@ checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
 dependencies = [
  "libc",
  "winapi",
+]
+
+[[package]]
+name = "rtrb"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2a6de2cc3b28e99ea0f6de26b7b53a10998028812326fab55f1e318512ba426"
+dependencies = [
+ "cache-padded",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,13 +66,14 @@ sha-1 = "0.9"
 [features]
 alsa-backend = ["librespot-playback/alsa-backend"]
 cpal-backend = ["librespot-playback/cpal-backend"]
+cpaljack-backend = ["librespot-playback/cpaljack-backend"]
+gstreamer-backend = ["librespot-playback/gstreamer-backend"]
+jackaudio-backend = ["librespot-playback/jackaudio-backend"]
 portaudio-backend = ["librespot-playback/portaudio-backend"]
 pulseaudio-backend = ["librespot-playback/pulseaudio-backend"]
-jackaudio-backend = ["librespot-playback/jackaudio-backend"]
 rodio-backend = ["librespot-playback/rodio-backend"]
 rodiojack-backend = ["librespot-playback/rodiojack-backend"]
 sdl-backend = ["librespot-playback/sdl-backend"]
-gstreamer-backend = ["librespot-playback/gstreamer-backend"]
 
 with-dns-sd = ["librespot-discovery/with-dns-sd"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,7 @@ sha-1 = "0.9"
 
 [features]
 alsa-backend = ["librespot-playback/alsa-backend"]
+cpal-backend = ["librespot-playback/cpal-backend"]
 portaudio-backend = ["librespot-playback/portaudio-backend"]
 pulseaudio-backend = ["librespot-playback/pulseaudio-backend"]
 jackaudio-backend = ["librespot-playback/jackaudio-backend"]

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -40,6 +40,7 @@ glib            = { version = "0.10", optional = true }
 # Rodio dependencies
 rodio           = { version = "0.14", optional = true, default-features = false }
 cpal            = { version = "0.13", optional = true }
+rtrb            = { version = "0.1", optional = true }
 thiserror       = { version = "1", optional = true }
 
 # Decoder
@@ -52,6 +53,7 @@ rand_distr = "0.4"
 
 [features]
 alsa-backend = ["alsa"]
+cpal-backend = ["cpal", "thiserror", "rtrb"]
 portaudio-backend = ["portaudio-rs"]
 pulseaudio-backend = ["libpulse-binding", "libpulse-simple-binding"]
 jackaudio-backend = ["jack"]

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -37,7 +37,7 @@ gstreamer       = { version = "0.16", optional = true }
 gstreamer-app   = { version = "0.16", optional = true }
 glib            = { version = "0.10", optional = true }
 
-# Rodio dependencies
+# Rodio and CPAL dependencies
 rodio           = { version = "0.14", optional = true, default-features = false }
 cpal            = { version = "0.13", optional = true }
 rtrb            = { version = "0.1", optional = true }
@@ -54,10 +54,11 @@ rand_distr = "0.4"
 [features]
 alsa-backend = ["alsa"]
 cpal-backend = ["cpal", "thiserror", "rtrb"]
+cpaljack-backend = ["cpal/jack", "thiserror", "rtrb"]
+gstreamer-backend = ["gstreamer", "gstreamer-app", "glib"]
+jackaudio-backend = ["jack"]
 portaudio-backend = ["portaudio-rs"]
 pulseaudio-backend = ["libpulse-binding", "libpulse-simple-binding"]
-jackaudio-backend = ["jack"]
 rodio-backend = ["rodio", "cpal", "thiserror"]
 rodiojack-backend = ["rodio", "cpal/jack", "thiserror"]
 sdl-backend = ["sdl2"]
-gstreamer-backend = ["gstreamer", "gstreamer-app", "glib"]

--- a/playback/src/audio_backend/cpal.rs
+++ b/playback/src/audio_backend/cpal.rs
@@ -1,0 +1,222 @@
+use std::process::exit;
+use std::{io, thread, time};
+
+use cpal::traits::{DeviceTrait, HostTrait};
+use cpal::{Sample, StreamConfig};
+use rtrb::{Consumer, RingBuffer};
+use thiserror::Error;
+
+use super::Sink;
+use crate::config::AudioFormat;
+use crate::convert::Converter;
+use crate::decoder::AudioPacket;
+use crate::{NUM_CHANNELS, SAMPLE_RATE};
+
+#[derive(Debug, Error)]
+pub enum CpalError {
+    #[error("Cpal: no device available")]
+    NoDeviceAvailable,
+    #[error("Cpal: device \"{0}\" is not available")]
+    DeviceNotAvailable(String),
+    #[error("Cannot get audio devices: {0}")]
+    DevicesError(#[from] cpal::DevicesError),
+}
+
+pub struct CpalSink<S: Sample> {
+    _stream: cpal::Stream,
+    format: AudioFormat,
+    sample_tx: rtrb::Producer<S>,
+}
+
+fn list_formats(device: &cpal::Device) {
+    match device.default_output_config() {
+        Ok(cfg) => {
+            debug!("  Default config:");
+            debug!("    {:?}", cfg);
+        }
+        Err(e) => {
+            // Use loglevel debug, since even the output is only debug
+            debug!("Error getting default cpal Sink config: {}", e);
+        }
+    };
+
+    match device.supported_output_configs() {
+        Ok(mut cfgs) => {
+            if let Some(first) = cfgs.next() {
+                debug!("  Available configs:");
+                debug!("    {:?}", first);
+            } else {
+                return;
+            }
+
+            for cfg in cfgs {
+                debug!("    {:?}", cfg);
+            }
+        }
+        Err(e) => {
+            debug!("Error getting supported cpal Sink configs: {}", e);
+        }
+    }
+}
+
+fn list_outputs(host: &cpal::Host) -> Result<(), cpal::DevicesError> {
+    let mut default_device_name = None;
+
+    if let Some(default_device) = host.default_output_device() {
+        default_device_name = default_device.name().ok();
+        println!(
+            "Default Audio Device:\n  {}",
+            default_device_name.as_deref().unwrap_or("[unknown name]")
+        );
+
+        list_formats(&default_device);
+
+        println!("Other Available Audio Devices:");
+    } else {
+        warn!("No default device was found");
+    }
+
+    for device in host.output_devices()? {
+        match device.name() {
+            Ok(name) if Some(&name) == default_device_name.as_ref() => (),
+            Ok(name) => {
+                println!("  {}", name);
+                list_formats(&device);
+            }
+            Err(e) => {
+                warn!("Cannot get device name: {}", e);
+                println!("   [unknown name]");
+                list_formats(&device);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn get_device(host: &cpal::Host, device: Option<String>) -> Result<cpal::Device, CpalError> {
+    let device = match device {
+        Some(ask) if &ask == "?" => {
+            let exit_code = match list_outputs(host) {
+                Ok(()) => 0,
+                Err(e) => {
+                    error!("{}", e);
+                    1
+                }
+            };
+            exit(exit_code)
+        }
+        Some(device_name) => {
+            host.output_devices()?
+                .find(|d| d.name().ok().map_or(false, |name| name == device_name)) // Ignore devices for which getting name fails
+                .ok_or(CpalError::DeviceNotAvailable(device_name))?
+        }
+        None => host
+            .default_output_device()
+            .ok_or(CpalError::NoDeviceAvailable)?,
+    };
+
+    info!(
+        "Using audio device: {}",
+        device.name().as_deref().unwrap_or("[unknown name]")
+    );
+
+    Ok(device)
+}
+
+fn data_callback<T: Sample>(
+    mut consumer: Consumer<T>,
+) -> impl FnMut(&mut [T], &cpal::OutputCallbackInfo) {
+    let silence = <T as cpal::Sample>::from(&0i16);
+
+    move |buf: &mut [T], _| {
+        let mut chunk = consumer.read_chunk(consumer.slots()).unwrap();
+
+        if chunk.len() >= buf.len() {
+            buf.iter_mut()
+                .zip(&mut chunk)
+                .for_each(|(to, from)| *to = *from);
+            chunk.commit_iterated();
+        } else {
+            buf.fill(silence);
+        }
+    }
+}
+
+pub fn open(dev: Option<String>, format: AudioFormat) -> Box<dyn Sink> {
+    fn open_with_format<T: Sample + Send + 'static>(
+        dev: Option<String>,
+        format: AudioFormat,
+    ) -> CpalSink<T> {
+        let host = cpal::default_host();
+        info!(
+            "Using cpal sink with format {:?} and host: {}",
+            format,
+            host.id().name()
+        );
+
+        let device = get_device(&host, dev).unwrap();
+
+        let (sample_tx, sample_rx) = RingBuffer::new(4 * 4096).split();
+
+        let stream = device
+            .build_output_stream::<T, _, _>(
+                &StreamConfig {
+                    buffer_size: cpal::BufferSize::Default,
+                    channels: NUM_CHANNELS as u16,
+                    sample_rate: cpal::SampleRate(SAMPLE_RATE),
+                },
+                data_callback(sample_rx),
+                |e| error!("Sink error: {}", e),
+            )
+            .unwrap();
+
+        debug!("cpal sink was created");
+
+        CpalSink {
+            _stream: stream,
+            format,
+            sample_tx,
+        }
+    }
+
+    match format {
+        AudioFormat::F32 => Box::new(open_with_format::<f32>(dev, format)),
+        AudioFormat::S16 => Box::new(open_with_format::<i16>(dev, format)),
+        _ => unimplemented!("cpal currently only supports F32 and S16 formats"),
+    }
+}
+
+impl<S: Sample + Default> Sink for CpalSink<S> {
+    fn write(&mut self, packet: &AudioPacket, converter: &mut Converter) -> io::Result<()> {
+        macro_rules! write_sink {
+            ($samples: expr) => {
+                let mut write_to = loop {
+                    match self.sample_tx.write_chunk($samples.len()) {
+                        Ok(x) => break x,
+                        Err(_) => thread::sleep(time::Duration::from_millis(10)),
+                    }
+                };
+                (&mut write_to)
+                    .zip($samples.iter())
+                    .for_each(|(to, from)| *to = S::from(from));
+                write_to.commit_iterated();
+            };
+        }
+
+        let samples = packet.samples();
+        match self.format {
+            AudioFormat::F32 => {
+                let samples_f32: &[f32] = &converter.f64_to_f32(samples);
+                write_sink!(samples_f32);
+            }
+            AudioFormat::S16 => {
+                let samples_s16: &[i16] = &converter.f64_to_s16(samples);
+                write_sink!(samples_s16);
+            }
+            _ => unreachable!(),
+        }
+
+        Ok(())
+    }
+}

--- a/playback/src/audio_backend/cpal.rs
+++ b/playback/src/audio_backend/cpal.rs
@@ -151,7 +151,8 @@ pub fn open(dev: Option<String>, format: AudioFormat) -> Box<dyn Sink> {
         device: cpal::Device,
         format: AudioFormat,
     ) -> CpalSink<T> {
-        let (sample_tx, sample_rx) = RingBuffer::new(4 * 4096).split();
+        let ring_buffer_size = NUM_CHANNELS as usize * 1024 * format.size();
+        let (sample_tx, sample_rx) = RingBuffer::new(ring_buffer_size).split();
 
         let stream = device
             .build_output_stream::<T, _, _>(

--- a/playback/src/audio_backend/cpal.rs
+++ b/playback/src/audio_backend/cpal.rs
@@ -137,8 +137,11 @@ fn data_callback<T: Sample>(
                 .zip(&mut chunk)
                 .for_each(|(to, from)| *to = *from);
             chunk.commit_iterated();
-        } else {
-            buf.fill(silence);
+        } else if let Some((last, elements)) = buf.split_last_mut() {
+            for element in elements {
+                element.clone_from(&silence);
+            }
+            *last = silence
         }
     }
 }

--- a/playback/src/audio_backend/cpal.rs
+++ b/playback/src/audio_backend/cpal.rs
@@ -176,8 +176,7 @@ fn create_sink<T: Sample + Send + 'static>(
     device: cpal::Device,
     format: AudioFormat,
 ) -> CpalSink<T> {
-    let ring_buffer_size = NUM_CHANNELS as usize * 1024 * format.size();
-    let (sample_tx, sample_rx) = RingBuffer::new(ring_buffer_size).split();
+    let (sample_tx, sample_rx) = RingBuffer::new(NUM_CHANNELS as usize * 2048).split();
 
     let stream = device
         .build_output_stream::<T, _, _>(

--- a/playback/src/audio_backend/mod.rs
+++ b/playback/src/audio_backend/mod.rs
@@ -113,7 +113,9 @@ pub const BACKENDS: &[(&str, SinkBuilder)] = &[
     #[cfg(feature = "alsa-backend")]
     (AlsaSink::NAME, mk_sink::<AlsaSink>),
     #[cfg(feature = "cpal-backend")]
-    ("cpal", cpal::open),
+    (cpal::NAME, cpal::mk_cpal),
+    #[cfg(feature = "cpaljack-backend")]
+    (cpal::JACK_NAME, cpal::mk_cpaljack),
     #[cfg(feature = "portaudio-backend")]
     (PortAudioSink::NAME, mk_sink::<PortAudioSink>),
     #[cfg(feature = "pulseaudio-backend")]

--- a/playback/src/audio_backend/mod.rs
+++ b/playback/src/audio_backend/mod.rs
@@ -68,6 +68,9 @@ mod alsa;
 #[cfg(feature = "alsa-backend")]
 use self::alsa::AlsaSink;
 
+#[cfg(feature = "cpal-backend")]
+mod cpal;
+
 #[cfg(feature = "portaudio-backend")]
 mod portaudio;
 #[cfg(feature = "portaudio-backend")]
@@ -109,6 +112,8 @@ pub const BACKENDS: &[(&str, SinkBuilder)] = &[
     (RodioSink::NAME, rodio::mk_rodio), // default goes first
     #[cfg(feature = "alsa-backend")]
     (AlsaSink::NAME, mk_sink::<AlsaSink>),
+    #[cfg(feature = "cpal-backend")]
+    ("cpal", cpal::open),
     #[cfg(feature = "portaudio-backend")]
     (PortAudioSink::NAME, mk_sink::<PortAudioSink>),
     #[cfg(feature = "pulseaudio-backend")]

--- a/playback/src/audio_backend/mod.rs
+++ b/playback/src/audio_backend/mod.rs
@@ -68,7 +68,7 @@ mod alsa;
 #[cfg(feature = "alsa-backend")]
 use self::alsa::AlsaSink;
 
-#[cfg(feature = "cpal-backend")]
+#[cfg(any(feature = "cpal-backend", feature = "cpaljack-backend"))]
 mod cpal;
 
 #[cfg(feature = "portaudio-backend")]


### PR DESCRIPTION
This is a working CPAL backend based on the extensive initial work by @Johannesd3 (thanks!).

The intention is to deprecate Rodio in favour of CPAL: Rodio is based on CPAL, and builds on it, but there is nothing extra we need in Rodio that isn't already in CPAL. This has been discussed in various places, notably #648 and https://github.com/librespot-org/librespot/discussions/734#discussioncomment-725127.

So far I have successfully tested this backend on Linux (`S16`, `F32`) and macOS (`F32`).

### Todo

- [x] Pass the build on MSRV
- [ ] Test on Windows (help needed: I don't have Windows machines to compile on)
- [x] Refactor slightly to bring it more in line with the other backends
- [x] Implement a companion `CpalJack` variant (like we also have `RodioJack`)
- [ ] Promote it to default backend status

### Open questions

 1. What do we want to do with the Rodio backend for the upcoming release: replace it with CPAL? Or keep it around for planned deprecation in a release sometime later?
 
 2. ~~The code that checks whether the requested audio format is available, or falls back to the system default otherwise, actually returns the highest supported audio format by default. Currently `librespot` defaults to `S16` but this code gives another opportunity: we could change format selection to an `Option<AudioFormat>`, selecting the highest quality by default unless specified otherwise. For other backends, that do not easily support querying supported formats, we could still default to `S16` unless specified otherwise. Should we get this in or leave it be? This would be another PR but I'd first like to hear your thoughts before I put time in.~~ No it would work with idiosyncracies for every backend and not be very transparent to the user.

 3. For an out-of-the-box experience on Windows, we need resampling. Do we want to add this, or forget about this PR and stick with Rodio? See: https://github.com/librespot-org/librespot/pull/786#issuecomment-852891109
