### PR TITLE
Fix `--device` argument to various backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [contrib] Hardened security of the systemd service units
 - [main] Verbose logging mode (`-v`, `--verbose`) now logs all parsed environment variables and command line arguments (credentials are redacted).
 - [playback] `Sink`: `write()` now receives ownership of the packet (breaking).
+- [playback] `pipe`: create file if it doesn't already exist
 
 ### Added
 - [cache] Add `disable-credential-cache` flag (breaking).

--- a/src/main.rs
+++ b/src/main.rs
@@ -748,44 +748,12 @@ fn get_setup() -> Setup {
         })
         .unwrap_or_default();
 
-    #[cfg(any(
-        feature = "alsa-backend",
-        feature = "rodio-backend",
-        feature = "portaudio-backend"
-    ))]
     let device = opt_str(DEVICE);
-
-    #[cfg(any(
-        feature = "alsa-backend",
-        feature = "rodio-backend",
-        feature = "portaudio-backend"
-    ))]
     if let Some(ref value) = device {
         if value == "?" {
             backend(device, format);
             exit(0);
-        } else if value.is_empty() {
-            empty_string_error_msg(DEVICE, DEVICE_SHORT);
         }
-    }
-
-    #[cfg(not(any(
-        feature = "alsa-backend",
-        feature = "rodio-backend",
-        feature = "portaudio-backend"
-    )))]
-    let device: Option<String> = None;
-
-    #[cfg(not(any(
-        feature = "alsa-backend",
-        feature = "rodio-backend",
-        feature = "portaudio-backend"
-    )))]
-    if opt_present(DEVICE) {
-        warn!(
-            "The `--{}` / `-{}` option is not supported by the included audio backend(s), and has no effect.",
-            DEVICE, DEVICE_SHORT,
-        );
     }
 
     #[cfg(feature = "alsa-backend")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -753,6 +753,8 @@ fn get_setup() -> Setup {
         if value == "?" {
             backend(device, format);
             exit(0);
+        } else if value.is_empty() {
+            empty_string_error_msg(DEVICE, DEVICE_SHORT);
         }
     }
 


### PR DESCRIPTION
Fixes #936.

This removes the `The ``--{}`` / ``-{}`` option is not supported by the included audio backend(s), and has no effect.` message that was introduced by @JasonLG1979. I couldn't find an easy and maintainable way of implementing this in all backends (like a `fn supports_device() -> bool where Self:: Sized` method in the `Sink` trait) and thought that low code complexity trumps here.

Also some small cleanups and the change that `pipe` now creates a file if it didn't already exist.