### PR TITLE
Add arm64 target example

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -9,8 +9,10 @@
 #
 # If only one architecture is desired, cargo can be invoked directly with the appropriate options :
 # $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features "alsa-backend"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features alsa-backend
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features alsa-backend
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features alsa-backend
+
 # $ docker run -v /tmp/librespot-build:/build librespot-cross contrib/docker-build-pi-armv6hf.sh
 
 FROM debian:stretch


### PR DESCRIPTION
Add arm64 target to docker run examples. 
Remove  feature quotes as they're not necessary and don't match
the non-quoted examples of targets in the cross compile section of the  [WIKI](https://github.com/librespot-org/librespot/wiki/Cross-compiling)