### PR TITLE
player: ensure load threads are done when dropping PlayerInternal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1406,6 +1406,7 @@ dependencies = [
  "librespot-metadata",
  "log",
  "ogg",
+ "parking_lot",
  "portaudio-rs",
  "rand",
  "rand_distr",

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -26,6 +26,7 @@ shell-words = "1.0.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["parking_lot", "rt", "rt-multi-thread", "sync"] }
 zerocopy = { version = "0.3" }
+parking_lot = { version = "0.11", features = ["deadlock_detection"] }
 
 # Backends
 alsa            = { version = "0.5", optional = true }


### PR DESCRIPTION
Fix a race where the load operation was trying to use a disposed tokio
context, resulting in panic.