### PR TITLE
adding callback for reusable credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] `Sink`: `write()` now receives ownership of the packet (breaking).
 - [playback] `pipe`: create file if it doesn't already exist
 - [playback] More robust dynamic limiter for very wide dynamic range (breaking)
+- [core] `Session`: `connect()` now returns the long-term credentials.
+- [core] `Session`: `connect()` now accespt a flag if the credentails should be stored via the cache.
 
 ### Added
 - [cache] Add `disable-credential-cache` flag (breaking).

--- a/core/tests/connect.rs
+++ b/core/tests/connect.rs
@@ -13,6 +13,7 @@ async fn test_connection() {
             SessionConfig::default(),
             Credentials::with_password("test", "test"),
             None,
+            false,
         )
         .await;
 

--- a/examples/get_token.rs
+++ b/examples/get_token.rs
@@ -20,7 +20,7 @@ async fn main() {
 
     println!("Connecting..");
     let credentials = Credentials::with_password(&args[1], &args[2]);
-    let session = Session::connect(session_config, credentials, None)
+    let (session, _) = Session::connect(session_config, credentials, None, false)
         .await
         .unwrap();
 

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -26,7 +26,7 @@ async fn main() {
     let backend = audio_backend::find(None).unwrap();
 
     println!("Connecting ..");
-    let session = Session::connect(session_config, credentials, None)
+    let (session, _) = Session::connect(session_config, credentials, None, false)
         .await
         .unwrap();
 

--- a/examples/playlist_tracks.rs
+++ b/examples/playlist_tracks.rs
@@ -27,7 +27,7 @@ async fn main() {
         process::exit(1);
     });
 
-    let session = Session::connect(session_config, credentials, None)
+    let (session, _) = Session::connect(session_config, credentials, None, false)
         .await
         .unwrap();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1603,6 +1603,7 @@ async fn main() {
                 setup.session_config.clone(),
                 credentials,
                 setup.cache.clone(),
+                true,
             )
             .fuse(),
         );
@@ -1633,6 +1634,7 @@ async fn main() {
                             setup.session_config.clone(),
                             credentials,
                             setup.cache.clone(),
+                            true,
                         ).fuse());
                     },
                     None => {
@@ -1642,7 +1644,7 @@ async fn main() {
                 }
             },
             session = &mut connecting, if !connecting.is_terminated() => match session {
-                Ok(session) => {
+                Ok((session,_)) => {
                     let mixer_config = setup.mixer_config.clone();
                     let mixer = (setup.mixer)(mixer_config);
                     let player_config = setup.player_config.clone();
@@ -1710,6 +1712,7 @@ async fn main() {
                             setup.session_config.clone(),
                             credentials,
                             setup.cache.clone(),
+                            true
                         ).fuse());
                     },
                     _ => {


### PR DESCRIPTION
This adds a callback to the creation of the session, so the reusable credentials can be stored separately. This is useful when using a keychain or something like the secret_service api.

The way it's implemented, no API is broken but the possibility to reuse the credentials is there.

#### Why do I wan't this?

When using librespot without the cache, Spotify will send an email about a new login attempt when using the password credentials, with the long-lived token this does not happen. But I don't want to either use the cache or I don't want the token in a json file on my fs.


Feel free to give me some feedback or another solution, but I’m relatively new to rust, so I might ask some questions.