### PR TITLE
Better errors in PulseAudio backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] `alsamixer`: make `--volume-ctrl {linear|log}` work as expected
 - [playback] `alsa`, `gstreamer`, `pulseaudio`: always output in native endianness
 - [playback] `alsa`: revert buffer size to ~500 ms
-- [playback] `alsa`, `pipe`: better error handling
+- [playback] `alsa`, `pipe`, `pulseaudio`: better error handling
 
 ## [0.2.0] - 2021-05-04
 

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -53,7 +53,7 @@ rand_distr = "0.4"
 [features]
 alsa-backend = ["alsa", "thiserror"]
 portaudio-backend = ["portaudio-rs"]
-pulseaudio-backend = ["libpulse-binding", "libpulse-simple-binding"]
+pulseaudio-backend = ["libpulse-binding", "libpulse-simple-binding", "thiserror"]
 jackaudio-backend = ["jack"]
 rodio-backend = ["rodio", "cpal", "thiserror"]
 rodiojack-backend = ["rodio", "cpal/jack", "thiserror"]

--- a/playback/src/audio_backend/pulseaudio.rs
+++ b/playback/src/audio_backend/pulseaudio.rs
@@ -14,34 +14,23 @@ pub struct PulseAudioSink {
     s: Option<Simple>,
     device: Option<String>,
     format: AudioFormat,
-    pulse_format: pulse::sample::Format,
 }
 
 impl Open for PulseAudioSink {
     fn open(device: Option<String>, format: AudioFormat) -> Self {
         let mut actual_format = format;
+
         if actual_format == AudioFormat::F64 {
-            warn!("PulseAudio currently does not support F64 output, falling back to F32");
+            warn!("PulseAudio currently does not support F64 output");
             actual_format = AudioFormat::F32;
         }
 
-        // PulseAudio calls S24 and S24_3 different from the rest of the world
-        let pulse_format = match actual_format {
-            AudioFormat::F32 => pulse::sample::Format::FLOAT32NE,
-            AudioFormat::S32 => pulse::sample::Format::S32NE,
-            AudioFormat::S24 => pulse::sample::Format::S24_32NE,
-            AudioFormat::S24_3 => pulse::sample::Format::S24NE,
-            AudioFormat::S16 => pulse::sample::Format::S16NE,
-            _ => unreachable!(),
-        };
-
-        info!("Using PulseAudio sink with format: {:?}", actual_format);
+        info!("Using PulseAudioSink with format: {:?}", actual_format);
 
         Self {
             s: None,
             device,
             format: actual_format,
-            pulse_format: pulse_format,
         }
     }
 }
@@ -52,8 +41,18 @@ impl Sink for PulseAudioSink {
             return Ok(());
         }
 
+        // PulseAudio calls S24 and S24_3 different from the rest of the world
+        let pulse_format = match self.format {
+            AudioFormat::F32 => pulse::sample::Format::FLOAT32NE,
+            AudioFormat::S32 => pulse::sample::Format::S32NE,
+            AudioFormat::S24 => pulse::sample::Format::S24_32NE,
+            AudioFormat::S24_3 => pulse::sample::Format::S24NE,
+            AudioFormat::S16 => pulse::sample::Format::S16NE,
+            _ => unreachable!(),
+        };
+
         let ss = pulse::sample::Spec {
-            format: self.pulse_format,
+            format: pulse_format,
             channels: NUM_CHANNELS,
             rate: SAMPLE_RATE,
         };
