### PR TITLE
Add Google sign in credential to protobufs

### DIFF
--- a/protocol/proto/spotify/login5/v3/credentials/credentials.proto
+++ b/protocol/proto/spotify/login5/v3/credentials/credentials.proto
@@ -46,3 +46,8 @@ message SamsungSignInCredential {
     string id_token = 3;
     string token_endpoint_url = 4;
 }
+
+message GoogleSignInCredential {
+    string auth_code = 1;
+    string redirect_uri = 2;
+}

--- a/protocol/proto/spotify/login5/v3/login5.proto
+++ b/protocol/proto/spotify/login5/v3/login5.proto
@@ -52,6 +52,7 @@ message LoginRequest {
         credentials.ParentChildCredential parent_child_credential = 105;
         credentials.AppleSignInCredential apple_sign_in_credential = 106;
         credentials.SamsungSignInCredential samsung_sign_in_credential = 107;
+        credentials.GoogleSignInCredential google_sign_in_credential = 108;
     }
 }
 


### PR DESCRIPTION
Is there any reason Google sign in credential was excluded from the protobufs? The Google sign in definition was taken from Spotify 1.1.68.