### PR TITLE
Prevent librespot from becoming a zombie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [cache] Add `disable-credential-cache` flag (breaking).
 
+### Fixed
+- [main] Prevent hang when discovery is disabled and there are no credentials or when bad credentials are given.
+
 ## [0.3.1] - 2021-10-24
 
 ### Changed

--- a/src/main.rs
+++ b/src/main.rs
@@ -647,6 +647,11 @@ fn get_setup(args: &[String]) -> Setup {
         )
     };
 
+    if credentials.is_none() && matches.opt_present(DISABLE_DISCOVERY) {
+        error!("Credentials are required if discovery is disabled.");
+        exit(1);
+    }
+
     let session_config = {
         let device_id = device_id(&name);
 
@@ -923,7 +928,8 @@ async fn main() {
                     player_event_channel = Some(event_channel);
                 },
                 Err(e) => {
-                    warn!("Connection failed: {}", e);
+                    error!("Connection failed: {}", e);
+                    exit(1);
                 }
             },
             _ = async { spirc_task.as_mut().unwrap().await }, if spirc_task.is_some() => {


### PR DESCRIPTION
Prevent hang when discovery is disabled and there are no credentials or when bad credentials are given.