### PR TITLE
Improve player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] Add `--format F64` (supported by Alsa and GStreamer only)
 
 ### Changed
-- [audio, playback] Moved `VorbisDecoder`, `VorbisError`, `AudioPacket`, `PassthroughDecoder`, `PassthroughError`, `AudioError`, `AudioDecoder` and the `convert` module from `librespot-audio` to `librespot-playback`. The underlying crates `vorbis`, `librespot-tremor`, `lewton` and `ogg` should be used directly. (breaking)
+- [audio, playback] Moved `VorbisDecoder`, `VorbisError`, `AudioPacket`, `PassthroughDecoder`, `PassthroughError`, `DecoderError`, `AudioDecoder` and the `convert` module from `librespot-audio` to `librespot-playback`. The underlying crates `vorbis`, `librespot-tremor`, `lewton` and `ogg` should be used directly. (breaking)
 - [audio, playback] Use `Duration` for time constants and functions (breaking)
 - [connect, playback] Moved volume controls from `librespot-connect` to `librespot-playback` crate
 - [connect] Synchronize player volume with mixer volume on playback

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -25,6 +25,7 @@ byteorder = "1.4"
 shell-words = "1.0.0"
 tokio = { version = "1", features = ["sync"] }
 zerocopy = { version = "0.3" }
+thiserror = { version = "1" }
 
 # Backends
 alsa            = { version = "0.5", optional = true }
@@ -40,7 +41,6 @@ glib            = { version = "0.10", optional = true }
 # Rodio dependencies
 rodio           = { version = "0.14", optional = true, default-features = false }
 cpal            = { version = "0.13", optional = true }
-thiserror       = { version = "1", optional = true }
 
 # Decoder
 lewton = "0.10"
@@ -51,11 +51,11 @@ rand = "0.8"
 rand_distr = "0.4"
 
 [features]
-alsa-backend = ["alsa", "thiserror"]
+alsa-backend = ["alsa"]
 portaudio-backend = ["portaudio-rs"]
-pulseaudio-backend = ["libpulse-binding", "libpulse-simple-binding", "thiserror"]
+pulseaudio-backend = ["libpulse-binding", "libpulse-simple-binding"]
 jackaudio-backend = ["jack"]
-rodio-backend = ["rodio", "cpal", "thiserror"]
-rodiojack-backend = ["rodio", "cpal/jack", "thiserror"]
+rodio-backend = ["rodio", "cpal"]
+rodiojack-backend = ["rodio", "cpal/jack"]
 sdl-backend = ["sdl2"]
 gstreamer-backend = ["gstreamer", "gstreamer-app", "glib"]

