### PR TITLE
Upgrade to Symphonia v0.5.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,9 +2726,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "symphonia"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7e5f38aa07e792f4eebb0faa93cee088ec82c48222dd332897aae1569d9a4b7"
+checksum = "eb30457ee7a904dae1e4ace25156dcabaf71e425db318e7885267f09cd8fb648"
 dependencies = [
  "lazy_static",
  "symphonia-bundle-mp3",
@@ -2740,9 +2740,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-bundle-mp3"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec4d97c4a61ece4651751dddb393ebecb7579169d9e758ae808fe507a5250790"
+checksum = "9130cae661447f234b58759d74d23500e9c95697b698589b34196cb0fb488a61"
 dependencies = [
  "bitflags",
  "lazy_static",
@@ -2753,9 +2753,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-codec-vorbis"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a29ed6748078effb35a05064a451493a78038918981dc1a76bdf5a2752d441fa"
+checksum = "746fc459966b37e277565f9632e5ffd6cbd83d9381152727123f68484cb8f9c4"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2764,9 +2764,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-core"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa135e97be0f4a666c31dfe5ef4c75435ba3d355fd6a73d2100aa79b14c104c9"
+checksum = "1edcb254d25e02b688b6f8a290a778153fa5f29674ac50773d03e0a16060391d"
 dependencies = [
  "arrayvec",
  "bitflags",
@@ -2777,9 +2777,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-format-ogg"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7b2357288a79adfec532cfd86049696cfa5c58efeff83bd51687a528f18a519"
+checksum = "00f5b92a2a6370873d9dbe3326dad1bf795b3151efcadca6e5f47d732499a518"
 dependencies = [
  "log",
  "symphonia-core",
@@ -2789,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-metadata"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5260599daba18d8fe905ca3eb3b42ba210529a6276886632412cc74984e79b1a"
+checksum = "f04ee665c99fd2b919b87261c86a5312e996b720ca142646a163d9583e72bd0e"
 dependencies = [
  "encoding_rs",
  "lazy_static",
@@ -2801,9 +2801,9 @@ dependencies = [
 
 [[package]]
 name = "symphonia-utils-xiph"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a37026c6948ff842e0bf94b4008579cc71ab16ed0ff9ca70a331f60f4f1e1e9"
+checksum = "abadfa53359fa437836f2554a0019dd06bfdf742fbb735d0645db3b6c5a763e0"
 dependencies = [
  "symphonia-core",
  "symphonia-metadata",

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -43,7 +43,7 @@ rodio           = { version = "0.15", optional = true, default-features = false 
 cpal            = { version = "0.13", optional = true }
 
 # Container and audio decoder
-symphonia = { version = "0.4", default-features = false, features = ["mp3", "ogg", "vorbis"] }
+symphonia = { version = "0.5", default-features = false, features = ["mp3", "ogg", "vorbis"] }
 
 # Legacy Ogg container decoder for the passthrough decoder
 ogg = { version = "0.8", optional = true }

--- a/playback/src/decoder/symphonia_decoder.rs
+++ b/playback/src/decoder/symphonia_decoder.rs
@@ -5,7 +5,7 @@ use symphonia::{
         audio::SampleBuffer,
         codecs::{Decoder, DecoderOptions},
         errors::Error,
-        formats::{FormatReader, SeekMode, SeekTo},
+        formats::{FormatOptions, FormatReader, SeekMode, SeekTo},
         io::{MediaSource, MediaSourceStream, MediaSourceStreamOptions},
         meta::{StandardTagKey, Value},
         units::Time,
@@ -40,7 +40,11 @@ impl SymphoniaDecoder {
         };
         let mss = MediaSourceStream::new(Box::new(input), mss_opts);
 
-        let format_opts = Default::default();
+        let format_opts = FormatOptions {
+            enable_gapless: true,
+            ..Default::default()
+        };
+
         let format: Box<dyn FormatReader> = if AudioFiles::is_ogg_vorbis(file_format) {
             Box::new(OggReader::try_new(mss, &format_opts)?)
         } else if AudioFiles::is_mp3(file_format) {
@@ -188,7 +192,7 @@ impl AudioDecoder for SymphoniaDecoder {
                 }
             };
 
-            let position_ms = self.ts_to_ms(packet.pts());
+            let position_ms = self.ts_to_ms(packet.ts());
             let packet_position = AudioPacketPosition {
                 position_ms,
                 skipped,

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -2210,7 +2210,7 @@ impl<T: Read + Seek> Seek for Subfile<T> {
 
 impl<R> MediaSource for Subfile<R>
 where
-    R: Read + Seek + Send,
+    R: Read + Seek + Send + Sync,
 {
     fn is_seekable(&self) -> bool {
         true


### PR DESCRIPTION
Hello!

This PR updates Symphonia to the newly published v0.5. This release adds gapless playback support (enabled for both Vorbis and MP3), and generally fixes many other quality and/or performance bugs.

I've been running a forked version of librespot with a git version of Symphonia for a couple weeks now and haven't encountered any problems.