### PR TITLE
Add minimum rust version

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -7,8 +7,6 @@ In order to compile librespot, you will first need to set up a suitable Rust bui
 ### Install Rust
 The easiest, and recommended way to get Rust is to use [rustup](https://rustup.rs). Once that’s installed, Rust's standard tools should be set up and ready to use.
 
-*Note: The current minimum supported Rust version at the time of writing is 1.61.*
-
 #### Additional Rust tools - `rustfmt`
 To ensure a consistent codebase, we utilise [`rustfmt`](https://github.com/rust-lang/rustfmt) and [`clippy`](https://github.com/rust-lang/rust-clippy), which are installed by default with `rustup` these days, else they can be installed manually with:
 ```bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "librespot"
 version = "0.5.0-dev"
+rust-version = "1.61"
 authors = ["Librespot Org"]
 license = "MIT"
 description = "An open source client library for Spotify, with support for Spotify Connect"

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "librespot-audio"
 version = "0.5.0-dev"
+rust-version = "1.61"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The audio fetching logic for librespot"
 license = "MIT"

--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "librespot-connect"
 version = "0.5.0-dev"
+rust-version = "1.61"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The discovery and Spotify Connect logic for librespot"
 license = "MIT"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "librespot-core"
 version = "0.5.0-dev"
+rust-version = "1.61"
 authors = ["Paul Lietar <paul@lietar.net>"]
 build = "build.rs"
 description = "The core functionality provided by librespot"

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "librespot-discovery"
 version = "0.5.0-dev"
+rust-version = "1.61"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The discovery logic for librespot"
 license = "MIT"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "librespot-metadata"
 version = "0.5.0-dev"
+rust-version = "1.61"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The metadata logic for librespot"
 license = "MIT"

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "librespot-playback"
 version = "0.5.0-dev"
+rust-version = "1.61"
 authors = ["Sasha Hilton <sashahilton00@gmail.com>"]
 description = "The audio playback logic for librespot"
 license = "MIT"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "librespot-protocol"
 version = "0.5.0-dev"
+rust-version = "1.61"
 authors = ["Paul Liétar <paul@lietar.net>"]
 build = "build.rs"
 description = "The protobuf logic for communicating with Spotify servers"


### PR DESCRIPTION
See also: https://github.com/librespot-org/librespot/issues/1033
This adds a nice error message in case the rust-version is too old to compile librespot:

```
$ cargo build --release
error: package `librespot v0.5.0-dev (/home/sqozz/git/librespot)` cannot be built because it requires rustc 1.62.2 or newer, while the currently active rustc version is 1.62.1
```

I tried 1.62.1 which also worked fine (just set it higher before to test the warning itself). It is the lowest rustc version available to me it might be possible 1.61.x works too but I've no way to verify this.