### PR TITLE
Return iterators instead of collected vecs

### DIFF
--- a/examples/playlist_tracks.rs
+++ b/examples/playlist_tracks.rs
@@ -36,7 +36,7 @@ async fn main() {
     let plist = Playlist::get(&session, plist_uri).await.unwrap();
     println!("{:?}", plist);
     for track_id in plist.tracks() {
-        let plist_track = Track::get(&session, track_id).await.unwrap();
+        let plist_track = Track::get(&session, *track_id).await.unwrap();
         println!("track: {} ", plist_track.name);
     }
 }

--- a/metadata/src/album.rs
+++ b/metadata/src/album.rs
@@ -67,13 +67,8 @@ pub struct Discs(pub Vec<Disc>);
 impl_deref_wrapped!(Discs, Vec<Disc>);
 
 impl Album {
-    pub fn tracks(&self) -> Tracks {
-        let result = self
-            .discs
-            .iter()
-            .flat_map(|disc| disc.tracks.deref().clone())
-            .collect();
-        Tracks(result)
+    pub fn tracks(&self) -> impl Iterator<Item = &SpotifyId> {
+        self.discs.iter().flat_map(|disc| disc.tracks.iter())
     }
 }
 

--- a/metadata/src/artist.rs
+++ b/metadata/src/artist.rs
@@ -140,14 +140,14 @@ impl Artist {
     /// Get the full list of albums, not containing duplicate variants of the same albums.
     ///
     /// See also [`AlbumGroups`](struct@AlbumGroups) and [`AlbumGroups::current_releases`]
-    pub fn albums_current(&self) -> Albums {
+    pub fn albums_current(&self) -> impl Iterator<Item = &SpotifyId> {
         self.albums.current_releases()
     }
 
     /// Get the full list of singles, not containing duplicate variants of the same singles.
     ///
     /// See also [`AlbumGroups`](struct@AlbumGroups) and [`AlbumGroups::current_releases`]
-    pub fn singles_current(&self) -> Albums {
+    pub fn singles_current(&self) -> impl Iterator<Item = &SpotifyId> {
         self.singles.current_releases()
     }
 
@@ -155,14 +155,14 @@ impl Artist {
     /// compilations.
     ///
     /// See also [`AlbumGroups`](struct@AlbumGroups) and [`AlbumGroups::current_releases`]
-    pub fn compilations_current(&self) -> Albums {
+    pub fn compilations_current(&self) -> impl Iterator<Item = &SpotifyId> {
         self.compilations.current_releases()
     }
 
     /// Get the full list of albums, not containing duplicate variants of the same albums.
     ///
     /// See also [`AlbumGroups`](struct@AlbumGroups) and [`AlbumGroups::current_releases`]
-    pub fn appears_on_albums_current(&self) -> Albums {
+    pub fn appears_on_albums_current(&self) -> impl Iterator<Item = &SpotifyId> {
         self.appears_on_albums.current_releases()
     }
 }
@@ -245,13 +245,8 @@ impl AlbumGroups {
     /// Get the contained albums. This will only use the latest release / variant of an album if
     /// multiple variants are available. This should be used if multiple variants of the same album
     /// are not explicitely desired.
-    pub fn current_releases(&self) -> Albums {
-        let albums = self
-            .iter()
-            .filter_map(|agrp| agrp.first())
-            .cloned()
-            .collect();
-        Albums(albums)
+    pub fn current_releases(&self) -> impl Iterator<Item = &SpotifyId> {
+        self.iter().filter_map(|agrp| agrp.first())
     }
 }
 

--- a/metadata/src/playlist/list.rs
+++ b/metadata/src/playlist/list.rs
@@ -105,13 +105,8 @@ impl Playlist {
         Self::parse(&msg, playlist_id)
     }
 
-    pub fn tracks(&self) -> Vec<SpotifyId> {
-        let tracks = self
-            .contents
-            .items
-            .iter()
-            .map(|item| item.id)
-            .collect::<Vec<_>>();
+    pub fn tracks(&self) -> impl ExactSizeIterator<Item = &SpotifyId> {
+        let tracks = self.contents.items.iter().map(|item| &item.id);
 
         let length = tracks.len();
         let expected_length = self.length as usize;


### PR DESCRIPTION
- Change the return type of metadata convenience iter functions to actual iterators instead of allocated collections
- The iterator item type is set to be a reference instead of the actual `SpotifyId` since that is a bit more versatile. Especially if at some point in the Track ids would get replaced by non Copy types like actual Tracks. Something like that was done with `Artists` in #1018 . If this is not desired it will of course be changed