### PR TITLE
Attenuate after normalisation

### DIFF
--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1186,10 +1186,6 @@ impl PlayerInternal {
             Some(mut packet) => {
                 if !packet.is_empty() {
                     if let AudioPacket::Samples(ref mut data) = packet {
-                        if let Some(ref editor) = self.audio_filter {
-                            editor.modify_stream(data)
-                        }
-
                         if self.config.normalisation
                             && !(f64::abs(normalisation_factor - 1.0) <= f64::EPSILON
                                 && self.config.normalisation_method == NormalisationMethod::Basic)
@@ -1301,6 +1297,10 @@ impl PlayerInternal {
                                     *sample = 1.0;
                                 }
                             }
+                        }
+
+                        if let Some(ref editor) = self.audio_filter {
+                            editor.modify_stream(data)
                         }
                     }
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1286,16 +1286,7 @@ impl PlayerInternal {
                                         }
                                     }
                                 }
-
                                 *sample *= actual_normalisation_factor;
-
-                                // Extremely sharp attacks, however unlikely, *may* still clip and provide
-                                // undefined results, so strictly enforce output within [-1.0, 1.0].
-                                if *sample < -1.0 {
-                                    *sample = -1.0;
-                                } else if *sample > 1.0 {
-                                    *sample = 1.0;
-                                }
                             }
                         }
 


### PR DESCRIPTION
This is a small change just to do things right: volume control should be the last in line, after normalisation and potentially other filters. In practice very few if any will notice.

At the same time I removed the clamping of floating point samples. It's not necessary, when converting to integer samples the conversion will saturate at the bounds (i.e. clip) anyway.