### PR TITLE
Remove the volume sample iteration

### DIFF
--- a/examples/play.rs
+++ b/examples/play.rs
@@ -6,6 +6,7 @@ use librespot::core::session::Session;
 use librespot::core::spotify_id::SpotifyId;
 use librespot::playback::audio_backend;
 use librespot::playback::config::{AudioFormat, PlayerConfig};
+use librespot::playback::mixer::NoOpVolumeApplier;
 use librespot::playback::player::Player;
 
 #[tokio::main]
@@ -30,9 +31,12 @@ async fn main() {
         .await
         .unwrap();
 
-    let (mut player, _) = Player::new(player_config, session, None, move || {
-        backend(None, audio_format)
-    });
+    let (mut player, _) = Player::new(
+        player_config,
+        session,
+        Box::new(NoOpVolumeApplier),
+        move || backend(None, audio_format),
+    );
 
     player.load(track, true, 0);
 

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -6,7 +6,7 @@ use librespot::core::session::Session;
 use librespot::core::spotify_id::SpotifyId;
 use librespot::playback::audio_backend;
 use librespot::playback::config::{AudioFormat, PlayerConfig};
-use librespot::playback::mixer::NoOpVolumeApplier;
+use librespot::playback::mixer::NoOpVolume;
 use librespot::playback::player::Player;
 
 #[tokio::main]
@@ -31,12 +31,9 @@ async fn main() {
         .await
         .unwrap();
 
-    let (mut player, _) = Player::new(
-        player_config,
-        session,
-        Box::new(NoOpVolumeApplier),
-        move || backend(None, audio_format),
-    );
+    let (mut player, _) = Player::new(player_config, session, Box::new(NoOpVolume), move || {
+        backend(None, audio_format)
+    });
 
     player.load(track, true, 0);
 

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -3,6 +3,8 @@ use crate::config::VolumeCtrl;
 pub mod mappings;
 use self::mappings::MappedCtrl;
 
+struct NoOpVolumeApplier;
+
 pub trait Mixer: Send {
     fn open(config: MixerConfig) -> Self
     where
@@ -11,13 +13,19 @@ pub trait Mixer: Send {
     fn set_volume(&self, volume: u16);
     fn volume(&self) -> u16;
 
-    fn get_soft_volume(&self) -> Option<Box<dyn SoftVolume + Send>> {
-        None
+    fn get_soft_volume(&self) -> Box<dyn SoftVolume + Send> {
+        Box::new(NoOpVolumeApplier)
     }
 }
 
 pub trait SoftVolume {
     fn attenuation_factor(&self) -> f64;
+}
+
+impl SoftVolume for NoOpVolumeApplier {
+    fn attenuation_factor(&self) -> f64 {
+        1.0
+    }
 }
 
 pub mod softmixer;

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -11,13 +11,13 @@ pub trait Mixer: Send {
     fn set_volume(&self, volume: u16);
     fn volume(&self) -> u16;
 
-    fn get_audio_filter(&self) -> Option<Box<dyn AudioFilter + Send>> {
+    fn get_soft_volume(&self) -> Option<Box<dyn SoftVolume + Send>> {
         None
     }
 }
 
-pub trait AudioFilter {
-    fn peek(&self) -> f64;
+pub trait SoftVolume {
+    fn attenuation_factor(&self) -> f64;
 }
 
 pub mod softmixer;

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -3,7 +3,7 @@ use crate::config::VolumeCtrl;
 pub mod mappings;
 use self::mappings::MappedCtrl;
 
-struct NoOpVolumeApplier;
+pub struct NoOpVolumeApplier;
 
 pub trait Mixer: Send {
     fn open(config: MixerConfig) -> Self

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -17,7 +17,7 @@ pub trait Mixer: Send {
 }
 
 pub trait AudioFilter {
-    fn modify_stream(&self, data: &mut [f64]);
+    fn peek(&self) -> f64;
 }
 
 pub mod softmixer;

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -3,7 +3,7 @@ use crate::config::VolumeCtrl;
 pub mod mappings;
 use self::mappings::MappedCtrl;
 
-pub struct NoOpVolumeApplier;
+pub struct NoOpVolume;
 
 pub trait Mixer: Send {
     fn open(config: MixerConfig) -> Self
@@ -13,16 +13,16 @@ pub trait Mixer: Send {
     fn set_volume(&self, volume: u16);
     fn volume(&self) -> u16;
 
-    fn get_soft_volume(&self) -> Box<dyn SoftVolume + Send> {
-        Box::new(NoOpVolumeApplier)
+    fn get_soft_volume(&self) -> Box<dyn VolumeGetter + Send> {
+        Box::new(NoOpVolume)
     }
 }
 
-pub trait SoftVolume {
+pub trait VolumeGetter {
     fn attenuation_factor(&self) -> f64;
 }
 
-impl SoftVolume for NoOpVolumeApplier {
+impl VolumeGetter for NoOpVolume {
     fn attenuation_factor(&self) -> f64 {
         1.0
     }

--- a/playback/src/mixer/softmixer.rs
+++ b/playback/src/mixer/softmixer.rs
@@ -35,10 +35,10 @@ impl Mixer for SoftMixer {
             .store(mapped_volume.to_bits(), Ordering::Relaxed)
     }
 
-    fn get_soft_volume(&self) -> Option<Box<dyn SoftVolume + Send>> {
-        Some(Box::new(SoftVolumeApplier {
+    fn get_soft_volume(&self) -> Box<dyn SoftVolume + Send> {
+        Box::new(SoftVolumeApplier {
             volume: self.volume.clone(),
-        }))
+        })
     }
 }
 

--- a/playback/src/mixer/softmixer.rs
+++ b/playback/src/mixer/softmixer.rs
@@ -1,7 +1,7 @@
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
-use super::AudioFilter;
+use super::SoftVolume;
 use super::{MappedCtrl, VolumeCtrl};
 use super::{Mixer, MixerConfig};
 
@@ -35,7 +35,7 @@ impl Mixer for SoftMixer {
             .store(mapped_volume.to_bits(), Ordering::Relaxed)
     }
 
-    fn get_audio_filter(&self) -> Option<Box<dyn AudioFilter + Send>> {
+    fn get_soft_volume(&self) -> Option<Box<dyn SoftVolume + Send>> {
         Some(Box::new(SoftVolumeApplier {
             volume: self.volume.clone(),
         }))
@@ -50,8 +50,8 @@ struct SoftVolumeApplier {
     volume: Arc<AtomicU64>,
 }
 
-impl AudioFilter for SoftVolumeApplier {
-    fn peek(&self) -> f64 {
+impl SoftVolume for SoftVolumeApplier {
+    fn attenuation_factor(&self) -> f64 {
         f64::from_bits(self.volume.load(Ordering::Relaxed))
     }
 }

--- a/playback/src/mixer/softmixer.rs
+++ b/playback/src/mixer/softmixer.rs
@@ -51,12 +51,7 @@ struct SoftVolumeApplier {
 }
 
 impl AudioFilter for SoftVolumeApplier {
-    fn modify_stream(&self, data: &mut [f64]) {
-        let volume = f64::from_bits(self.volume.load(Ordering::Relaxed));
-        if volume < 1.0 {
-            for x in data.iter_mut() {
-                *x *= volume;
-            }
-        }
+    fn peek(&self) -> f64 {
+        f64::from_bits(self.volume.load(Ordering::Relaxed))
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1648,12 +1648,12 @@ async fn main() {
                     let player_config = setup.player_config.clone();
                     let connect_config = setup.connect_config.clone();
 
-                    let audio_filter = mixer.get_audio_filter();
+                    let soft_volume = mixer.get_soft_volume();
                     let format = setup.format;
                     let backend = setup.backend;
                     let device = setup.device.clone();
                     let (player, event_channel) =
-                        Player::new(player_config, session.clone(), audio_filter, move || {
+                        Player::new(player_config, session.clone(), soft_volume, move || {
                             (backend)(device, format)
                         });
 


### PR DESCRIPTION
Move volume calculations out of their own separate samples iteration and into the normalisation iteration.



I plan on doing this and more in the new API branch. This bit was just a quick and easy backport that really don't change much at all. Further work on the new API branch may get backports or not depending on if/when 0.4 is released, as anything after 0.4 can't break the 0.4 API.