### PR TITLE
Upstream LibreELEC patch

### DIFF
--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -10,6 +10,12 @@ pub enum SpotifyAudioType {
     NonPlayable,
 }
 
+impl fmt::Display for SpotifyAudioType {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 impl From<&str> for SpotifyAudioType {
     fn from(v: &str) -> Self {
         match v {

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -138,6 +138,7 @@ pub struct PlayerConfig {
     pub normalisation_attack: Duration,
     pub normalisation_release: Duration,
     pub normalisation_knee: f64,
+    pub notify_kodi: bool,
 
     // pass function pointers so they can be lazily instantiated *after* spawning a thread
     // (thereby circumventing Send bounds that they might not satisfy)
@@ -159,6 +160,7 @@ impl Default for PlayerConfig {
             normalisation_knee: 1.0,
             passthrough: false,
             ditherer: Some(mk_ditherer::<TriangularDitherer>),
+            notify_kodi: false,
         }
     }
 }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1868,6 +1868,10 @@ impl PlayerInternal {
         }
     }
 
+    fn notify_kodi(&mut self, event: String) {
+        eprintln!("@{}", event);
+    }
+
     fn send_event(&mut self, event: PlayerEvent) {
         let mut index = 0;
         while index < self.event_senders.len() {
@@ -1876,6 +1880,16 @@ impl PlayerInternal {
                 Err(_) => {
                     self.event_senders.remove(index);
                 }
+            }
+        }
+        if self.config.notify_kodi {
+            use PlayerEvent::*;
+            match event {
+                Playing {track_id, .. } => self.notify_kodi(["Playing",
+                                               &track_id.audio_type.to_string(),
+                                               &track_id.to_base62()].join(" ")),
+                Stopped { .. } => self.notify_kodi("Stopped".to_string()),
+                _ => ()
             }
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -577,6 +577,11 @@ fn get_setup(args: &[String]) -> Setup {
         AP_PORT,
         "Connect to an AP with a specified port 1 - 65535. If no AP with that port is present a fallback AP will be used. Available ports are usually 80, 443 and 4070.",
         "PORT",
+    )
+    .optflag(
+        "",
+       "notify-kodi",
+        "Notify Kodi",
     );
 
     let matches = match opts.parse(&args[1..]) {
@@ -1386,6 +1391,8 @@ fn get_setup(args: &[String]) -> Setup {
 
         let passthrough = matches.opt_present(PASSTHROUGH);
 
+        let notify_kodi = matches.opt_present("notify-kodi");
+
         PlayerConfig {
             bitrate,
             gapless,
@@ -1399,6 +1406,7 @@ fn get_setup(args: &[String]) -> Setup {
             normalisation_release,
             normalisation_knee,
             ditherer,
+            notify_kodi,
         }
     };
 


### PR DESCRIPTION
Hello,
librespot for LibreELEC is [patched to notify Kodi of playback start/stop](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/addons/service/librespot/patches/librespot-01_notify_kodi.patch).
I have updated the patch for librespot 0.1.6 to work for librespot of the dev branch.
Would it be possible to upstream this patch to librespot?
This commit is the best I can do with my limited knowledge of librespot and Rust.
I expect that this commit needs to be adapted to suit librespot coding conventions.
