### PR TITLE
Fix `SpClient::get_playlist` endpoint generation

### DIFF
--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -408,7 +408,7 @@ impl SpClient {
     }
 
     pub async fn get_playlist(&self, playlist_id: &SpotifyId) -> SpClientResult {
-        let endpoint = format!("/playlist/v2/playlist/{:?}", playlist_id.to_base62());
+        let endpoint = format!("/playlist/v2/playlist/{}", playlist_id.to_base62()?);
 
         self.request(&Method::GET, &endpoint, None, None).await
     }


### PR DESCRIPTION
The generated endpoint used the debug printed Option instead of the conatined value. So bascially `"/playlist/v2/playlist/Option(id)"` instead of `"/playlist/v2/playlist/id"`