### PR TITLE
Make CI ignore things that should not trigger build tests (reprise)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,11 +11,11 @@ on:
         "Cargo.lock",
         "rustfmt.toml",
         ".github/workflows/*",
-        "!**.md",
+        "!*.md",
         "!contrib/*",
         "!docs/*",
         "!LICENSE",
-        "!**.sh",
+        "!*.sh",
       ]
   pull_request:
     paths:
@@ -25,11 +25,11 @@ on:
         "Cargo.lock",
         "rustfmt.toml",
         ".github/workflows/*",
-        "!**.md",
+        "!*.md",
         "!contrib/*",
         "!docs/*",
         "!LICENSE",
-        "!**.sh",
+        "!*.sh",
       ]
   schedule:
     # Run CI every week


### PR DESCRIPTION
Let's try just 1 `*`. I'm sorry I'm relying on Google and the github docs so I can't really test this myself very well as CI doesn't run on my fork.