### PR TITLE
Add comment setter to PassthroughDecoder

### DIFF
--- a/playback/src/decoder/passthrough_decoder.rs
+++ b/playback/src/decoder/passthrough_decoder.rs
@@ -68,6 +68,10 @@ impl<R: Read + Seek> PassthroughDecoder<R> {
             bos: false,
         })
     }
+
+    pub fn set_comment(&mut self, comment: Box<[u8]>) {
+        self.comment = comment;
+    }
 }
 
 impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {


### PR DESCRIPTION
*from https://github.com/librespot-org/librespot/discussions/790:*
The new `PassthroughDecoder` is very useful, but in my case it's still missing a feature that I require: access to the `comment` field. My use case is to overwrite the comment header in order to add metadata for my audio player.

This PR adds a setter function for the `comment` field of the `PassthroughDecoder`.

Feel free to close or change if's not aligned with the requirements.