### PR TITLE
Address clippy lint warnings for rust 1.57

### DIFF
--- a/connect/src/context.rs
+++ b/connect/src/context.rs
@@ -46,6 +46,7 @@ pub struct TrackContext {
     // pub metadata: MetadataContext,
 }
 
+#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 #[serde(rename_all = "camelCase")]
 pub struct ArtistContext {
@@ -54,6 +55,7 @@ pub struct ArtistContext {
     image_uri: String,
 }
 
+#[allow(dead_code)]
 #[derive(Deserialize, Debug)]
 pub struct MetadataContext {
     album_title: String,

--- a/core/src/connection/codec.rs
+++ b/core/src/connection/codec.rs
@@ -87,8 +87,7 @@ impl Decoder for ApCodec {
 
                 let mut payload = buf.split_to(size + MAC_SIZE);
 
-                self.decode_cipher
-                    .decrypt(&mut payload.get_mut(..size).unwrap());
+                self.decode_cipher.decrypt(payload.get_mut(..size).unwrap());
                 let mac = payload.split_off(size);
                 self.decode_cipher.check_mac(mac.as_ref())?;
 

--- a/playback/src/audio_backend/jackaudio.rs
+++ b/playback/src/audio_backend/jackaudio.rs
@@ -24,15 +24,12 @@ pub struct JackData {
 impl ProcessHandler for JackData {
     fn process(&mut self, _: &Client, ps: &ProcessScope) -> Control {
         // get output port buffers
-        let mut out_r = self.port_r.as_mut_slice(ps);
-        let mut out_l = self.port_l.as_mut_slice(ps);
-        let buf_r: &mut [f32] = &mut out_r;
-        let buf_l: &mut [f32] = &mut out_l;
+        let buf_r: &mut [f32] = self.port_r.as_mut_slice(ps);
+        let buf_l: &mut [f32] = self.port_l.as_mut_slice(ps);
         // get queue iterator
         let mut queue_iter = self.rec.try_iter();
 
-        let buf_size = buf_r.len();
-        for i in 0..buf_size {
+        for i in 0..buf_r.len() {
             buf_r[i] = queue_iter.next().unwrap_or(0.0);
             buf_l[i] = queue_iter.next().unwrap_or(0.0);
         }

--- a/playback/src/audio_backend/mod.rs
+++ b/playback/src/audio_backend/mod.rs
@@ -104,7 +104,7 @@ use self::gstreamer::GstreamerSink;
 
 #[cfg(any(feature = "rodio-backend", feature = "rodiojack-backend"))]
 mod rodio;
-#[cfg(any(feature = "rodio-backend", feature = "rodiojack-backend"))]
+#[cfg(feature = "rodio-backend")]
 use self::rodio::RodioSink;
 
 #[cfg(feature = "sdl-backend")]

--- a/playback/src/audio_backend/rodio.rs
+++ b/playback/src/audio_backend/rodio.rs
@@ -227,5 +227,6 @@ impl Sink for RodioSink {
 }
 
 impl RodioSink {
+    #[allow(dead_code)]
     pub const NAME: &'static str = "rodio";
 }

--- a/playback/src/mixer/alsamixer.rs
+++ b/playback/src/mixer/alsamixer.rs
@@ -10,6 +10,7 @@ use alsa::{Ctl, Round};
 use std::ffi::CString;
 
 #[derive(Clone)]
+#[allow(dead_code)]
 pub struct AlsaMixer {
     config: MixerConfig,
     min: i64,


### PR DESCRIPTION
I noticed this while building Raspotify packages. Let's see if it doesn't trip up rust 1.48?