### PR TITLE
Fix playlist metadata fields parsing

### DIFF
--- a/core/src/cdn_url.rs
+++ b/core/src/cdn_url.rs
@@ -1,5 +1,5 @@
 use std::{
-    convert::{TryFrom, TryInto},
+    convert::TryFrom,
     ops::{Deref, DerefMut},
 };
 
@@ -152,7 +152,7 @@ impl TryFrom<CdnUrlMessage> for MaybeExpiringUrls {
 
                     Ok(MaybeExpiringUrl(
                         cdn_url.to_owned(),
-                        Some(expiry.try_into()?),
+                        Some(Date::from_timestamp_ms(expiry * 1000)?),
                     ))
                 } else {
                     Ok(MaybeExpiringUrl(cdn_url.to_owned(), None))

--- a/core/src/date.rs
+++ b/core/src/date.rs
@@ -28,12 +28,11 @@ impl Deref for Date {
 }
 
 impl Date {
-    pub fn as_timestamp(&self) -> i64 {
+    pub fn as_timestamp_ms(&self) -> i64 {
         (self.0.unix_timestamp_nanos() / 1_000_000) as i64
     }
 
-    pub fn from_timestamp(timestamp: i64) -> Result<Self, Error> {
-        // the timestamp is in milliseconds
+    pub fn from_timestamp_ms(timestamp: i64) -> Result<Self, Error> {
         let date_time = OffsetDateTime::from_unix_timestamp_nanos(timestamp as i128 * 1_000_000)?;
         Ok(Self(date_time))
     }
@@ -78,12 +77,5 @@ impl TryFrom<&DateMessage> for Date {
 impl From<OffsetDateTime> for Date {
     fn from(datetime: OffsetDateTime) -> Self {
         Self(datetime)
-    }
-}
-
-impl TryFrom<i64> for Date {
-    type Error = crate::Error;
-    fn try_from(timestamp: i64) -> Result<Self, Self::Error> {
-        Self::from_timestamp(timestamp)
     }
 }

--- a/core/src/date.rs
+++ b/core/src/date.rs
@@ -29,11 +29,12 @@ impl Deref for Date {
 
 impl Date {
     pub fn as_timestamp(&self) -> i64 {
-        self.0.unix_timestamp()
+        (self.0.unix_timestamp_nanos() / 1_000_000) as i64
     }
 
     pub fn from_timestamp(timestamp: i64) -> Result<Self, Error> {
-        let date_time = OffsetDateTime::from_unix_timestamp(timestamp)?;
+        // the timestamp is in milliseconds
+        let date_time = OffsetDateTime::from_unix_timestamp_nanos(timestamp as i128 * 1_000_000)?;
         Ok(Self(date_time))
     }
 

--- a/metadata/src/playlist/attribute.rs
+++ b/metadata/src/playlist/attribute.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{image::PictureSizes, util::from_repeated_enum};
 
-use librespot_core::{date::Date, SpotifyId};
+use librespot_core::date::Date;
 
 use librespot_protocol as protocol;
 use protocol::playlist4_external::FormatListAttribute as PlaylistFormatAttributeMessage;
@@ -24,7 +24,7 @@ use protocol::playlist4_external::UpdateListAttributes as PlaylistUpdateAttribut
 pub struct PlaylistAttributes {
     pub name: String,
     pub description: String,
-    pub picture: SpotifyId,
+    pub picture: Vec<u8>,
     pub is_collaborative: bool,
     pub pl3_version: String,
     pub is_deleted_by_owner: bool,
@@ -63,7 +63,7 @@ pub struct PlaylistItemAttributes {
     pub seen_at: Date,
     pub is_public: bool,
     pub format_attributes: PlaylistFormatAttribute,
-    pub item_id: SpotifyId,
+    pub item_id: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]
@@ -113,7 +113,7 @@ impl TryFrom<&PlaylistAttributesMessage> for PlaylistAttributes {
         Ok(Self {
             name: attributes.get_name().to_owned(),
             description: attributes.get_description().to_owned(),
-            picture: attributes.get_picture().try_into()?,
+            picture: attributes.get_picture().to_owned(),
             is_collaborative: attributes.get_collaborative(),
             pl3_version: attributes.get_pl3_version().to_owned(),
             is_deleted_by_owner: attributes.get_deleted_by_owner(),
@@ -150,7 +150,7 @@ impl TryFrom<&PlaylistItemAttributesMessage> for PlaylistItemAttributes {
             seen_at: attributes.get_seen_at().try_into()?,
             is_public: attributes.get_public(),
             format_attributes: attributes.get_format_attributes().into(),
-            item_id: attributes.get_item_id().try_into()?,
+            item_id: attributes.get_item_id().to_owned(),
         })
     }
 }

--- a/metadata/src/playlist/attribute.rs
+++ b/metadata/src/playlist/attribute.rs
@@ -146,8 +146,8 @@ impl TryFrom<&PlaylistItemAttributesMessage> for PlaylistItemAttributes {
     fn try_from(attributes: &PlaylistItemAttributesMessage) -> Result<Self, Self::Error> {
         Ok(Self {
             added_by: attributes.get_added_by().to_owned(),
-            timestamp: attributes.get_timestamp().try_into()?,
-            seen_at: attributes.get_seen_at().try_into()?,
+            timestamp: Date::from_timestamp_ms(attributes.get_timestamp())?,
+            seen_at: Date::from_timestamp_ms(attributes.get_seen_at())?,
             is_public: attributes.get_public(),
             format_attributes: attributes.get_format_attributes().into(),
             item_id: attributes.get_item_id().to_owned(),

--- a/metadata/src/playlist/item.rs
+++ b/metadata/src/playlist/item.rs
@@ -94,7 +94,7 @@ impl TryFrom<&PlaylistMetaItemMessage> for PlaylistMetaItem {
             revision: item.try_into()?,
             attributes: item.get_attributes().try_into()?,
             length: item.get_length(),
-            timestamp: item.get_timestamp().try_into()?,
+            timestamp: Date::from_timestamp_ms(item.get_timestamp())?,
             owner_username: item.get_owner_username().to_owned(),
             has_abuse_reporting: item.get_abuse_reporting_enabled(),
             capabilities: item.get_capabilities().into(),

--- a/metadata/src/playlist/list.rs
+++ b/metadata/src/playlist/list.rs
@@ -216,7 +216,7 @@ impl TryFrom<&<Playlist as Metadata>::Message> for SelectedListContent {
             has_multiple_heads: playlist.get_multiple_heads(),
             is_up_to_date: playlist.get_up_to_date(),
             nonces: playlist.get_nonces().into(),
-            timestamp: playlist.get_timestamp().try_into()?,
+            timestamp: Date::from_timestamp_ms(playlist.get_timestamp())?,
             owner_username: playlist.get_owner_username().to_owned(),
             has_abuse_reporting: playlist.get_abuse_reporting_enabled(),
             capabilities: playlist.get_capabilities().into(),

--- a/metadata/src/track.rs
+++ b/metadata/src/track.rs
@@ -132,7 +132,7 @@ impl TryFrom<&<Self as Metadata>::Message> for Track {
             sale_periods: track.get_sale_period().try_into()?,
             previews: track.get_preview().into(),
             tags: track.get_tags().to_vec(),
-            earliest_live_timestamp: track.get_earliest_live_timestamp().try_into()?,
+            earliest_live_timestamp: Date::from_timestamp_ms(track.get_earliest_live_timestamp())?,
             has_lyrics: track.get_has_lyrics(),
             availability: track.get_availability().try_into()?,
             licensor: Uuid::from_slice(track.get_licensor().get_uuid())


### PR DESCRIPTION
On the `new-api` branch, running the `playlist_tracks` example failed for me on all playlists I tried. (e.g., `spotify:playlist:44PATzOl8NaSihxJQs02h6`)

```
T22:31:02Z ERROR librespot_core::session] could not dispatch command: Service unavailable { error handling Mercury response: MercuryResponse { uri: "hm://pusher/v1/connections/some_random_long_string_dont_know_if_this_is_sensitive", status_code: 200, payload: [] } }
[core/src/spotify_id.rs:151] &src = [ 0, 0, 0, 95, 44, 47, 124, 183, 128, 198, 126, 114, 116, 12, 168, 188, 186, 208, 26, 252, 170, 101, 87, 65 ]
thread 'main' panicked at 'called `Result::unwrap()` on an `Err` value: Error { kind: InvalidArgument, error: InvalidId }', examples/playlist_tracks.rs:36:58
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Logging several values revealed that some fields (`revision`, `item_id`) were parsed into `SpotifyId`s, which failed, since `SpotifyId` expects exactly 16 bytes, while those were of different lengths. Additionally, there were some optional fields (`diff`, `sync_result`), which weren't present in this case, and, as such, a default was used. This default included a `[]`, which would then also be parsed as a `SpotifyId` and failed.

Apart from that, the timestamps included in the response were all in milliseconds and exceeded the accepted range in `OffsetDateTime::from_unix_timestamp()`.

See [playlist_proto.txt](https://github.com/librespot-org/librespot/files/9015264/playlist_proto.txt) (or the binary version [playlist_bin.txt](https://github.com/librespot-org/librespot/files/9015265/playlist_bin.txt)) for the data for all this occurred with.

---

While the example works now, I'm not sure about some things:

- There are certainly other optional fields than the two that I met during my testing (`diff`, `sync_result`). Should those all be wrapped in `Option`s or should the `SpotifyId` just be changed to not fail on the default case (`[]`)?
- Is there a better way to map optional fields to `Option<T>`s than the `.as_ref().map(TryInto::try_into).transpose()?`?
- Is the `TryFrom<i64> for Date` implementation used anywhere else, where the value is not in `milliseconds`?
- Should there be a wrapper type / type alias for those `Vec<u8>` fields?