### PR TITLE
Update default normalisation threshold

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] `alsamixer`: use `--device` name for `--mixer-card` unless specified otherwise
 - [playback] `player`: consider errors in `sink.start`, `sink.stop` and `sink.write` fatal and `exit(1)` (breaking)
 - [playback] `player`: make `convert` and `decoder` public so you can implement your own `Sink`
+- [playback] Updated default normalisation threshold to -2 dBFS
 
 ### Deprecated
 - [connect] The `discovery` module was deprecated in favor of the `librespot-discovery` crate

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -151,7 +151,7 @@ impl Default for PlayerConfig {
             normalisation_type: NormalisationType::default(),
             normalisation_method: NormalisationMethod::default(),
             normalisation_pregain: 0.0,
-            normalisation_threshold: db_to_ratio(-1.0),
+            normalisation_threshold: db_to_ratio(-2.0),
             normalisation_attack: Duration::from_millis(5),
             normalisation_release: Duration::from_millis(100),
             normalisation_knee: 1.0,

--- a/src/main.rs
+++ b/src/main.rs
@@ -371,7 +371,7 @@ fn get_setup(args: &[String]) -> Setup {
     .optopt(
         "",
         NORMALISATION_THRESHOLD,
-        "Threshold (dBFS) to prevent clipping. Defaults to -1.0.",
+        "Threshold (dBFS) to prevent clipping. Defaults to -2.0.",
         "THRESHOLD",
     )
     .optopt(


### PR DESCRIPTION
The latest protobufs indicate that Spotify has changed its normalisation threshold from -1 to -2 dBFS.
Spotify also updated its pregain settings, and I already edited the wiki to follow suit.