### PR TITLE
Update audio file format definitions in media_manifest.proto

### DIFF
--- a/protocol/proto/media_manifest.proto
+++ b/protocol/proto/media_manifest.proto
@@ -18,7 +18,14 @@ message AudioFile {
         MP3_160_ENC = 7;
         AAC_24 = 8;
         AAC_48 = 9;
+        MP4_128 = 10;
+        MP4_128_DUAL = 11;
+        MP4_128_CBCS = 12;
+        MP4_256 = 13;
+        MP4_256_DUAL = 14;
+        MP4_256_CBCS = 15;
         FLAC_FLAC = 16;
+        MP4_FLAC = 17;
     }
 }
 


### PR DESCRIPTION
Grabbed some definitions from the [Spotify Web Player](https://open.scdn.co/cdn/build/web-player/vendor~web-player.b9ac5bb4.js) (CTRL+F for 'FORMAT_OGG_VORBIS_96' to get first definition and index). Here is also a picture for easy reference:

<img width="426" alt="spotify_manifest" src="https://user-images.githubusercontent.com/25168557/134128498-94f84512-acf3-43af-a8dd-38b30cd0d316.png">
 