### PR TITLE
New dynamic limiter for very wide dynamic ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [contrib] Hardened security of the systemd service units
 - [main] Verbose logging mode (`-v`, `--verbose`) now logs all parsed environment variables and command line arguments (credentials are redacted).
 - [playback] `Sink`: `write()` now receives ownership of the packet (breaking).
+- [playback] More robust dynamic limiter for very wide dynamic range (breaking)
 
 ### Added
 - [cache] Add `disable-credential-cache` flag (breaking).

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -1,10 +1,7 @@
-use super::player::db_to_ratio;
-use crate::convert::i24;
-pub use crate::dither::{mk_ditherer, DithererBuilder, TriangularDitherer};
+use std::{mem, str::FromStr, time::Duration};
 
-use std::mem;
-use std::str::FromStr;
-use std::time::Duration;
+pub use crate::dither::{mk_ditherer, DithererBuilder, TriangularDitherer};
+use crate::{convert::i24, player::duration_to_coefficient};
 
 #[derive(Clone, Copy, Debug, Hash, PartialOrd, Ord, PartialEq, Eq)]
 pub enum Bitrate {
@@ -133,11 +130,11 @@ pub struct PlayerConfig {
     pub normalisation: bool,
     pub normalisation_type: NormalisationType,
     pub normalisation_method: NormalisationMethod,
-    pub normalisation_pregain: f64,
-    pub normalisation_threshold: f64,
-    pub normalisation_attack: Duration,
-    pub normalisation_release: Duration,
-    pub normalisation_knee: f64,
+    pub normalisation_pregain_db: f32,
+    pub normalisation_threshold_dbfs: f32,
+    pub normalisation_attack_cf: f64,
+    pub normalisation_release_cf: f64,
+    pub normalisation_knee_db: f32,
 
     // pass function pointers so they can be lazily instantiated *after* spawning a thread
     // (thereby circumventing Send bounds that they might not satisfy)
@@ -152,11 +149,11 @@ impl Default for PlayerConfig {
             normalisation: false,
             normalisation_type: NormalisationType::default(),
             normalisation_method: NormalisationMethod::default(),
-            normalisation_pregain: 0.0,
-            normalisation_threshold: db_to_ratio(-2.0),
-            normalisation_attack: Duration::from_millis(5),
-            normalisation_release: Duration::from_millis(100),
-            normalisation_knee: 1.0,
+            normalisation_pregain_db: 0.0,
+            normalisation_threshold_dbfs: -2.0,
+            normalisation_attack_cf: duration_to_coefficient(Duration::from_millis(5)),
+            normalisation_release_cf: duration_to_coefficient(Duration::from_millis(100)),
+            normalisation_knee_db: 5.0,
             passthrough: false,
             ditherer: Some(mk_ditherer::<TriangularDitherer>),
         }

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -131,10 +131,10 @@ pub struct PlayerConfig {
     pub normalisation_type: NormalisationType,
     pub normalisation_method: NormalisationMethod,
     pub normalisation_pregain_db: f32,
-    pub normalisation_threshold_dbfs: f32,
+    pub normalisation_threshold_dbfs: f64,
     pub normalisation_attack_cf: f64,
     pub normalisation_release_cf: f64,
-    pub normalisation_knee_db: f32,
+    pub normalisation_knee_db: f64,
 
     // pass function pointers so they can be lazily instantiated *after* spawning a thread
     // (thereby circumventing Send bounds that they might not satisfy)

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ use librespot::playback::dither;
 #[cfg(feature = "alsa-backend")]
 use librespot::playback::mixer::alsamixer::AlsaMixer;
 use librespot::playback::mixer::{self, MixerConfig, MixerFn};
-use librespot::playback::player::{db_to_ratio, ratio_to_db, Player};
+use librespot::playback::player::{coefficient_to_duration, duration_to_coefficient, Player};
 
 mod player_event_handler;
 use player_event_handler::{emit_sink_event, run_program_on_events};
@@ -186,9 +186,9 @@ struct Setup {
 fn get_setup() -> Setup {
     const VALID_INITIAL_VOLUME_RANGE: RangeInclusive<u16> = 0..=100;
     const VALID_VOLUME_RANGE: RangeInclusive<f64> = 0.0..=100.0;
-    const VALID_NORMALISATION_KNEE_RANGE: RangeInclusive<f64> = 0.0..=2.0;
-    const VALID_NORMALISATION_PREGAIN_RANGE: RangeInclusive<f64> = -10.0..=10.0;
-    const VALID_NORMALISATION_THRESHOLD_RANGE: RangeInclusive<f64> = -10.0..=0.0;
+    const VALID_NORMALISATION_KNEE_RANGE: RangeInclusive<f32> = 0.0..=2.0;
+    const VALID_NORMALISATION_PREGAIN_RANGE: RangeInclusive<f32> = -10.0..=10.0;
+    const VALID_NORMALISATION_THRESHOLD_RANGE: RangeInclusive<f32> = -10.0..=0.0;
     const VALID_NORMALISATION_ATTACK_RANGE: RangeInclusive<u64> = 1..=500;
     const VALID_NORMALISATION_RELEASE_RANGE: RangeInclusive<u64> = 1..=1000;
 
@@ -540,7 +540,7 @@ fn get_setup() -> Setup {
     .optopt(
         NORMALISATION_KNEE_SHORT,
         NORMALISATION_KNEE,
-        "Knee steepness of the dynamic limiter from 0.0 to 2.0. Defaults to 1.0.",
+        "Knee width (dB) of the dynamic limiter from 0.0 to 10.0. Defaults to 5.0.",
         "KNEE",
     )
     .optopt(
@@ -1287,11 +1287,11 @@ fn get_setup() -> Setup {
 
         let normalisation_method;
         let normalisation_type;
-        let normalisation_pregain;
-        let normalisation_threshold;
-        let normalisation_attack;
-        let normalisation_release;
-        let normalisation_knee;
+        let normalisation_pregain_db;
+        let normalisation_threshold_dbfs;
+        let normalisation_attack_cf;
+        let normalisation_release_cf;
+        let normalisation_knee_db;
 
         if !normalisation {
             for a in &[
@@ -1314,11 +1314,11 @@ fn get_setup() -> Setup {
 
             normalisation_method = player_default_config.normalisation_method;
             normalisation_type = player_default_config.normalisation_type;
-            normalisation_pregain = player_default_config.normalisation_pregain;
-            normalisation_threshold = player_default_config.normalisation_threshold;
-            normalisation_attack = player_default_config.normalisation_attack;
-            normalisation_release = player_default_config.normalisation_release;
-            normalisation_knee = player_default_config.normalisation_knee;
+            normalisation_pregain_db = player_default_config.normalisation_pregain_db;
+            normalisation_threshold_dbfs = player_default_config.normalisation_threshold_dbfs;
+            normalisation_attack_cf = player_default_config.normalisation_attack_cf;
+            normalisation_release_cf = player_default_config.normalisation_release_cf;
+            normalisation_knee_db = player_default_config.normalisation_knee_db;
         } else {
             normalisation_method = opt_str(NORMALISATION_METHOD)
                 .as_deref()
@@ -1368,8 +1368,8 @@ fn get_setup() -> Setup {
                 })
                 .unwrap_or(player_default_config.normalisation_type);
 
-            normalisation_pregain = opt_str(NORMALISATION_PREGAIN)
-                .map(|pregain| match pregain.parse::<f64>() {
+            normalisation_pregain_db = opt_str(NORMALISATION_PREGAIN)
+                .map(|pregain| match pregain.parse::<f32>() {
                     Ok(value) if (VALID_NORMALISATION_PREGAIN_RANGE).contains(&value) => value,
                     _ => {
                         let valid_values = &format!(
@@ -1383,19 +1383,17 @@ fn get_setup() -> Setup {
                             NORMALISATION_PREGAIN_SHORT,
                             &pregain,
                             valid_values,
-                            &player_default_config.normalisation_pregain.to_string(),
+                            &player_default_config.normalisation_pregain_db.to_string(),
                         );
 
                         exit(1);
                     }
                 })
-                .unwrap_or(player_default_config.normalisation_pregain);
+                .unwrap_or(player_default_config.normalisation_pregain_db);
 
-            normalisation_threshold = opt_str(NORMALISATION_THRESHOLD)
-                .map(|threshold| match threshold.parse::<f64>() {
-                    Ok(value) if (VALID_NORMALISATION_THRESHOLD_RANGE).contains(&value) => {
-                        db_to_ratio(value)
-                    }
+            normalisation_threshold_dbfs = opt_str(NORMALISATION_THRESHOLD)
+                .map(|threshold| match threshold.parse::<f32>() {
+                    Ok(value) if (VALID_NORMALISATION_THRESHOLD_RANGE).contains(&value) => value,
                     _ => {
                         let valid_values = &format!(
                             "{} - {}",
@@ -1408,18 +1406,20 @@ fn get_setup() -> Setup {
                             NORMALISATION_THRESHOLD_SHORT,
                             &threshold,
                             valid_values,
-                            &ratio_to_db(player_default_config.normalisation_threshold).to_string(),
+                            &player_default_config
+                                .normalisation_threshold_dbfs
+                                .to_string(),
                         );
 
                         exit(1);
                     }
                 })
-                .unwrap_or(player_default_config.normalisation_threshold);
+                .unwrap_or(player_default_config.normalisation_threshold_dbfs);
 
-            normalisation_attack = opt_str(NORMALISATION_ATTACK)
+            normalisation_attack_cf = opt_str(NORMALISATION_ATTACK)
                 .map(|attack| match attack.parse::<u64>() {
                     Ok(value) if (VALID_NORMALISATION_ATTACK_RANGE).contains(&value) => {
-                        Duration::from_millis(value)
+                        duration_to_coefficient(Duration::from_millis(value))
                     }
                     _ => {
                         let valid_values = &format!(
@@ -1433,8 +1433,7 @@ fn get_setup() -> Setup {
                             NORMALISATION_ATTACK_SHORT,
                             &attack,
                             valid_values,
-                            &player_default_config
-                                .normalisation_attack
+                            &coefficient_to_duration(player_default_config.normalisation_attack_cf)
                                 .as_millis()
                                 .to_string(),
                         );
@@ -1442,12 +1441,12 @@ fn get_setup() -> Setup {
                         exit(1);
                     }
                 })
-                .unwrap_or(player_default_config.normalisation_attack);
+                .unwrap_or(player_default_config.normalisation_attack_cf);
 
-            normalisation_release = opt_str(NORMALISATION_RELEASE)
+            normalisation_release_cf = opt_str(NORMALISATION_RELEASE)
                 .map(|release| match release.parse::<u64>() {
                     Ok(value) if (VALID_NORMALISATION_RELEASE_RANGE).contains(&value) => {
-                        Duration::from_millis(value)
+                        duration_to_coefficient(Duration::from_millis(value))
                     }
                     _ => {
                         let valid_values = &format!(
@@ -1461,19 +1460,20 @@ fn get_setup() -> Setup {
                             NORMALISATION_RELEASE_SHORT,
                             &release,
                             valid_values,
-                            &player_default_config
-                                .normalisation_release
-                                .as_millis()
-                                .to_string(),
+                            &coefficient_to_duration(
+                                player_default_config.normalisation_release_cf,
+                            )
+                            .as_millis()
+                            .to_string(),
                         );
 
                         exit(1);
                     }
                 })
-                .unwrap_or(player_default_config.normalisation_release);
+                .unwrap_or(player_default_config.normalisation_release_cf);
 
-            normalisation_knee = opt_str(NORMALISATION_KNEE)
-                .map(|knee| match knee.parse::<f64>() {
+            normalisation_knee_db = opt_str(NORMALISATION_KNEE)
+                .map(|knee| match knee.parse::<f32>() {
                     Ok(value) if (VALID_NORMALISATION_KNEE_RANGE).contains(&value) => value,
                     _ => {
                         let valid_values = &format!(
@@ -1487,13 +1487,13 @@ fn get_setup() -> Setup {
                             NORMALISATION_KNEE_SHORT,
                             &knee,
                             valid_values,
-                            &player_default_config.normalisation_knee.to_string(),
+                            &player_default_config.normalisation_knee_db.to_string(),
                         );
 
                         exit(1);
                     }
                 })
-                .unwrap_or(player_default_config.normalisation_knee);
+                .unwrap_or(player_default_config.normalisation_knee_db);
         }
 
         let ditherer_name = opt_str(DITHER);
@@ -1535,11 +1535,11 @@ fn get_setup() -> Setup {
             normalisation,
             normalisation_type,
             normalisation_method,
-            normalisation_pregain,
-            normalisation_threshold,
-            normalisation_attack,
-            normalisation_release,
-            normalisation_knee,
+            normalisation_pregain_db,
+            normalisation_threshold_dbfs,
+            normalisation_attack_cf,
+            normalisation_release_cf,
+            normalisation_knee_db,
             ditherer,
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -186,9 +186,9 @@ struct Setup {
 fn get_setup() -> Setup {
     const VALID_INITIAL_VOLUME_RANGE: RangeInclusive<u16> = 0..=100;
     const VALID_VOLUME_RANGE: RangeInclusive<f64> = 0.0..=100.0;
-    const VALID_NORMALISATION_KNEE_RANGE: RangeInclusive<f32> = 0.0..=2.0;
+    const VALID_NORMALISATION_KNEE_RANGE: RangeInclusive<f64> = 0.0..=10.0;
     const VALID_NORMALISATION_PREGAIN_RANGE: RangeInclusive<f32> = -10.0..=10.0;
-    const VALID_NORMALISATION_THRESHOLD_RANGE: RangeInclusive<f32> = -10.0..=0.0;
+    const VALID_NORMALISATION_THRESHOLD_RANGE: RangeInclusive<f64> = -10.0..=0.0;
     const VALID_NORMALISATION_ATTACK_RANGE: RangeInclusive<u64> = 1..=500;
     const VALID_NORMALISATION_RELEASE_RANGE: RangeInclusive<u64> = 1..=1000;
 
@@ -1392,7 +1392,7 @@ fn get_setup() -> Setup {
                 .unwrap_or(player_default_config.normalisation_pregain_db);
 
             normalisation_threshold_dbfs = opt_str(NORMALISATION_THRESHOLD)
-                .map(|threshold| match threshold.parse::<f32>() {
+                .map(|threshold| match threshold.parse::<f64>() {
                     Ok(value) if (VALID_NORMALISATION_THRESHOLD_RANGE).contains(&value) => value,
                     _ => {
                         let valid_values = &format!(
@@ -1473,7 +1473,7 @@ fn get_setup() -> Setup {
                 .unwrap_or(player_default_config.normalisation_release_cf);
 
             normalisation_knee_db = opt_str(NORMALISATION_KNEE)
-                .map(|knee| match knee.parse::<f32>() {
+                .map(|knee| match knee.parse::<f64>() {
                     Ok(value) if (VALID_NORMALISATION_KNEE_RANGE).contains(&value) => value,
                     _ => {
                         let valid_values = &format!(


### PR DESCRIPTION
Well that was a fun exercise! This time I actually think I know what I'm doing.

The current dynamic limiter was an amateur attempt that worked within a limited range and first Rust code I ever wrote. This time I took a article from the Journal of the Audio Engineering Society [1] and wrote a fresh implementation of the most recommended variant (feed-forward in the log domain with a smooth, decoupled peak detector).

So far it seems to work beautifully, including the tracks with wide dynamic range in the linked issue. Would be nice if some of you could give this a spin on various genres and let me know how it goes.

I purposely changed the field names to signal developers downstream that some of these fields now hold values in a different unit. Before in `0.2.0` this caused distorted audio for some other applications and I'd like to prevent that this time.

Closes: #934

[1] [Giannoulis, D., Massberg, M., & Reiss, J.D. (2012). Digital Dynamic Range Compressor Design—A Tutorial and Analysis. Journal of The Audio Engineering Society, 60, 399-408](https://github.com/librespot-org/librespot/files/7850566/GiannoulisMassbergReiss-dynamicrangecompression-JAES2012.pdf)