### PR TITLE
include more metadata in track struct

### DIFF
--- a/metadata/src/artist.rs
+++ b/metadata/src/artist.rs
@@ -21,10 +21,10 @@ pub struct Artist {
 }
 
 #[derive(Debug, Clone)]
-pub struct Artists(pub Vec<SpotifyId>);
+pub struct Artists(pub Vec<Artist>);
 
 impl Deref for Artists {
-    type Target = Vec<SpotifyId>;
+    type Target = Vec<Artist>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }

--- a/metadata/src/track.rs
+++ b/metadata/src/track.rs
@@ -18,7 +18,7 @@ use crate::{
     restriction::Restrictions,
     sale_period::SalePeriods,
     util::try_from_repeated_message,
-    Metadata, RequestResult,
+    Album, Metadata, RequestResult,
 };
 
 use librespot_core::{date::Date, Error, Session, SpotifyId};
@@ -28,7 +28,7 @@ use librespot_protocol as protocol;
 pub struct Track {
     pub id: SpotifyId,
     pub name: String,
-    pub album: SpotifyId,
+    pub album: Album,
     pub artists: Artists,
     pub number: i32,
     pub disc_number: i32,


### PR DESCRIPTION
Based on [this patch](https://github.com/librespot-org/librespot/commit/4f54dc8f5b5b9191899b9159801958cc3e748de9), this exposes some more metadata in the public `struct`s that is sent from Spotify.