### PR TITLE
Only log runtime argument if it starts with a dash "-"

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -661,6 +661,7 @@ fn get_setup() -> Setup {
             let opt = key.trim_start_matches('-');
 
             if index > 0
+                && key.starts_with('-')
                 && &args[index - 1] != key
                 && matches.opt_defined(opt)
                 && matches.opt_present(opt)


### PR DESCRIPTION
When there's a value that corresponds to an argument name used in the same command line, the logging of the arguments gets confused and logs the matching argument, but without the leading dash:

```
% target/debug/librespot -n c --verbose -c /path/to/my/cache
[2022-02-07T22:32:25Z INFO  librespot] librespot 0.3.1 55ced49 (Built on 2022-02-07, Build ID: qaEB8kEW, Profile: debug)
[2022-02-07T22:32:25Z TRACE librespot] Command line argument(s):
[2022-02-07T22:32:25Z TRACE librespot] 		-n "c"
[2022-02-07T22:32:25Z TRACE librespot] 		c "/path/to/my/cache"
[2022-02-07T22:32:25Z TRACE librespot] 		--verbose
[2022-02-07T22:32:25Z TRACE librespot] 		-c "/path/to/my/cache"
```

Here we're using the literal `c` as the device name, and the `-c` argument. Thus the `c /path/to/my/cache` is logged in addition to `-c /path...`.

After checking whether the key has a leading dash, this issue is gone:

```
% target/debug/librespot -n c --verbose -c /path/to/my/cache
[2022-02-07T22:32:41Z INFO  librespot] librespot 0.3.1 55ced49 (Built on 2022-02-07, Build ID: qaEB8kEW, Profile: debug)
[2022-02-07T22:32:41Z TRACE librespot] Command line argument(s):
[2022-02-07T22:32:41Z TRACE librespot] 		-n "c"
[2022-02-07T22:32:41Z TRACE librespot] 		--verbose
[2022-02-07T22:32:41Z TRACE librespot] 		-c "/path/to/my/cache"
```