### PR TITLE
Refactor main.rs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- [main] Enforce reasonable ranges for option values (breaking).
+- [main] Don't evaluate options that would otherwise have no effect.
+
 ### Added
 - [cache] Add `disable-credential-cache` flag (breaking).
+- [main] Use different option descriptions and error messages based on what backends are enabled at build time.
+- [main] Add a `-q`, `--quiet` option that changes the logging level to warn.
+- [main] Add a short name for every flag and option.
 
 ### Fixed
 - [main] Prevent hang when discovery is disabled and there are no credentials or when bad credentials are given.
+- [main] Don't panic when parsing options. Instead list valid values and exit.
+
+### Removed
+- [playback] `alsamixer`: previously deprecated option `mixer-card` has been removed.
+- [playback] `alsamixer`: previously deprecated option `mixer-name` has been removed.
+- [playback] `alsamixer`: previously deprecated option `mixer-index` has been removed.
 
 ## [0.3.1] - 2021-10-24
 

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -125,3 +125,15 @@ pub struct ConnectConfig {
     pub has_volume_ctrl: bool,
     pub autoplay: bool,
 }
+
+impl Default for ConnectConfig {
+    fn default() -> ConnectConfig {
+        ConnectConfig {
+            name: "Librespot".to_string(),
+            device_type: DeviceType::default(),
+            initial_volume: Some(50),
+            has_volume_ctrl: true,
+            autoplay: false,
+        }
+    }
+}

--- a/playback/src/audio_backend/mod.rs
+++ b/playback/src/audio_backend/mod.rs
@@ -146,11 +146,6 @@ pub fn find(name: Option<String>) -> Option<SinkBuilder> {
             .find(|backend| name == backend.0)
             .map(|backend| backend.1)
     } else {
-        Some(
-            BACKENDS
-                .first()
-                .expect("No backends were enabled at build time")
-                .1,
-        )
+        BACKENDS.first().map(|backend| backend.1)
     }
 }

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -76,7 +76,7 @@ impl AudioFormat {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum NormalisationType {
     Album,
     Track,
@@ -101,7 +101,7 @@ impl Default for NormalisationType {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum NormalisationMethod {
     Basic,
     Dynamic,


### PR DESCRIPTION
* Don't panic when parsing options. Instead list valid values and exit.
* Get rid of needless .expect in playback/src/audio_backend/mod.rs.
* Enforce reasonable ranges for option values (breaking).
* Don't evaluate options that would otherwise have no effect.
* Add pub const MIXERS to mixer/mod.rs very similar to the audio_backend's implementation. (non-breaking though)
* Use different option descriptions and error messages based on what backends are enabled at build time.
* Add a -q, --quiet option that changed the logging level to warn.
* Add a short name for every flag and option.
* Note removed options.
* Other misc cleanups.