### PR TITLE
Add build profile to displayed version info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Include build profile in the displayed version information
+
 ### Fixed
 - [connect] Partly fix behavior after last track of an album/playlist
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,14 +160,20 @@ pub fn parse_file_size(input: &str) -> Result<u64, ParseFileSizeError> {
     Ok((num * base.pow(exponent) as f64) as u64)
 }
 
-fn print_version() {
-    println!(
-        "librespot {semver} {sha} (Built on {build_date}, Build ID: {build_id})",
+fn get_version_string() -> String {
+    #[cfg(debug_assertions)]
+    const BUILD_PROFILE: &str = "debug";
+    #[cfg(not(debug_assertions))]
+    const BUILD_PROFILE: &str = "release";
+
+    format!(
+        "librespot {semver} {sha} (Built on {build_date}, Build ID: {build_id}, Profile: {build_profile})",
         semver = version::SEMVER,
         sha = version::SHA_SHORT,
         build_date = version::BUILD_DATE,
-        build_id = version::BUILD_ID
-    );
+        build_id = version::BUILD_ID,
+        build_profile = BUILD_PROFILE
+    )
 }
 
 struct Setup {
@@ -438,20 +444,14 @@ fn get_setup(args: &[String]) -> Setup {
     }
 
     if matches.opt_present(VERSION) {
-        print_version();
+        println!("{}", get_version_string());
         exit(0);
     }
 
     let verbose = matches.opt_present(VERBOSE);
     setup_logging(verbose);
 
-    info!(
-        "librespot {semver} {sha} (Built on {build_date}, Build ID: {build_id})",
-        semver = version::SEMVER,
-        sha = version::SHA_SHORT,
-        build_date = version::BUILD_DATE,
-        build_id = version::BUILD_ID
-    );
+    info!("{}", get_version_string());
 
     let backend_name = matches.opt_str(BACKEND);
     if backend_name == Some("?".into()) {


### PR DESCRIPTION
Example output from -V for a debug build is:
librespot 0.3.0 832889b (Built on 2021-10-14, Build ID: ANJrycbG, Profile: debug)

Using `debug_assertions` seems a little hacky but it works (I could only find [this old SO post](https://stackoverflow.com/questions/39204908/how-to-check-release-debug-builds-using-cfg-in-rust) on the subject). Alternatively we should be able to do something in the build script like this:
```
if let Ok(profile) = env::var("PROFILE") {
    println!("cargo:rustc-env=LIBRESPOT_BUILD_PROFILE={}", profile);
}
```
Happy to change to that method if preferred.