### PR TITLE
Avoid crash when Avahi is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] Adhere to ReplayGain spec when calculating gain normalisation factor.
 - [playback] `alsa`: Use `--volume-range` overrides for softvol controls
 - [connect] Don't panic when activating shuffle without previous interaction.
+- [main] Fix crash when built with Avahi support but Avahi is locally unavailable.
 
 ### Removed
 - [playback] `alsamixer`: previously deprecated option `mixer-card` has been removed.

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -111,8 +111,7 @@ impl Builder {
                     None,
                     port,
                     &["VERSION=1.0", "CPath=/"],
-                )
-                .unwrap();
+                ).map_err(|e| Error::DnsSdError(io::Error::new(io::ErrorKind::Unsupported, e)))?;
 
             } else {
                 let responder = libmdns::Responder::spawn(&tokio::runtime::Handle::current())?;


### PR DESCRIPTION
When librespot is built with Avahi turned on, it will crash if Avahi is
later not available at runtime.

This change avoids it crashing hard when Avahi is not available;
librespot will merely warn of the issue.

This affects some distribution packages too, where the maintainer might
prefer leaving Avahi support enabled, but many setups don't (or can't)
run Avahi.