### PR TITLE
Bump libmdns to 0.7

### DIFF
--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -15,7 +15,7 @@ form_urlencoded = "1.0"
 futures-core = "0.3"
 hmac = "0.11"
 hyper = { version = "0.14", features = ["server", "http1", "tcp"] }
-libmdns = "0.6"
+libmdns = "0.7"
 log = "0.4"
 rand = "0.8"
 serde_json = "1.0.25"


### PR DESCRIPTION
On my machine I'm getting spammed with warnings of this type:
```
[2022-05-19T16:56:38Z WARN  libmdns::fsm] couldn't parse packet from 192.168.178.112:5353: type 47 is invalid
[2022-05-19T16:56:45Z WARN  libmdns::fsm] couldn't parse packet from 192.168.178.114:5353: type 47 is invalid
[2022-05-19T16:56:45Z WARN  libmdns::fsm] couldn't parse packet from 192.168.178.28:5353: type 47 is invalid

```
This is because some devices in my network use mDNS to talk to each other, broadcasting messages to other mDNS devices like the machine running librespot. But this packet type 47 hasn't been implemented in libmdns, so the warning is printed.

As I use librespot as a systemd daemon all those messages end up in my journal and accumulate to >1000 warning per day. This warning has been fixed 11 days ago in libmdns (see [https://github.com/librespot-org/libmdns/issues/19](https://github.com/librespot-org/libmdns/issues/19)).

I've locally compiled with the new libmdns version 0.7 instead of 0.6 and the messages disappear, so the bug seems to be resolved