### PR TITLE
Add and default to "auto" normalisation type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] Add `--volume-range` option to set dB range and control `log` and `cubic` volume control curves
 - [playback] `alsamixer`: support for querying dB range from Alsa softvol
 - [playback] Add `--format F64` (supported by Alsa and GStreamer only)
-- [playback] Add `--normalisation-type auto` that switches between album and track automatically
+- [playback] Add `--normalisation-type auto` that switches between album and track automatically (breaking)
 
 ### Changed
 - [audio, playback] Moved `VorbisDecoder`, `VorbisError`, `AudioPacket`, `PassthroughDecoder`, `PassthroughError`, `AudioError`, `AudioDecoder` and the `convert` module from `librespot-audio` to `librespot-playback`. The underlying crates `vorbis`, `librespot-tremor`, `lewton` and `ogg` should be used directly. (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] Add `--volume-range` option to set dB range and control `log` and `cubic` volume control curves
 - [playback] `alsamixer`: support for querying dB range from Alsa softvol
 - [playback] Add `--format F64` (supported by Alsa and GStreamer only)
-- [playback] Add `--normalisation-type auto` that switches between album and track automatically (breaking)
+- [playback] Add `--normalisation-type auto` that switches between album and track automatically
 
 ### Changed
 - [audio, playback] Moved `VorbisDecoder`, `VorbisError`, `AudioPacket`, `PassthroughDecoder`, `PassthroughError`, `AudioError`, `AudioDecoder` and the `convert` module from `librespot-audio` to `librespot-playback`. The underlying crates `vorbis`, `librespot-tremor`, `lewton` and `ogg` should be used directly. (breaking)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] Add `--volume-range` option to set dB range and control `log` and `cubic` volume control curves
 - [playback] `alsamixer`: support for querying dB range from Alsa softvol
 - [playback] Add `--format F64` (supported by Alsa and GStreamer only)
+- [playback] Add `--normalisation-type auto` that switches between album and track automatically
 
 ### Changed
 - [audio, playback] Moved `VorbisDecoder`, `VorbisError`, `AudioPacket`, `PassthroughDecoder`, `PassthroughError`, `AudioError`, `AudioDecoder` and the `convert` module from `librespot-audio` to `librespot-playback`. The underlying crates `vorbis`, `librespot-tremor`, `lewton` and `ogg` should be used directly. (breaking)
@@ -26,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] `alsamixer`: use `--device` name for `--mixer-card` unless specified otherwise
 - [playback] `player`: consider errors in `sink.start`, `sink.stop` and `sink.write` fatal and `exit(1)` (breaking)
 - [playback] `player`: make `convert` and `decoder` public so you can implement your own `Sink`
-- [playback] Updated default normalisation threshold to -2 dBFS
+- [playback] `player`: update default normalisation threshold to -2 dBFS
+- [playback] `player`: default normalisation type is now `auto`
 
 ### Deprecated
 - [connect] The `discovery` module was deprecated in favor of the `librespot-discovery` crate

--- a/audio/src/fetch/receive.rs
+++ b/audio/src/fetch/receive.rs
@@ -266,7 +266,8 @@ impl AudioFileFetch {
     fn handle_file_data(&mut self, data: ReceivedData) -> ControlFlow {
         match data {
             ReceivedData::ResponseTime(response_time) => {
-                trace!("Ping time estimated as: {}ms", response_time.as_millis());
+                // chatty
+                // trace!("Ping time estimated as: {}ms", response_time.as_millis());
 
                 // prune old response times. Keep at most two so we can push a third.
                 while self.network_response_times.len() >= 3 {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -907,6 +907,7 @@ impl SpircTask {
             // Note: This doesn't seem to reflect in the UI
             // the additional tracks in the frame don't show up as with station view
             debug!("Extending playlist <{}>", context_uri);
+            self.player.set_auto_normalise_as_album(false);
             self.update_tracks_from_context();
         }
         if new_index >= tracks_len {
@@ -1083,6 +1084,9 @@ impl SpircTask {
             // Get autoplay_station_uri for regular playlists
             self.autoplay_fut = self.resolve_autoplay_uri(&context_uri);
         }
+
+        self.player
+            .set_auto_normalise_as_album(context_uri.starts_with("spotify:album:"));
 
         self.state.set_playing_track_index(index);
         self.state.set_track(tracks.iter().cloned().collect());

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -902,12 +902,12 @@ impl SpircTask {
             self.context_fut = self.resolve_station(&context_uri);
             self.update_tracks_from_context();
         }
-        if self.config.autoplay && new_index == tracks_len - 1 {
+        let last_track = new_index == tracks_len - 1;
+        if self.config.autoplay && last_track {
             // Extend the playlist
             // Note: This doesn't seem to reflect in the UI
             // the additional tracks in the frame don't show up as with station view
             debug!("Extending playlist <{}>", context_uri);
-            self.player.set_auto_normalise_as_album(false);
             self.update_tracks_from_context();
         }
         if new_index >= tracks_len {
@@ -918,6 +918,11 @@ impl SpircTask {
         if tracks_len > 0 {
             self.state.set_playing_track_index(new_index);
             self.load_track(continue_playing, 0);
+            if self.config.autoplay && last_track {
+                // If we're now playing the last track of an album, then
+                // switch to track normalisation mode for the autoplay to come.
+                self.player.set_auto_normalise_as_album(false);
+            }
         } else {
             info!("Not playing next track because there are no more tracks left in queue.");
             self.state.set_playing_track_index(0);

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -76,10 +76,11 @@ impl AudioFormat {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub enum NormalisationType {
     Album,
     Track,
+    Auto,
 }
 
 impl FromStr for NormalisationType {
@@ -88,6 +89,7 @@ impl FromStr for NormalisationType {
         match s.to_lowercase().as_ref() {
             "album" => Ok(Self::Album),
             "track" => Ok(Self::Track),
+            "auto" => Ok(Self::Auto),
             _ => Err(()),
         }
     }
@@ -95,7 +97,7 @@ impl FromStr for NormalisationType {
 
 impl Default for NormalisationType {
     fn default() -> Self {
-        Self::Album
+        Self::Auto
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -359,7 +359,7 @@ fn get_setup(args: &[String]) -> Setup {
     .optopt(
         "",
         NORMALISATION_GAIN_TYPE,
-        "Specify the normalisation gain type to use {track|album}. Defaults to album.",
+        "Specify the normalisation gain type to use {track|album|auto}. Defaults to auto.",
         "TYPE",
     )
     .optopt(


### PR DESCRIPTION
As discussed in #780, this adds an "auto" normalisation type, and makes it the default. This automatically picks the album or track ReplayGain values, depending on whether the current context is an album context or not.

When autoplay is enabled and the playlist is extended when an album reaches its end, then "auto" starts picking the track values until an album is put up again.