### PR TITLE
Fix Alsa softvol linear mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] Don't panic when parsing options. Instead list valid values and exit.
 - [main] `--alsa-mixer-device` and `--alsa-mixer-index` now fallback to the card and index specified in `--device`.
 - [core] Removed unsafe code (breaking)
+- [playback] `alsa`: Use `--volume-range` overrides for softvol controls
 
 ### Removed
 - [playback] `alsamixer`: previously deprecated option `mixer-card` has been removed.


### PR DESCRIPTION
When `--volume-range` was set, that propagated to the mapped volume control, but not to the Alsa mixer itself. This caused incorrect `mapped_to_linear` calculations.

Fixes: #948