### PR TITLE
Harden systemd service, update restart policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [main] Enforce reasonable ranges for option values (breaking).
 - [main] Don't evaluate options that would otherwise have no effect.
+- [contrib] Hardened security of the systemd service units
 
 ### Added
 - [cache] Add `disable-credential-cache` flag (breaking).

--- a/contrib/librespot.service
+++ b/contrib/librespot.service
@@ -2,13 +2,14 @@
 Description=Librespot (an open source Spotify client)
 Documentation=https://github.com/librespot-org/librespot
 Documentation=https://github.com/librespot-org/librespot/wiki/Options
-Requires=network-online.target
-After=network-online.target
+Requires=network.target audio.target
+After=network.target audio.target
 
 [Service]
 DynamicUser=yes
 SupplementaryGroups=audio
-Restart=on-failure
+Restart=always
+RestartSec=10
 ExecStart=/usr/bin/librespot --name "%p@%H"
 
 [Install]

--- a/contrib/librespot.service
+++ b/contrib/librespot.service
@@ -6,10 +6,9 @@ Requires=network-online.target
 After=network-online.target
 
 [Service]
-User=nobody
-Group=audio
-Restart=always
-RestartSec=10
+DynamicUser=yes
+SupplementaryGroups=audio
+Restart=on-failure
 ExecStart=/usr/bin/librespot --name "%p@%H"
 
 [Install]

--- a/contrib/librespot.service
+++ b/contrib/librespot.service
@@ -2,8 +2,8 @@
 Description=Librespot (an open source Spotify client)
 Documentation=https://github.com/librespot-org/librespot
 Documentation=https://github.com/librespot-org/librespot/wiki/Options
-Requires=network.target audio.target
-After=network.target audio.target
+Wants=network.target sound.target
+After=network.target sound.target
 
 [Service]
 DynamicUser=yes

--- a/contrib/librespot.user.service
+++ b/contrib/librespot.user.service
@@ -4,8 +4,7 @@ Documentation=https://github.com/librespot-org/librespot
 Documentation=https://github.com/librespot-org/librespot/wiki/Options
 
 [Service]
-Restart=always
-RestartSec=10
+Restart=on-failure
 ExecStart=/usr/bin/librespot --name "%u@%H"
 
 [Install]

--- a/contrib/librespot.user.service
+++ b/contrib/librespot.user.service
@@ -2,9 +2,12 @@
 Description=Librespot (an open source Spotify client)
 Documentation=https://github.com/librespot-org/librespot
 Documentation=https://github.com/librespot-org/librespot/wiki/Options
+Requires=network.target audio.target
+After=network.target audio.target
 
 [Service]
-Restart=on-failure
+Restart=always
+RestartSec=10
 ExecStart=/usr/bin/librespot --name "%u@%H"
 
 [Install]

--- a/contrib/librespot.user.service
+++ b/contrib/librespot.user.service
@@ -2,8 +2,8 @@
 Description=Librespot (an open source Spotify client)
 Documentation=https://github.com/librespot-org/librespot
 Documentation=https://github.com/librespot-org/librespot/wiki/Options
-Requires=network.target audio.target
-After=network.target audio.target
+Wants=network.target sound.target
+After=network.target sound.target
 
 [Service]
 Restart=always


### PR DESCRIPTION
Running as `nobody` throws the following warning:

```
/usr/lib/systemd/system/librespot.service:9: Special user nobody configured, this is not safe!
```

Since it appears librespot doesn't require its own per-say, I've chosen [DynamicUser](https://www.freedesktop.org/software/systemd/man/systemd.exec.html#DynamicUser=), which adds some sand-boxing niceties alongside.

I've also changed the [Restart](https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=) policy to `on-failure` as it would otherwise restart on clean/0 exit codes.