### PR TITLE
Fix behavior after last track of an album/playlist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [connect] Fix step size on volume up/down events
+- [connect] Fix looping back to the first track after the last track of an album or playlist
 - [playback] Incorrect `PlayerConfig::default().normalisation_threshold` caused distortion when using dynamic volume normalisation downstream 
 - [playback] Fix `log` and `cubic` volume controls to be mute at zero volume
 - [playback] Fix `S24_3` format on big-endian systems


### PR DESCRIPTION
 * When autoplay is disabled, then loop back to the first track instead of 10 tracks back. Continue or stop playing depending on the state of the repeat button.

 * When autoplay is enabled, then extend the playlist *after* the last track. #844 broke this such that the last track of an album or playlist was never played.

Fixes: #434