### PR TITLE
Quantum Realm level normalisation optimization

### DIFF
--- a/playback/src/convert.rs
+++ b/playback/src/convert.rs
@@ -70,8 +70,19 @@ impl Converter {
     // necessary for other formats, because casting to integer will saturate
     // to the bounds of the primitive.
     pub fn clamping_scale(&mut self, sample: f64, factor: f64) -> f64 {
+        let int_value = self.scale(sample, factor);
+
         // In two's complement, there are more negative than positive values.
-        f64::min(f64::max(self.scale(sample, factor), -factor), factor - 1.0)
+        let min = -factor;
+        let max = factor - 1.0;
+
+        if int_value < min {
+            min
+        } else if int_value > max {
+            max
+        } else {
+            int_value
+        }
     }
 
     pub fn f64_to_f32(&mut self, samples: &[f64]) -> Vec<f32> {

--- a/playback/src/convert.rs
+++ b/playback/src/convert.rs
@@ -23,14 +23,15 @@ pub struct Converter {
 
 impl Converter {
     pub fn new(dither_config: Option<DithererBuilder>) -> Self {
-        if let Some(ref ditherer_builder) = dither_config {
-            let ditherer = (ditherer_builder)();
-            info!("Converting with ditherer: {}", ditherer.name());
-            Self {
-                ditherer: Some(ditherer),
+        match dither_config {
+            Some(ditherer_builder) => {
+                let ditherer = (ditherer_builder)();
+                info!("Converting with ditherer: {}", ditherer.name());
+                Self {
+                    ditherer: Some(ditherer),
+                }
             }
-        } else {
-            Self { ditherer: None }
+            None => Self { ditherer: None },
         }
     }
 
@@ -52,18 +53,15 @@ impl Converter {
     const SCALE_S16: f64 = 32768.;
 
     pub fn scale(&mut self, sample: f64, factor: f64) -> f64 {
-        let dither = match self.ditherer {
-            Some(ref mut d) => d.noise(),
-            None => 0.0,
-        };
-
         // From the many float to int conversion methods available, match what
         // the reference Vorbis implementation uses: sample * 32768 (for 16 bit)
-        let int_value = sample * factor + dither;
 
         // Casting float to integer rounds towards zero by default, i.e. it
         // truncates, and that generates larger error than rounding to nearest.
-        int_value.round()
+        match self.ditherer.as_mut() {
+            Some(d) => (sample * factor + d.noise()).round(),
+            None => (sample * factor).round(),
+        }
     }
 
     // Special case for samples packed in a word of greater bit depth (e.g.
@@ -72,18 +70,8 @@ impl Converter {
     // necessary for other formats, because casting to integer will saturate
     // to the bounds of the primitive.
     pub fn clamping_scale(&mut self, sample: f64, factor: f64) -> f64 {
-        let int_value = self.scale(sample, factor);
-
         // In two's complement, there are more negative than positive values.
-        let min = -factor;
-        let max = factor - 1.0;
-
-        if int_value < min {
-            return min;
-        } else if int_value > max {
-            return max;
-        }
-        int_value
+        f64::min(f64::max(self.scale(sample, factor), -factor), factor - 1.0)
     }
 
     pub fn f64_to_f32(&mut self, samples: &[f64]) -> Vec<f32> {
@@ -109,12 +97,7 @@ impl Converter {
     pub fn f64_to_s24_3(&mut self, samples: &[f64]) -> Vec<i24> {
         samples
             .iter()
-            .map(|sample| {
-                // Not as DRY as calling f32_to_s24 first, but this saves iterating
-                // over all samples twice.
-                let int_value = self.clamping_scale(*sample, Self::SCALE_S24) as i32;
-                i24::from_s24(int_value)
-            })
+            .map(|sample| i24::from_s24(self.clamping_scale(*sample, Self::SCALE_S24) as i32))
             .collect()
     }
 

--- a/playback/src/dither.rs
+++ b/playback/src/dither.rs
@@ -3,7 +3,7 @@ use rand::SeedableRng;
 use rand_distr::{Distribution, Normal, Triangular, Uniform};
 use std::fmt;
 
-const NUM_CHANNELS: usize = 2;
+use crate::NUM_CHANNELS;
 
 // Dithering lowers digital-to-analog conversion ("requantization") error,
 // linearizing output, lowering distortion and replacing it with a constant,
@@ -102,7 +102,7 @@ impl GaussianDitherer {
 
 pub struct HighPassDitherer {
     active_channel: usize,
-    previous_noises: [f64; NUM_CHANNELS],
+    previous_noises: [f64; NUM_CHANNELS as usize],
     cached_rng: SmallRng,
     distribution: Uniform<f64>,
 }
@@ -111,7 +111,7 @@ impl Ditherer for HighPassDitherer {
     fn new() -> Self {
         Self {
             active_channel: 0,
-            previous_noises: [0.0; NUM_CHANNELS],
+            previous_noises: [0.0; NUM_CHANNELS as usize],
             cached_rng: create_rng(),
             distribution: Uniform::new_inclusive(-0.5, 0.5), // 1 LSB +/- 1 LSB (previous) = 2 LSB
         }


### PR DESCRIPTION
* We don't need to test against EPSILON. The factor will never be over 1.0 in basic normalisation mode.

* Don't check the normalisation mode EVERY sample.

* Do as little math as possible by simplfiying all equations as much as possible (while still retaining the textbook equations in comments).

This saves up to 1-2% CPU useage on a PI 4 depending on how much normalisation is actually being done.