@@ -61,31 +60,54 @@ impl Sink for PulseAudioSink {
         if !ss.is_valid() {
             return Err(io::Error::new(
                 io::ErrorKind::Other,
-                "Invalid PulseAudio sample spec",
+                "Error starting PulseAudioSink, invalid PulseAudio sample spec",
             ));
         }
 
-        let device = self.device.as_deref();
         let result = Simple::new(
-            None,                // Use the default server.
-            APP_NAME,            // Our application's name.
-            Direction::Playback, // Direction.
-            device,              // Our device (sink) name.
-            STREAM_NAME,         // Description of our stream.
-            &ss,                 // Our sample format.
-            None,                // Use default channel map.
-            None,                // Use default buffering attributes.
+            None,                   // Use the default server.
+            APP_NAME,               // Our application's name.
+            Direction::Playback,    // Direction.
+            self.device.as_deref(), // Our device (sink) name.
+            STREAM_NAME,            // Description of our stream.
+            &ss,                    // Our sample format.
+            None,                   // Use default channel map.
+            None,                   // Use default buffering attributes.
         );
+
         match result {
             Ok(s) => {
                 self.s = Some(s);
-                Ok(())
             }
-            Err(e) => Err(io::Error::new(io::ErrorKind::ConnectionRefused, e)),
+            Err(e) => {
+                return Err(io::Error::new(
+                    io::ErrorKind::ConnectionRefused,
+                    format!(
+                        "Error starting PulseAudioSink, could not connect to PulseAudio server, {}",
+                        e
+                    ),
+                ));
+            }
         }
+
+        Ok(())
     }
 
     fn stop(&mut self) -> io::Result<()> {
+        match &self.s {
+            Some(s) => {
+                if let Err(e) = s.drain() {
+                    return Err(io::Error::new(io::ErrorKind::Other, format!("Error stopping PulseAudioSink, failed to drain PulseAudio server buffer, {}", e)));
+                }
+            }
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "Error stopping PulseAudioSink, Not connected to PulseAudio server",
+                ));
+            }
+        }
+
         self.s = None;
         Ok(())
     }
@@ -95,17 +117,27 @@ impl Sink for PulseAudioSink {
 
 impl SinkAsBytes for PulseAudioSink {
     fn write_bytes(&mut self, data: &[u8]) -> io::Result<()> {
-        if let Some(s) = &self.s {
-            match s.write(data) {
-                Ok(_) => Ok(()),
-                Err(e) => Err(io::Error::new(io::ErrorKind::BrokenPipe, e)),
+        match &self.s {
+            Some(s) => {
+                if let Err(e) = s.write(data) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::BrokenPipe,
+                        format!(
+                            "Error writing from PulseAudioSink to PulseAudio server, {}",
+                            e
+                        ),
+                    ));
+                }
             }
-        } else {
-            Err(io::Error::new(
-                io::ErrorKind::NotConnected,
-                "Not connected to PulseAudio",
-            ))
+            None => {
+                return Err(io::Error::new(
+                    io::ErrorKind::NotConnected,
+                    "Error writing from PulseAudioSink to PulseAudio, Not connected to PulseAudio server",
+                ));
+            }
         }
+
+        Ok(())
     }
 }
 

--- a/playback/src/audio_backend/pulseaudio.rs
+++ b/playback/src/audio_backend/pulseaudio.rs
@@ -19,10 +19,8 @@ enum PulseError {
     ConnectionRefused(PAErr),
     #[error("Error stopping PulseAudioSink, failed to drain PulseAudio server buffer, {0}")]
     DrainFailure(PAErr),
-    #[error("Error stopping PulseAudioSink, Not connected to PulseAudio server")]
-    NotConnectedOnStop,
-    #[error("Error writing from PulseAudioSink to PulseAudio, Not connected to PulseAudio server")]
-    NotConnectedOnWrite,
+    #[error("Error in PulseAudioSink, Not connected to PulseAudio server")]
+    ServerNone,
     #[error("Error writing from PulseAudioSink to PulseAudio server, {0}")]
     OnWrite(PAErr),
 }
@@ -120,7 +118,7 @@ impl Sink for PulseAudioSink {
             None => {
                 return Err(io::Error::new(
                     io::ErrorKind::NotConnected,
-                    PulseError::NotConnectedOnStop,
+                    PulseError::ServerNone,
                 ));
             }
         }
@@ -146,7 +144,7 @@ impl SinkAsBytes for PulseAudioSink {
             None => {
                 return Err(io::Error::new(
                     io::ErrorKind::NotConnected,
-                    PulseError::NotConnectedOnWrite,
+                    PulseError::ServerNone,
                 ));
             }
         }


### PR DESCRIPTION
* Use F32 if a user requests F64 (F64 is not supported by PulseAudio)
* Move all code that can fail to `start` where errors can be returned to prevent a panic!
* Remove unneeded unwraps.

Combined with the ability to gracefully exit on error player in https://github.com/librespot-org/librespot/pull/797 this should about do it for for the whole "never panic!" idea as far as the PulseAudio backend is concerned. 