### PR TITLE
Set the PulseAudio name to match librespot's device name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] Add a `-q`, `--quiet` option that changes the logging level to warn.
 - [main] Add a short name for every flag and option.
 - [main] Add the ability to parse environment variables.
+- [playback] `pulseaudio`: set the PulseAudio name to match librespot's device name via `PULSE_PROP_application.name` environment variable (user set env var value takes precedence). (breaking)
+- [playback] `pulseaudio`: set icon to `audio-x-generic` so we get an icon instead of a placeholder via `PULSE_PROP_application.icon_name` environment variable (user set env var value takes precedence). (breaking)
+- [playback] `pulseaudio`: set values to: `PULSE_PROP_application.version`, `PULSE_PROP_application.process.binary`, `PULSE_PROP_stream.description`, `PULSE_PROP_media.software` and `PULSE_PROP_media.role` environment variables (user set env var values take precedence). (breaking)
 
 ### Fixed
 - [main] Prevent hang when discovery is disabled and there are no credentials or when bad credentials are given.

--- a/src/main.rs
+++ b/src/main.rs
@@ -1124,6 +1124,43 @@ fn get_setup() -> Setup {
             exit(1);
         }
 
+        #[cfg(feature = "pulseaudio-backend")]
+        {
+            if env::var("PULSE_PROP_application.name").is_err() {
+                let pulseaudio_name = if name != connect_default_config.name {
+                    format!("{} - {}", connect_default_config.name, name)
+                } else {
+                    name.clone()
+                };
+
+                env::set_var("PULSE_PROP_application.name", pulseaudio_name);
+            }
+
+            if env::var("PULSE_PROP_application.version").is_err() {
+                env::set_var("PULSE_PROP_application.version", version::SEMVER);
+            }
+
+            if env::var("PULSE_PROP_application.icon_name").is_err() {
+                env::set_var("PULSE_PROP_application.icon_name", "audio-x-generic");
+            }
+
+            if env::var("PULSE_PROP_application.process.binary").is_err() {
+                env::set_var("PULSE_PROP_application.process.binary", "librespot");
+            }
+
+            if env::var("PULSE_PROP_stream.description").is_err() {
+                env::set_var("PULSE_PROP_stream.description", "Spotify Connect endpoint");
+            }
+
+            if env::var("PULSE_PROP_media.software").is_err() {
+                env::set_var("PULSE_PROP_media.software", "Spotify");
+            }
+
+            if env::var("PULSE_PROP_media.role").is_err() {
+                env::set_var("PULSE_PROP_media.role", "music");
+            }
+        }
+
         let initial_volume = opt_str(INITIAL_VOLUME)
             .map(|initial_volume| {
                 let volume = match initial_volume.parse::<u16>() {


### PR DESCRIPTION
This sets the name displayed by PulseAudio to `Librespot - Instance Name` if a name is given otherwise `Librespot` (the default name).

`librespot -n "Instance Name"` Results in:

![Screenshot from 2022-03-08 17-39-23](https://user-images.githubusercontent.com/6667703/157344531-59c0b8eb-f793-4eee-a01f-0b56387857db.png)

This also sets the correct "role" to "music" as per the docs:

https://www.freedesktop.org/wiki/Software/PulseAudio/Documentation/Developer/Clients/ApplicationProperties/

PA_PROP_MEDIA_ROLE

"This is a property of the actual streamed data, not so much the application"

Roles are used for policies, things like automatically muting a music player when a call comes in and whatnot.

For bonus points this also sets `PULSE_PROP_application.icon_name` to `audio-x-generic` so that we get a nice icon in the PulseAudio settings by our name instead of a missing icon placeholder.
