### PR TITLE
Blacklist ap-gew4 access point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] `pipe`: Better error handling
 
 ### Added
+- [core] `apresolve`: Blacklist ap-gew4 access point that causes channel errors
 - [playback] `pipe`: Implement stop
 
 ### Fixed
@@ -116,7 +117,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - [connect] Fix step size on volume up/down events
 - [connect] Fix looping back to the first track after the last track of an album or playlist
-- [playback] Incorrect `PlayerConfig::default().normalisation_threshold` caused distortion when using dynamic volume normalisation downstream 
+- [playback] Incorrect `PlayerConfig::default().normalisation_threshold` caused distortion when using dynamic volume normalisation downstream
 - [playback] Fix `log` and `cubic` volume controls to be mute at zero volume
 - [playback] Fix `S24_3` format on big-endian systems
 - [playback] `alsamixer`: make `cubic` consistent between cards that report minimum volume as mute, and cards that report some dB value

--- a/core/src/apresolve.rs
+++ b/core/src/apresolve.rs
@@ -52,6 +52,7 @@ async fn try_apresolve(
             if !AP_BLACKLIST.iter().any(|&blacklisted| host == blacklisted) {
                 Some(ap)
             } else {
+                warn!("Ignoring blacklisted access point {}", ap);
                 None
             }
         })
@@ -70,7 +71,7 @@ async fn try_apresolve(
         // ...or pick the first on the list
         aps.into_iter().next()
     }
-    .ok_or("empty AP List")?;
+    .ok_or("Unable to resolve any viable access points.")?;
 
     Ok(ap)
 }


### PR DESCRIPTION
Only `ap-gew4.spotify.com` is listed now, but the mechanism allows to add other access points to the blacklist if so necessary in the future.

Fixes #972 