### PR TITLE
implement stop for pipe backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- [playback] `pipe`: close & reopen file between songs when --disable-gapless is set
 
 ### Added
 

--- a/playback/src/audio_backend/pipe.rs
+++ b/playback/src/audio_backend/pipe.rs
@@ -52,6 +52,12 @@ impl Sink for StdoutSink {
     }
 
     sink_as_bytes!();
+
+    fn stop(&mut self) -> SinkResult<()> {
+        self.output = None;
+
+        Ok(())
+    }
 }
 
 impl SinkAsBytes for StdoutSink {


### PR DESCRIPTION
the pipe device should be closed & reopened between songs when
--disable-gapless is set, implementing stop() achieves this


this is my first rust PR, so apologies if using `take()` to reset an optional to None is a gross no-no, I'm open to other suggestions. 