### PR TITLE
make convert and decoder public as they are needed by Sink traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] `alsamixer`: query card dB range for the `log` volume control unless specified otherwise
 - [playback] `alsamixer`: use `--device` name for `--mixer-card` unless specified otherwise
 - [playback] `player`: consider errors in `sink.start`, `sink.stop` and `sink.write` fatal and `exit(1)` (breaking)
-- [playback] make `convert` and `decoder` public so you can implement your own `Sink`
+- [playback] `player`: make `convert` and `decoder` public so you can implement your own `Sink`
 
 ### Deprecated
 - [connect] The `discovery` module was deprecated in favor of the `librespot-discovery` crate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] `alsamixer`: query card dB range for the `log` volume control unless specified otherwise
 - [playback] `alsamixer`: use `--device` name for `--mixer-card` unless specified otherwise
 - [playback] `player`: consider errors in `sink.start`, `sink.stop` and `sink.write` fatal and `exit(1)` (breaking)
+- [playback] make `convert` and `decoder` public so you can implement your own `Sink`
 
 ### Deprecated
 - [connect] The `discovery` module was deprecated in favor of the `librespot-discovery` crate

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -7,8 +7,8 @@ use librespot_metadata as metadata;
 
 pub mod audio_backend;
 pub mod config;
-mod convert;
-mod decoder;
+pub mod convert;
+pub mod decoder;
 pub mod dither;
 pub mod mixer;
 pub mod player;


### PR DESCRIPTION
the Sink traits use AudioPacket and Converter and these are currently not public. This prevents you to implement your own sink implementation. I need this to integrate Librespot in my own player