### PR TITLE
Change hand-picked RNGs back to `SmallRng`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1288,7 +1288,6 @@ dependencies = [
  "portaudio-rs",
  "rand",
  "rand_distr",
- "rand_xoshiro",
  "rodio",
  "sdl2",
  "shell-words",
@@ -1895,15 +1894,6 @@ name = "rand_hc"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d51e9f596de227fda2ea6c84607f5558e196eeaf43c986b724ba4fb8fdf497e7"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_xoshiro"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
 dependencies = [
  "rand_core",
 ]

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -47,9 +47,8 @@ lewton = "0.10"
 ogg = "0.8"
 
 # Dithering
-rand = "0.8"
+rand = { version = "0.8", features = ["small_rng"] }
 rand_distr = "0.4"
-rand_xoshiro = "0.6"
 
 [features]
 alsa-backend = ["alsa"]


### PR DESCRIPTION
I misread the [paper](https://vigna.di.unimi.it/papers.php#BlVSLPNG) and it's better to just stick to what `SmallRng` uses by default. It's easier on the eyes, too.

 * While `Xoshiro256Plus` is faster on 64-bit, it has low linear complexity in the lower three bits, which *are* used when generating dither (I thought only `Xoroshiro128` had low linear complexity, and I was wrong).

 * And on 32-bit, while `Xoshiro128StarStar` access one less variable from the heap than `Xoshiro128PlusPlus`, multiplication is generally slower than addition in hardware.

Sorry for the noise.