--- a/playback/src/audio_backend/jackaudio.rs
+++ b/playback/src/audio_backend/jackaudio.rs
@@ -71,7 +71,10 @@ impl Open for JackSink {
 
 impl Sink for JackSink {
     fn write(&mut self, packet: &AudioPacket, converter: &mut Converter) -> io::Result<()> {
-        let samples_f32: &[f32] = &converter.f64_to_f32(packet.samples());
+        let samples = packet
+            .samples()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+        let samples_f32: &[f32] = &converter.f64_to_f32(samples);
         for sample in samples_f32.iter() {
             let res = self.send.send(*sample);
             if res.is_err() {

--- a/playback/src/audio_backend/portaudio.rs
+++ b/playback/src/audio_backend/portaudio.rs
@@ -148,7 +148,10 @@ impl<'a> Sink for PortAudioSink<'a> {
             };
         }
 
-        let samples = packet.samples();
+        let samples = packet
+            .samples()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
+
         let result = match self {
             Self::F32(stream, _parameters) => {
                 let samples_f32: &[f32] = &converter.f64_to_f32(samples);

--- a/playback/src/audio_backend/rodio.rs
+++ b/playback/src/audio_backend/rodio.rs
@@ -176,7 +176,9 @@ pub fn open(host: cpal::Host, device: Option<String>, format: AudioFormat) -> Ro
 
 impl Sink for RodioSink {
     fn write(&mut self, packet: &AudioPacket, converter: &mut Converter) -> io::Result<()> {
-        let samples = packet.samples();
+        let samples = packet
+            .samples()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
         match self.format {
             AudioFormat::F32 => {
                 let samples_f32: &[f32] = &converter.f64_to_f32(samples);

--- a/playback/src/audio_backend/sdl.rs
+++ b/playback/src/audio_backend/sdl.rs
@@ -92,7 +92,9 @@ impl Sink for SdlSink {
             }};
         }
 
-        let samples = packet.samples();
+        let samples = packet
+            .samples()
+            .map_err(|e| io::Error::new(io::ErrorKind::Other, e.to_string()))?;
         match self {
             Self::F32(queue) => {
                 let samples_f32: &[f32] = &converter.f64_to_f32(samples);

--- a/playback/src/decoder/lewton_decoder.rs
+++ b/playback/src/decoder/lewton_decoder.rs
@@ -1,4 +1,5 @@
 use super::{AudioDecoder, AudioError, AudioPacket};
+use crate::SAMPLES_PER_MS;
 
 use lewton::inside_ogg::OggStreamReader;
 use lewton::samples::InterleavedSamples;
@@ -24,7 +25,7 @@ where
     R: Read + Seek,
 {
     fn seek(&mut self, ms: i64) -> Result<(), AudioError> {
-        let absgp = (ms as f64 * crate::SAMPLES_PER_MS).round() as u64;
+        let absgp = (ms as f64 * SAMPLES_PER_MS).round() as u64;
         self.0
             .seek_absgp_pg(absgp)
             .map_err(|e| AudioError::VorbisError(e.into()))?;

--- a/playback/src/decoder/lewton_decoder.rs
+++ b/playback/src/decoder/lewton_decoder.rs
@@ -1,4 +1,4 @@
-use super::{AudioDecoder, AudioError, AudioPacket, DecoderResult};
+use super::{AudioDecoder, DecoderError, AudioPacket, DecoderResult};
 
 use lewton::audio::AudioReadError::AudioIsHeader;
 use lewton::inside_ogg::OggStreamReader;
@@ -16,7 +16,7 @@ where
 {
     pub fn new(input: R) -> DecoderResult<VorbisDecoder<R>> {
         let reader =
-            OggStreamReader::new(input).map_err(|e| AudioError::LewtonDecoder(e.to_string()))?;
+            OggStreamReader::new(input).map_err(|e| DecoderError::LewtonDecoder(e.to_string()))?;
         Ok(VorbisDecoder(reader))
     }
 }
@@ -28,7 +28,7 @@ where
     fn seek(&mut self, absgp: u64) -> DecoderResult<()> {
         self.0
             .seek_absgp_pg(absgp)
-            .map_err(|e| AudioError::LewtonDecoder(e.to_string()))?;
+            .map_err(|e| DecoderError::LewtonDecoder(e.to_string()))?;
         Ok(())
     }
 
@@ -39,7 +39,7 @@ where
                 Ok(None) => return Ok(None),
                 Err(BadAudio(AudioIsHeader)) => (),
                 Err(OggError(NoCapturePatternFound)) => (),
-                Err(e) => return Err(AudioError::LewtonDecoder(e.to_string())),
+                Err(e) => return Err(DecoderError::LewtonDecoder(e.to_string())),
             }
         }
     }

--- a/playback/src/decoder/lewton_decoder.rs
+++ b/playback/src/decoder/lewton_decoder.rs
@@ -1,5 +1,4 @@
 use super::{AudioDecoder, AudioError, AudioPacket};
-use crate::SAMPLES_PER_MS;
 
 use lewton::inside_ogg::OggStreamReader;
 use lewton::samples::InterleavedSamples;
@@ -24,8 +23,7 @@ impl<R> AudioDecoder for VorbisDecoder<R>
 where
     R: Read + Seek,
 {
-    fn seek(&mut self, ms: i64) -> Result<(), AudioError> {
-        let absgp = (ms as f64 * SAMPLES_PER_MS).round() as u64;
+    fn seek(&mut self, absgp: u64) -> Result<(), AudioError> {
         self.0
             .seek_absgp_pg(absgp)
             .map_err(|e| AudioError::VorbisError(e.into()))?;

--- a/playback/src/decoder/lewton_decoder.rs
+++ b/playback/src/decoder/lewton_decoder.rs
@@ -1,4 +1,4 @@
-use super::{AudioDecoder, DecoderError, AudioPacket, DecoderResult};
+use super::{AudioDecoder, AudioPacket, DecoderError, DecoderResult};
 
 use lewton::audio::AudioReadError::AudioIsHeader;
 use lewton::inside_ogg::OggStreamReader;

--- a/playback/src/decoder/mod.rs
+++ b/playback/src/decoder/mod.rs
@@ -14,7 +14,7 @@ pub enum AudioError {
     PassthroughDecoder(String),
     #[error("Decoder OggData Error: Can't return OggData on Samples")]
     OggData,
-    #[error("Decoder Sample Error: Can't return Samples on OggData")]
+    #[error("Decoder Samples Error: Can't return Samples on OggData")]
     Samples,
 }
 

--- a/playback/src/decoder/mod.rs
+++ b/playback/src/decoder/mod.rs
@@ -1,10 +1,24 @@
-use std::fmt;
+use thiserror::Error;
 
 mod lewton_decoder;
-pub use lewton_decoder::{VorbisDecoder, VorbisError};
+pub use lewton_decoder::VorbisDecoder;
 
 mod passthrough_decoder;
-pub use passthrough_decoder::{PassthroughDecoder, PassthroughError};
+pub use passthrough_decoder::PassthroughDecoder;
+
+#[derive(Error, Debug)]
+pub enum AudioError {
+    #[error("Lewton Decoder Error: {0}")]
+    LewtonDecoder(String),
+    #[error("Passthrough Decoder Error: {0}")]
+    PassthroughDecoder(String),
+    #[error("Decoder OggData Error: Can't return OggData on Samples")]
+    OggData,
+    #[error("Decoder Sample Error: Can't return Samples on OggData")]
+    Samples,
+}
+
+pub type DecoderResult<T> = Result<T, AudioError>;
 
 pub enum AudioPacket {
     Samples(Vec<f64>),
@@ -17,17 +31,17 @@ impl AudioPacket {
         AudioPacket::Samples(f64_samples)
     }
 
-    pub fn samples(&self) -> &[f64] {
+    pub fn samples(&self) -> DecoderResult<&[f64]> {
         match self {
-            AudioPacket::Samples(s) => s,
-            AudioPacket::OggData(_) => panic!("can't return OggData on samples"),
+            AudioPacket::Samples(s) => Ok(s),
+            AudioPacket::OggData(_) => Err(AudioError::OggData),
         }
     }
 
-    pub fn oggdata(&self) -> &[u8] {
+    pub fn oggdata(&self) -> DecoderResult<&[u8]> {
         match self {
-            AudioPacket::Samples(_) => panic!("can't return samples on OggData"),
-            AudioPacket::OggData(d) => d,
+            AudioPacket::OggData(d) => Ok(d),
+            AudioPacket::Samples(_) => Err(AudioError::Samples),
         }
     }
 
@@ -39,34 +53,7 @@ impl AudioPacket {
     }
 }
 
-#[derive(Debug)]
-pub enum AudioError {
-    PassthroughError(PassthroughError),
-    VorbisError(VorbisError),
-}
-
-impl fmt::Display for AudioError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            AudioError::PassthroughError(err) => write!(f, "PassthroughError({})", err),
-            AudioError::VorbisError(err) => write!(f, "VorbisError({})", err),
-        }
-    }
-}
-
-impl From<VorbisError> for AudioError {
-    fn from(err: VorbisError) -> AudioError {
-        AudioError::VorbisError(err)
-    }
-}
-
-impl From<PassthroughError> for AudioError {
-    fn from(err: PassthroughError) -> AudioError {
-        AudioError::PassthroughError(err)
-    }
-}
-
 pub trait AudioDecoder {
-    fn seek(&mut self, absgp: u64) -> Result<(), AudioError>;
-    fn next_packet(&mut self) -> Result<Option<AudioPacket>, AudioError>;
+    fn seek(&mut self, absgp: u64) -> DecoderResult<()>;
+    fn next_packet(&mut self) -> DecoderResult<Option<AudioPacket>>;
 }

--- a/playback/src/decoder/mod.rs
+++ b/playback/src/decoder/mod.rs
@@ -7,7 +7,7 @@ mod passthrough_decoder;
 pub use passthrough_decoder::PassthroughDecoder;
 
 #[derive(Error, Debug)]
-pub enum AudioError {
+pub enum DecoderError {
     #[error("Lewton Decoder Error: {0}")]
     LewtonDecoder(String),
     #[error("Passthrough Decoder Error: {0}")]
@@ -18,7 +18,7 @@ pub enum AudioError {
     Samples,
 }
 
-pub type DecoderResult<T> = Result<T, AudioError>;
+pub type DecoderResult<T> = Result<T, DecoderError>;
 
 pub enum AudioPacket {
     Samples(Vec<f64>),
@@ -34,14 +34,14 @@ impl AudioPacket {
     pub fn samples(&self) -> DecoderResult<&[f64]> {
         match self {
             AudioPacket::Samples(s) => Ok(s),
-            AudioPacket::OggData(_) => Err(AudioError::OggData),
+            AudioPacket::OggData(_) => Err(DecoderError::OggData),
         }
     }
 
     pub fn oggdata(&self) -> DecoderResult<&[u8]> {
         match self {
             AudioPacket::OggData(d) => Ok(d),
-            AudioPacket::Samples(_) => Err(AudioError::Samples),
+            AudioPacket::Samples(_) => Err(DecoderError::Samples),
         }
     }
 

--- a/playback/src/decoder/mod.rs
+++ b/playback/src/decoder/mod.rs
@@ -12,13 +12,19 @@ pub enum DecoderError {
     LewtonDecoder(String),
     #[error("Passthrough Decoder Error: {0}")]
     PassthroughDecoder(String),
+}
+
+pub type DecoderResult<T> = Result<T, DecoderError>;
+
+#[derive(Error, Debug)]
+pub enum AudioPacketError {
     #[error("Decoder OggData Error: Can't return OggData on Samples")]
     OggData,
     #[error("Decoder Samples Error: Can't return Samples on OggData")]
     Samples,
 }
 
-pub type DecoderResult<T> = Result<T, DecoderError>;
+pub type AudioPacketResult<T> = Result<T, AudioPacketError>;
 
 pub enum AudioPacket {
     Samples(Vec<f64>),
@@ -31,17 +37,17 @@ impl AudioPacket {
         AudioPacket::Samples(f64_samples)
     }
 
-    pub fn samples(&self) -> DecoderResult<&[f64]> {
+    pub fn samples(&self) -> AudioPacketResult<&[f64]> {
         match self {
             AudioPacket::Samples(s) => Ok(s),
-            AudioPacket::OggData(_) => Err(DecoderError::OggData),
+            AudioPacket::OggData(_) => Err(AudioPacketError::OggData),
         }
     }
 
-    pub fn oggdata(&self) -> DecoderResult<&[u8]> {
+    pub fn oggdata(&self) -> AudioPacketResult<&[u8]> {
         match self {
             AudioPacket::OggData(d) => Ok(d),
-            AudioPacket::Samples(_) => Err(DecoderError::Samples),
+            AudioPacket::Samples(_) => Err(AudioPacketError::Samples),
         }
     }
 

--- a/playback/src/decoder/mod.rs
+++ b/playback/src/decoder/mod.rs
@@ -67,6 +67,6 @@ impl From<PassthroughError> for AudioError {
 }
 
 pub trait AudioDecoder {
-    fn seek(&mut self, ms: i64) -> Result<(), AudioError>;
+    fn seek(&mut self, absgp: u64) -> Result<(), AudioError>;
     fn next_packet(&mut self) -> Result<Option<AudioPacket>, AudioError>;
 }

--- a/playback/src/decoder/passthrough_decoder.rs
+++ b/playback/src/decoder/passthrough_decoder.rs
@@ -1,5 +1,5 @@
 // Passthrough decoder for librespot
-use super::{AudioDecoder, DecoderError, AudioPacket, DecoderResult};
+use super::{AudioDecoder, AudioPacket, DecoderError, DecoderResult};
 use ogg::{OggReadError, Packet, PacketReader, PacketWriteEndInfo, PacketWriter};
 use std::io::{Read, Seek};
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -105,7 +105,9 @@ impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
                         debug!("Seek to offset page {}", self.ofsgp_page);
                         Ok(())
                     }
-                    None => Err(DecoderError::PassthroughDecoder("Packet is None".to_string())),
+                    None => Err(DecoderError::PassthroughDecoder(
+                        "Packet is None".to_string(),
+                    )),
                 }
             }
             Err(e) => Err(DecoderError::PassthroughDecoder(e.to_string())),

--- a/playback/src/decoder/passthrough_decoder.rs
+++ b/playback/src/decoder/passthrough_decoder.rs
@@ -1,10 +1,9 @@
 // Passthrough decoder for librespot
 use super::{AudioDecoder, AudioError, AudioPacket};
-use crate::SAMPLE_RATE;
+use crate::SAMPLES_PER_MS;
 use ogg::{OggReadError, Packet, PacketReader, PacketWriteEndInfo, PacketWriter};
 use std::fmt;
 use std::io::{Read, Seek};
-use std::time::Duration;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 fn get_header<T>(code: u8, rdr: &mut PacketReader<T>) -> Result<Box<[u8]>, PassthroughError>
@@ -98,10 +97,10 @@ impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
         self.stream_serial += 1;
 
         // hard-coded to 44.1 kHz
-        match self.rdr.seek_absgp(
-            None,
-            Duration::from_millis(ms as u64 * SAMPLE_RATE as u64).as_secs(),
-        ) {
+
+        let absgp = (ms as f64 * SAMPLES_PER_MS).round() as u64;
+
+        match self.rdr.seek_absgp(None, absgp) {
             Ok(_) => {
                 // need to set some offset for next_page()
                 let pck = self.rdr.read_packet().unwrap().unwrap();

--- a/playback/src/decoder/passthrough_decoder.rs
+++ b/playback/src/decoder/passthrough_decoder.rs
@@ -1,21 +1,22 @@
 // Passthrough decoder for librespot
-use super::{AudioDecoder, AudioError, AudioPacket};
+use super::{AudioDecoder, AudioError, AudioPacket, DecoderResult};
 use ogg::{OggReadError, Packet, PacketReader, PacketWriteEndInfo, PacketWriter};
-use std::fmt;
 use std::io::{Read, Seek};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-fn get_header<T>(code: u8, rdr: &mut PacketReader<T>) -> Result<Box<[u8]>, PassthroughError>
+fn get_header<T>(code: u8, rdr: &mut PacketReader<T>) -> DecoderResult<Box<[u8]>>
 where
     T: Read + Seek,
 {
-    let pck: Packet = rdr.read_packet_expected()?;
+    let pck: Packet = rdr
+        .read_packet_expected()
+        .map_err(|e| AudioError::PassthroughDecoder(e.to_string()))?;
 
     let pkt_type = pck.data[0];
     debug!("Vorbis header type {}", &pkt_type);
 
     if pkt_type != code {
-        return Err(PassthroughError(OggReadError::InvalidData));
+        return Err(AudioError::PassthroughDecoder("Invalid Data".to_string()));
     }
 
     Ok(pck.data.into_boxed_slice())
@@ -33,16 +34,14 @@ pub struct PassthroughDecoder<R: Read + Seek> {
     setup: Box<[u8]>,
 }
 
-pub struct PassthroughError(ogg::OggReadError);
-
 impl<R: Read + Seek> PassthroughDecoder<R> {
     /// Constructs a new Decoder from a given implementation of `Read + Seek`.
-    pub fn new(rdr: R) -> Result<Self, PassthroughError> {
+    pub fn new(rdr: R) -> DecoderResult<Self> {
         let mut rdr = PacketReader::new(rdr);
-        let stream_serial = SystemTime::now()
+        let since_epoch = SystemTime::now()
             .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_millis() as u32;
+            .map_err(|e| AudioError::PassthroughDecoder(e.to_string()))?;
+        let stream_serial = since_epoch.as_millis() as u32;
 
         info!("Starting passthrough track with serial {}", stream_serial);
 
@@ -69,7 +68,7 @@ impl<R: Read + Seek> PassthroughDecoder<R> {
 }
 
 impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
-    fn seek(&mut self, absgp: u64) -> Result<(), AudioError> {
+    fn seek(&mut self, absgp: u64) -> DecoderResult<()> {
         // add an eos to previous stream if missing
         if self.bos && !self.eos {
             match self.rdr.read_packet() {
@@ -82,7 +81,7 @@ impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
                             PacketWriteEndInfo::EndStream,
                             absgp_page,
                         )
-                        .unwrap();
+                        .map_err(|e| AudioError::PassthroughDecoder(e.to_string()))?;
                 }
                 _ => warn! {"Cannot write EoS after seeking"},
             };
@@ -96,16 +95,24 @@ impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
         match self.rdr.seek_absgp(None, absgp) {
             Ok(_) => {
                 // need to set some offset for next_page()
-                let pck = self.rdr.read_packet().unwrap().unwrap();
-                self.ofsgp_page = pck.absgp_page();
-                debug!("Seek to offset page {}", self.ofsgp_page);
-                Ok(())
+                let pck = self
+                    .rdr
+                    .read_packet()
+                    .map_err(|e| AudioError::PassthroughDecoder(e.to_string()))?;
+                match pck {
+                    Some(pck) => {
+                        self.ofsgp_page = pck.absgp_page();
+                        debug!("Seek to offset page {}", self.ofsgp_page);
+                        Ok(())
+                    }
+                    None => Err(AudioError::PassthroughDecoder("Packet is None".to_string())),
+                }
             }
-            Err(err) => Err(AudioError::PassthroughError(err.into())),
+            Err(e) => Err(AudioError::PassthroughDecoder(e.to_string())),
         }
     }
 
-    fn next_packet(&mut self) -> Result<Option<AudioPacket>, AudioError> {
+    fn next_packet(&mut self) -> DecoderResult<Option<AudioPacket>> {
         // write headers if we are (re)starting
         if !self.bos {
             self.wtr
@@ -115,7 +122,7 @@ impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
                     PacketWriteEndInfo::EndPage,
                     0,
                 )
-                .unwrap();
+                .map_err(|e| AudioError::PassthroughDecoder(e.to_string()))?;
             self.wtr
                 .write_packet(
                     self.comment.clone(),
@@ -123,7 +130,7 @@ impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
                     PacketWriteEndInfo::NormalPacket,
                     0,
                 )
-                .unwrap();
+                .map_err(|e| AudioError::PassthroughDecoder(e.to_string()))?;
             self.wtr
                 .write_packet(
                     self.setup.clone(),
@@ -131,7 +138,7 @@ impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
                     PacketWriteEndInfo::EndPage,
                     0,
                 )
-                .unwrap();
+                .map_err(|e| AudioError::PassthroughDecoder(e.to_string()))?;
             self.bos = true;
             debug!("Wrote Ogg headers");
         }
@@ -143,7 +150,7 @@ impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
                     info!("end of streaming");
                     return Ok(None);
                 }
-                Err(err) => return Err(AudioError::PassthroughError(err.into())),
+                Err(e) => return Err(AudioError::PassthroughDecoder(e.to_string())),
             };
 
             let pckgp_page = pck.absgp_page();
@@ -170,32 +177,14 @@ impl<R: Read + Seek> AudioDecoder for PassthroughDecoder<R> {
                     inf,
                     pckgp_page - self.ofsgp_page,
                 )
-                .unwrap();
+                .map_err(|e| AudioError::PassthroughDecoder(e.to_string()))?;
 
             let data = self.wtr.inner_mut();
 
             if !data.is_empty() {
-                let result = AudioPacket::OggData(std::mem::take(data));
-                return Ok(Some(result));
+                let ogg_data = AudioPacket::OggData(std::mem::take(data));
+                return Ok(Some(ogg_data));
             }
         }
-    }
-}
-
-impl fmt::Debug for PassthroughError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Debug::fmt(&self.0, f)
-    }
-}
-
-impl From<ogg::OggReadError> for PassthroughError {
-    fn from(err: OggReadError) -> PassthroughError {
-        PassthroughError(err)
-    }
-}
-
-impl fmt::Display for PassthroughError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        fmt::Display::fmt(&self.0, f)
     }
 }

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -16,5 +16,5 @@ pub mod player;
 pub const SAMPLE_RATE: u32 = 44100;
 pub const NUM_CHANNELS: u8 = 2;
 pub const SAMPLES_PER_SECOND: u32 = SAMPLE_RATE as u32 * NUM_CHANNELS as u32;
-pub const SAMPLES_PER_MS: f64 = SAMPLE_RATE as f64 / 1000.0;
-pub const MS_PER_SAMPLE: f64 = 1000.0 / SAMPLE_RATE as f64;
+pub const PAGES_PER_MS: f64 = SAMPLE_RATE as f64 / 1000.0;
+pub const MS_PER_PAGE: f64 = 1000.0 / SAMPLE_RATE as f64;

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -16,3 +16,5 @@ pub mod player;
 pub const SAMPLE_RATE: u32 = 44100;
 pub const NUM_CHANNELS: u8 = 2;
 pub const SAMPLES_PER_SECOND: u32 = SAMPLE_RATE as u32 * NUM_CHANNELS as u32;
+pub const SAMPLES_PER_MS: f64 = SAMPLE_RATE as f64 / 1000.0;
+pub const MS_PER_SAMPLE: f64 = 1000.0 / SAMPLE_RATE as f64;

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -27,7 +27,7 @@ use crate::decoder::{AudioDecoder, AudioError, AudioPacket, PassthroughDecoder, 
 use crate::metadata::{AudioItem, FileFormat};
 use crate::mixer::AudioFilter;
 
-use crate::{NUM_CHANNELS, SAMPLES_PER_SECOND};
+use crate::{MS_PER_SAMPLE, NUM_CHANNELS, SAMPLES_PER_MS, SAMPLES_PER_SECOND};
 
 const PRELOAD_NEXT_TRACK_BEFORE_END_DURATION_MS: u32 = 30000;
 pub const DB_VOLTAGE_RATIO: f64 = 20.0;
@@ -1043,11 +1043,11 @@ impl Future for PlayerInternal {
 
 impl PlayerInternal {
     fn position_pcm_to_ms(position_pcm: u64) -> u32 {
-        (position_pcm * 10 / 441) as u32
+        (position_pcm as f64 * MS_PER_SAMPLE).round() as u32
     }
 
     fn position_ms_to_pcm(position_ms: u32) -> u64 {
-        position_ms as u64 * 441 / 10
+        (position_ms as f64 * SAMPLES_PER_MS).round() as u64
     }
 
     fn ensure_sink_running(&mut self) {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -23,7 +23,7 @@ use crate::convert::Converter;
 use crate::core::session::Session;
 use crate::core::spotify_id::SpotifyId;
 use crate::core::util::SeqGenerator;
-use crate::decoder::{AudioDecoder, DecoderError, AudioPacket, PassthroughDecoder, VorbisDecoder};
+use crate::decoder::{AudioDecoder, AudioPacket, DecoderError, PassthroughDecoder, VorbisDecoder};
 use crate::metadata::{AudioItem, FileFormat};
 use crate::mixer::AudioFilter;
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -27,7 +27,7 @@ use crate::decoder::{AudioDecoder, AudioError, AudioPacket, PassthroughDecoder, 
 use crate::metadata::{AudioItem, FileFormat};
 use crate::mixer::AudioFilter;
 
-use crate::{MS_PER_SAMPLE, NUM_CHANNELS, SAMPLES_PER_MS, SAMPLES_PER_SECOND};
+use crate::{MS_PER_PAGE, NUM_CHANNELS, PAGES_PER_MS, SAMPLES_PER_SECOND};
 
 const PRELOAD_NEXT_TRACK_BEFORE_END_DURATION_MS: u32 = 30000;
 pub const DB_VOLTAGE_RATIO: f64 = 20.0;
@@ -1091,11 +1091,11 @@ impl Future for PlayerInternal {
 
 impl PlayerInternal {
     fn position_pcm_to_ms(position_pcm: u64) -> u32 {
-        (position_pcm as f64 * MS_PER_SAMPLE).round() as u32
+        (position_pcm as f64 * MS_PER_PAGE) as u32
     }
 
     fn position_ms_to_pcm(position_ms: u32) -> u64 {
-        (position_ms as f64 * SAMPLES_PER_MS).round() as u64
+        (position_ms as f64 * PAGES_PER_MS) as u64
     }
 
     fn ensure_sink_running(&mut self) {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -23,7 +23,7 @@ use crate::convert::Converter;
 use crate::core::session::Session;
 use crate::core::spotify_id::SpotifyId;
 use crate::core::util::SeqGenerator;
-use crate::decoder::{AudioDecoder, AudioError, AudioPacket, PassthroughDecoder, VorbisDecoder};
+use crate::decoder::{AudioDecoder, DecoderError, AudioPacket, PassthroughDecoder, VorbisDecoder};
 use crate::metadata::{AudioItem, FileFormat};
 use crate::mixer::AudioFilter;
 
@@ -813,12 +813,12 @@ impl PlayerTrackLoader {
             let result = if self.config.passthrough {
                 match PassthroughDecoder::new(audio_file) {
                     Ok(result) => Ok(Box::new(result) as Decoder),
-                    Err(e) => Err(AudioError::PassthroughDecoder(e.to_string())),
+                    Err(e) => Err(DecoderError::PassthroughDecoder(e.to_string())),
                 }
             } else {
                 match VorbisDecoder::new(audio_file) {
                     Ok(result) => Ok(Box::new(result) as Decoder),
-                    Err(e) => Err(AudioError::LewtonDecoder(e.to_string())),
+                    Err(e) => Err(DecoderError::LewtonDecoder(e.to_string())),
                 }
             };
 


### PR DESCRIPTION
* Make the decoders and player use the same math for converting between samples and milliseconds.

* Remove unwraps, expects and panics from player, decoders and mod.

* Reduce redundant math.

* Simplify decoder errors with thiserror.