### PR TITLE
Better errors in pipe backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,7 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] `alsamixer`: make `--volume-ctrl {linear|log}` work as expected
 - [playback] `alsa`, `gstreamer`, `pulseaudio`: always output in native endianness
 - [playback] `alsa`: revert buffer size to ~500 ms
-- [playback] `alsa`: better error handling
+- [playback] `alsa`, `pipe`: better error handling
 
 ## [0.2.0] - 2021-05-04
 

--- a/playback/src/audio_backend/pipe.rs
+++ b/playback/src/audio_backend/pipe.rs
@@ -16,7 +16,7 @@ impl Open for StdoutSink {
         info!("Using pipe sink with format: {:?}", format);
         Self {
             output: None,
-            path: path,
+            path,
             format,
         }
     }

--- a/playback/src/audio_backend/pipe.rs
+++ b/playback/src/audio_backend/pipe.rs
@@ -6,31 +6,57 @@ use std::fs::OpenOptions;
 use std::io::{self, Write};
 
 pub struct StdoutSink {
-    output: Box<dyn Write>,
+    output: Option<Box<dyn Write>>,
+    path: Option<String>,
     format: AudioFormat,
 }
 
 impl Open for StdoutSink {
     fn open(path: Option<String>, format: AudioFormat) -> Self {
         info!("Using pipe sink with format: {:?}", format);
-
-        let output: Box<dyn Write> = match path {
-            Some(path) => Box::new(OpenOptions::new().write(true).open(path).unwrap()),
-            _ => Box::new(io::stdout()),
-        };
-
-        Self { output, format }
+        Self {
+            output: None,
+            path: path,
+            format,
+        }
     }
 }
 
 impl Sink for StdoutSink {
+    fn start(&mut self) -> io::Result<()> {
+        if self.output.is_none() {
+            let output: Box<dyn Write> = match self.path.as_deref() {
+                Some(path) => {
+                    let open_op = OpenOptions::new()
+                        .write(true)
+                        .open(path)
+                        .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                    Box::new(open_op)
+                }
+                None => Box::new(io::stdout()),
+            };
+
+            self.output = Some(output);
+        }
+
+        Ok(())
+    }
+
     sink_as_bytes!();
 }
 
 impl SinkAsBytes for StdoutSink {
     fn write_bytes(&mut self, data: &[u8]) -> io::Result<()> {
-        self.output.write_all(data)?;
-        self.output.flush()?;
+        match self.output.as_deref_mut() {
+            Some(output) => {
+                output.write_all(data)?;
+                output.flush()?;
+            }
+            None => {
+                return Err(io::Error::new(io::ErrorKind::Other, "Output is None"));
+            }
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
* Move all code that can fail to `start` where errors can be returned to prevent a panic!
* Replace unwrap

Another backend fix much the same as the PulseAudio backend fix combined with the ability to gracefully exit on error player in #797 this should about do it for for the whole "never panic!" idea as far as the pipe backend is concerned.