### PR TITLE
Implement Default trait for vec / hashmap wrappers in metadata

### DIFF
--- a/metadata/src/album.rs
+++ b/metadata/src/album.rs
@@ -41,7 +41,7 @@ pub struct Album {
     pub availability: Availabilities,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Albums(pub Vec<SpotifyId>);
 
 impl Deref for Albums {
@@ -58,7 +58,7 @@ pub struct Disc {
     pub tracks: Tracks,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Discs(pub Vec<Disc>);
 
 impl Deref for Discs {

--- a/metadata/src/artist.rs
+++ b/metadata/src/artist.rs
@@ -20,7 +20,7 @@ pub struct Artist {
     pub top_tracks: CountryTopTracks,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Artists(pub Vec<SpotifyId>);
 
 impl Deref for Artists {
@@ -37,7 +37,7 @@ pub struct ArtistWithRole {
     pub role: ArtistRole,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ArtistsWithRole(pub Vec<ArtistWithRole>);
 
 impl Deref for ArtistsWithRole {
@@ -53,7 +53,7 @@ pub struct TopTracks {
     pub tracks: Tracks,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct CountryTopTracks(pub Vec<TopTracks>);
 
 impl Deref for CountryTopTracks {

--- a/metadata/src/audio/file.rs
+++ b/metadata/src/audio/file.rs
@@ -6,7 +6,7 @@ use librespot_protocol as protocol;
 use protocol::metadata::AudioFile as AudioFileMessage;
 pub use protocol::metadata::AudioFile_Format as AudioFileFormat;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct AudioFiles(pub HashMap<AudioFileFormat, FileId>);
 
 impl Deref for AudioFiles {

--- a/metadata/src/availability.rs
+++ b/metadata/src/availability.rs
@@ -21,7 +21,7 @@ pub struct Availability {
     pub start: Date,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Availabilities(pub Vec<Availability>);
 
 impl Deref for Availabilities {

--- a/metadata/src/content_rating.rs
+++ b/metadata/src/content_rating.rs
@@ -11,7 +11,7 @@ pub struct ContentRating {
     pub tags: Vec<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ContentRatings(pub Vec<ContentRating>);
 
 impl Deref for ContentRatings {

--- a/metadata/src/copyright.rs
+++ b/metadata/src/copyright.rs
@@ -12,7 +12,7 @@ pub struct Copyright {
     pub text: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Copyrights(pub Vec<Copyright>);
 
 impl Deref for Copyrights {

--- a/metadata/src/episode.rs
+++ b/metadata/src/episode.rs
@@ -52,7 +52,7 @@ pub struct Episode {
     pub is_audiobook_chapter: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Episodes(pub Vec<SpotifyId>);
 
 impl Deref for Episodes {

--- a/metadata/src/external_id.rs
+++ b/metadata/src/external_id.rs
@@ -11,7 +11,7 @@ pub struct ExternalId {
     pub id: String, // this can be anything from a URL to a ISRC, EAN or UPC
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ExternalIds(pub Vec<ExternalId>);
 
 impl Deref for ExternalIds {

--- a/metadata/src/image.rs
+++ b/metadata/src/image.rs
@@ -22,7 +22,7 @@ pub struct Image {
     pub height: i32,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Images(pub Vec<Image>);
 
 impl Deref for Images {
@@ -38,7 +38,7 @@ pub struct PictureSize {
     pub url: String,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PictureSizes(pub Vec<PictureSize>);
 
 impl Deref for PictureSizes {

--- a/metadata/src/playlist/attribute.rs
+++ b/metadata/src/playlist/attribute.rs
@@ -34,7 +34,7 @@ pub struct PlaylistAttributes {
     pub picture_sizes: PictureSizes,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PlaylistAttributeKinds(pub Vec<PlaylistAttributeKind>);
 
 impl Deref for PlaylistAttributeKinds {
@@ -46,7 +46,7 @@ impl Deref for PlaylistAttributeKinds {
 
 from_repeated_enum!(PlaylistAttributeKind, PlaylistAttributeKinds);
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PlaylistFormatAttribute(pub HashMap<String, String>);
 
 impl Deref for PlaylistFormatAttribute {
@@ -66,7 +66,7 @@ pub struct PlaylistItemAttributes {
     pub item_id: Vec<u8>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PlaylistItemAttributeKinds(pub Vec<PlaylistItemAttributeKind>);
 
 impl Deref for PlaylistItemAttributeKinds {

--- a/metadata/src/playlist/item.rs
+++ b/metadata/src/playlist/item.rs
@@ -24,7 +24,7 @@ pub struct PlaylistItem {
     pub attributes: PlaylistItemAttributes,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PlaylistItems(pub Vec<PlaylistItem>);
 
 impl Deref for PlaylistItems {
@@ -53,7 +53,7 @@ pub struct PlaylistMetaItem {
     pub capabilities: Capabilities,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PlaylistMetaItems(pub Vec<PlaylistMetaItem>);
 
 impl Deref for PlaylistMetaItems {

--- a/metadata/src/playlist/list.rs
+++ b/metadata/src/playlist/list.rs
@@ -26,7 +26,7 @@ use librespot_core::{
 use librespot_protocol as protocol;
 use protocol::playlist4_external::GeoblockBlockingType as Geoblock;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Geoblocks(Vec<Geoblock>);
 
 impl Deref for Geoblocks {
@@ -55,7 +55,7 @@ pub struct Playlist {
     pub geoblocks: Geoblocks,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Playlists(pub Vec<SpotifyId>);
 
 impl Deref for Playlists {

--- a/metadata/src/playlist/operation.rs
+++ b/metadata/src/playlist/operation.rs
@@ -29,7 +29,7 @@ pub struct PlaylistOperation {
     pub update_list_attributes: PlaylistUpdateAttributes,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PlaylistOperations(pub Vec<PlaylistOperation>);
 
 impl Deref for PlaylistOperations {

--- a/metadata/src/playlist/permission.rs
+++ b/metadata/src/playlist/permission.rs
@@ -16,7 +16,7 @@ pub struct Capabilities {
     pub can_cancel_membership: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PermissionLevels(pub Vec<PermissionLevel>);
 
 impl Deref for PermissionLevels {

--- a/metadata/src/restriction.rs
+++ b/metadata/src/restriction.rs
@@ -17,7 +17,7 @@ pub struct Restriction {
     pub countries_forbidden: Option<Vec<String>>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Restrictions(pub Vec<Restriction>);
 
 impl Deref for Restrictions {

--- a/metadata/src/sale_period.rs
+++ b/metadata/src/sale_period.rs
@@ -18,7 +18,7 @@ pub struct SalePeriod {
     pub end: Date,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct SalePeriods(pub Vec<SalePeriod>);
 
 impl Deref for SalePeriods {

--- a/metadata/src/track.rs
+++ b/metadata/src/track.rs
@@ -53,7 +53,7 @@ pub struct Track {
     pub artists_with_role: ArtistsWithRole,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct Tracks(pub Vec<SpotifyId>);
 
 impl Deref for Tracks {

--- a/metadata/src/video.rs
+++ b/metadata/src/video.rs
@@ -7,7 +7,7 @@ use librespot_core::FileId;
 use librespot_protocol as protocol;
 use protocol::metadata::VideoFile as VideoFileMessage;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct VideoFiles(pub Vec<FileId>);
 
 impl Deref for VideoFiles {


### PR DESCRIPTION
- Derive `Default` trait for the vec / hashmap wrapper types in `librespot-metadata`
- The wrapped types (`Vec` / `Hashmap`) implement Default, so the wrapper types should as well