### PR TITLE
Improve `--device ?` functionality for the alsa backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [main] Enforce reasonable ranges for option values (breaking).
 - [main] Don't evaluate options that would otherwise have no effect.
+- [playback] `alsa`: Improve `--device ?` functionality for the alsa backend.
 
 ### Added
 - [cache] Add `disable-credential-cache` flag (breaking).


### PR DESCRIPTION
This makes `--device ?` only show compatible devices (ones that support 2 ch 44.1 Interleaved) and it shows what `librespot` format(s) they support.

This should be more useful to users as the info maps directly to `librespot`'s `--device` and `--format` options.

The output looks like this:

```

Compatible alsa device(s):

----------------------------------------------

Device:

hw:CARD=Generic,DEV=3

Description:

HD-Audio Generic, HDMI 0
Direct hardware device without any conversions

Supported Format(s):

S32 S16

----------------------------------------------

Device:

hw:CARD=Generic,DEV=7

Description:

HD-Audio Generic, HDMI 1
Direct hardware device without any conversions

Supported Format(s):

S32 S16

----------------------------------------------

Device:

hw:CARD=Generic,DEV=8

Description:

HD-Audio Generic, HDMI 2
Direct hardware device without any conversions

Supported Format(s):

S32 S16

----------------------------------------------

Device:

plughw:CARD=Generic,DEV=3

Description:

HD-Audio Generic, HDMI 0
Hardware device with all software conversions

Supported Format(s):

F64 F32 S32 S24 S16 S24_3

----------------------------------------------

Device:

plughw:CARD=Generic,DEV=7

Description:

HD-Audio Generic, HDMI 1
Hardware device with all software conversions

Supported Format(s):

F64 F32 S32 S24 S16 S24_3

----------------------------------------------

Device:

plughw:CARD=Generic,DEV=8

Description:

HD-Audio Generic, HDMI 2
Hardware device with all software conversions

Supported Format(s):

F64 F32 S32 S24 S16 S24_3

----------------------------------------------

Device:

hdmi:CARD=Generic,DEV=0

Description:

HD-Audio Generic, HDMI 0
HDMI Audio Output

Supported Format(s):

S32 S16

----------------------------------------------

Device:

hdmi:CARD=Generic,DEV=1

Description:

HD-Audio Generic, HDMI 1
HDMI Audio Output

Supported Format(s):

S32 S16

----------------------------------------------

Device:

hdmi:CARD=Generic,DEV=2

Description:

HD-Audio Generic, HDMI 2
HDMI Audio Output

Supported Format(s):

S32 S16

----------------------------------------------

Device:

hw:CARD=DAC,DEV=0

Description:

JDS Labs Element DAC, USB Audio
Direct hardware device without any conversions

Supported Format(s):

S16 S24_3

----------------------------------------------

Device:

hw:CARD=DAC,DEV=1

Description:

JDS Labs Element DAC, USB Audio #1
Direct hardware device without any conversions

Supported Format(s):

S16

----------------------------------------------

Device:

plughw:CARD=DAC,DEV=0

Description:

JDS Labs Element DAC, USB Audio
Hardware device with all software conversions

Supported Format(s):

F64 F32 S32 S24 S16 S24_3

----------------------------------------------

Device:

plughw:CARD=DAC,DEV=1

Description:

JDS Labs Element DAC, USB Audio #1
Hardware device with all software conversions

Supported Format(s):

F64 F32 S32 S24 S16 S24_3

----------------------------------------------

Device:

sysdefault:CARD=DAC

Description:

JDS Labs Element DAC, USB Audio
Default Audio Device

Supported Format(s):

F64 F32 S32 S24 S16 S24_3

----------------------------------------------

Device:

front:CARD=DAC,DEV=0

Description:

JDS Labs Element DAC, USB Audio
Front output / input

Supported Format(s):

S16 S24_3

----------------------------------------------

Device:

surround40:CARD=DAC,DEV=0

Description:

JDS Labs Element DAC, USB Audio
4.0 Surround output to Front and Rear speakers

Supported Format(s):

S16 S24_3

----------------------------------------------

Device:

iec958:CARD=DAC,DEV=0

Description:

JDS Labs Element DAC, USB Audio
IEC958 (S/PDIF) Digital Audio Output

Supported Format(s):

S16 S24_3

----------------------------------------------

```