### PR TITLE
Auto format

### DIFF
--- a/playback/src/audio_backend/gstreamer.rs
+++ b/playback/src/audio_backend/gstreamer.rs
@@ -29,6 +29,7 @@ impl Open for GstreamerSink {
         let gst_format = match format {
             AudioFormat::S24 => "S24_32".to_string(),
             AudioFormat::S24_3 => "S24".to_string(),
+            AudioFormat::Auto => "F32".to_string(),
             _ => format!("{:?}", format),
         };
         let sample_size = format.size();

--- a/playback/src/audio_backend/jackaudio.rs
+++ b/playback/src/audio_backend/jackaudio.rs
@@ -39,10 +39,10 @@ impl ProcessHandler for JackData {
 
 impl Open for JackSink {
     fn open(client_name: Option<String>, format: AudioFormat) -> Self {
-        if format != AudioFormat::F32 {
+        if !matches!(format, AudioFormat::F32 | AudioFormat::Auto) {
             warn!("JACK currently does not support {:?} output", format);
         }
-        info!("Using JACK sink with format {:?}", AudioFormat::F32);
+        info!("Using JACK sink with format {:?}", format);
 
         let client_name = client_name.unwrap_or_else(|| "librespot".to_string());
         let (client, _status) =

--- a/playback/src/audio_backend/mod.rs
+++ b/playback/src/audio_backend/mod.rs
@@ -66,7 +66,7 @@ macro_rules! sink_as_bytes {
                         let samples_s24_3: &[i24] = &converter.f64_to_s24_3(&samples);
                         self.write_bytes(samples_s24_3.as_bytes())
                     }
-                    AudioFormat::S16 => {
+                    AudioFormat::S16 | AudioFormat::Auto => {
                         let samples_s16: &[i16] = &converter.f64_to_s16(&samples);
                         self.write_bytes(samples_s16.as_bytes())
                     }

--- a/playback/src/audio_backend/portaudio.rs
+++ b/playback/src/audio_backend/portaudio.rs
@@ -84,7 +84,7 @@ impl<'a> Open for PortAudioSink<'a> {
             }};
         }
         match format {
-            AudioFormat::F32 => open_sink!(Self::F32, f32),
+            AudioFormat::F32 | AudioFormat::Auto => open_sink!(Self::F32, f32),
             AudioFormat::S32 => open_sink!(Self::S32, i32),
             AudioFormat::S16 => open_sink!(Self::S16, i16),
             _ => {
@@ -153,15 +153,15 @@ impl<'a> Sink for PortAudioSink<'a> {
 
         let result = match self {
             Self::F32(stream, _parameters) => {
-                let samples_f32: &[f32] = &converter.f64_to_f32(&samples);
+                let samples_f32: &[f32] = &converter.f64_to_f32(samples);
                 write_sink!(ref mut stream, samples_f32)
             }
             Self::S32(stream, _parameters) => {
-                let samples_s32: &[i32] = &converter.f64_to_s32(&samples);
+                let samples_s32: &[i32] = &converter.f64_to_s32(samples);
                 write_sink!(ref mut stream, samples_s32)
             }
             Self::S16(stream, _parameters) => {
-                let samples_s16: &[i16] = &converter.f64_to_s16(&samples);
+                let samples_s16: &[i16] = &converter.f64_to_s16(samples);
                 write_sink!(ref mut stream, samples_s16)
             }
         };

--- a/playback/src/audio_backend/pulseaudio.rs
+++ b/playback/src/audio_backend/pulseaudio.rs
@@ -63,6 +63,10 @@ impl Open for PulseAudioSink {
 
         info!("Using PulseAudioSink with format: {:?}", actual_format);
 
+        if actual_format == AudioFormat::Auto {
+            actual_format = AudioFormat::F32;
+        }
+
         Self {
             s: None,
             device,

--- a/playback/src/audio_backend/rodio.rs
+++ b/playback/src/audio_backend/rodio.rs
@@ -174,13 +174,23 @@ pub fn open(host: cpal::Host, device: Option<String>, format: AudioFormat) -> Ro
         host.id().name()
     );
 
-    if format != AudioFormat::S16 && format != AudioFormat::F32 {
+    if !matches!(
+        format,
+        AudioFormat::F32 | AudioFormat::S16 | AudioFormat::Auto
+    ) {
         unimplemented!("Rodio currently only supports F32 and S16 formats");
     }
 
     let (sink, stream) = create_sink(&host, device).unwrap();
 
     debug!("Rodio sink was created");
+
+    let format = if format == AudioFormat::Auto {
+        AudioFormat::F32
+    } else {
+        format
+    };
+
     RodioSink {
         rodio_sink: sink,
         format,

--- a/playback/src/audio_backend/sdl.rs
+++ b/playback/src/audio_backend/sdl.rs
@@ -41,7 +41,7 @@ impl Open for SdlSink {
             }};
         }
         match format {
-            AudioFormat::F32 => open_sink!(Self::F32, f32),
+            AudioFormat::F32 | AudioFormat::Auto => open_sink!(Self::F32, f32),
             AudioFormat::S32 => open_sink!(Self::S32, i32),
             AudioFormat::S16 => open_sink!(Self::S16, i16),
             _ => {

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -39,6 +39,7 @@ pub enum AudioFormat {
     S24,
     S24_3,
     S16,
+    Auto,
 }
 
 impl FromStr for AudioFormat {
@@ -51,6 +52,7 @@ impl FromStr for AudioFormat {
             "S24" => Ok(Self::S24),
             "S24_3" => Ok(Self::S24_3),
             "S16" => Ok(Self::S16),
+            "AUTO" => Ok(Self::Auto),
             _ => Err(()),
         }
     }
@@ -58,7 +60,7 @@ impl FromStr for AudioFormat {
 
 impl Default for AudioFormat {
     fn default() -> Self {
-        Self::S16
+        Self::Auto
     }
 }
 
@@ -69,9 +71,9 @@ impl AudioFormat {
         match self {
             Self::F64 => mem::size_of::<f64>(),
             Self::F32 => mem::size_of::<f32>(),
+            Self::S32 | Self::S24 => mem::size_of::<i32>(),
             Self::S24_3 => mem::size_of::<i24>(),
-            Self::S16 => mem::size_of::<i16>(),
-            _ => mem::size_of::<i32>(), // S32 and S24 are both stored in i32
+            Self::S16 | Self::Auto => mem::size_of::<i16>(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -396,7 +396,7 @@ fn get_setup() -> Setup {
     .optopt(
         FORMAT_SHORT,
         FORMAT,
-        "Output format {F64|F32|S32|S24|S24_3|S16}. Defaults to S16.",
+        "Output format {F64|F32|S32|S24|S24_3|S16|auto}. Defaults to auto.",
         "FORMAT",
     )
     .optopt(
@@ -739,7 +739,7 @@ fn get_setup() -> Setup {
                     FORMAT,
                     FORMAT_SHORT,
                     format,
-                    "F64, F32, S32, S24, S24_3, S16",
+                    "F64, F32, S32, S24, S24_3, S16, auto",
                     default_value,
                 );
 
@@ -1510,8 +1510,8 @@ fn get_setup() -> Setup {
                             DITHER,
                             DITHER_SHORT,
                             &opt_str(DITHER).unwrap_or_default(),
-                            "none, gpdf, tpdf, tpdf_hp for formats S16, S24, S24_3, S32, none for formats F32, F64",
-                            "tpdf for formats S16, S24, S24_3 and none for formats S32, F32, F64",
+                            "none, gpdf, tpdf, tpdf_hp for formats S16, S24, S24_3, S32, none for formats F32, F64, auto",
+                            "tpdf for formats S16, S24, S24_3 and none for formats S32, F32, F64, auto",
                         );
 
                         exit(1);


### PR DESCRIPTION
Auto audio format:

alsa: auto = try to find the actual highest supported format.
pipe: auto = S16.
gstreamer, jackaudio, portaudio, pulseaudio, rodio, sdl: auto = F32

Also for bonus points clean up a clippy lint that was introduced in https://github.com/librespot-org/librespot/pull/920.