### PR TITLE
Minor alsa backend tweaks

### DIFF
--- a/playback/src/audio_backend/alsa.rs
+++ b/playback/src/audio_backend/alsa.rs
@@ -6,7 +6,6 @@ use crate::{NUM_CHANNELS, SAMPLE_RATE};
 use alsa::device_name::HintIter;
 use alsa::pcm::{Access, Format, Frames, HwParams, PCM};
 use alsa::{Direction, ValueOr};
-use std::cmp::min;
 use std::process::exit;
 use thiserror::Error;
 
@@ -141,7 +140,7 @@ fn list_compatible_devices() -> SinkResult<()> {
 
                                 println!(
                                     "\tDescription:\n\n\t\t{}\n",
-                                    a.desc.unwrap_or_default().replace("\n", "\n\t\t")
+                                    a.desc.unwrap_or_default().replace('\n', "\n\t\t")
                                 );
 
                                 println!(
@@ -467,7 +466,7 @@ impl SinkAsBytes for AlsaSink {
         loop {
             let data_left = data_len - start_index;
             let space_left = capacity - self.period_buffer.len();
-            let data_to_buffer = min(data_left, space_left);
+            let data_to_buffer = data_left.min(space_left);
             let end_index = start_index + data_to_buffer;
 
             self.period_buffer


### PR DESCRIPTION
Silence a clippy warning and we don't need `std::cmp::min` when `usize` already has `min`.