### PR TITLE
Fix armv6hp Builds (RPI 1 & Zero) for `old-api` also

### DIFF
--- a/contrib/docker-build-pi-armv6hf.sh
+++ b/contrib/docker-build-pi-armv6hf.sh
@@ -1,42 +1,17 @@
 #!/usr/bin/env bash
 
-# Snipped and tucked from https://github.com/plietar/librespot/pull/202/commits/21549641d39399cbaec0bc92b36c9951d1b87b90
-# and further inputs from https://github.com/kingosticks/librespot/commit/c55dd20bd6c7e44dd75ff33185cf50b2d3bd79c3
+# largerly inspired by https://github.com/Spotifyd/spotifyd/blob/993336f7/.github/workflows/cd.yml#L109
 
 set -eux
-# Get alsa lib and headers
-ALSA_VER="1.0.25-4"
-DEPS=( \
-  "http://mirrordirector.raspbian.org/raspbian/pool/main/a/alsa-lib/libasound2_${ALSA_VER}_armhf.deb" \
-  "http://mirrordirector.raspbian.org/raspbian/pool/main/a/alsa-lib/libasound2-dev_${ALSA_VER}_armhf.deb" \
+
+# See https://github.com/raspberrypi/tools/commit/5caa7046
+# Since this commit is not (yet) contained in what is downloaded in Dockerfile, we use the target of the symlink directly
+PI1_TOOLS_DIR="/pi-tools/arm-bcm2708/arm-rpi-4.9.3-linux-gnueabihf"
+
+PI1_LIB_DIRS=(
+  "$PI1_TOOLS_DIR/arm-linux-gnueabihf/sysroot/lib"
+  "$PI1_TOOLS_DIR/arm-linux-gnueabihf/sysroot/usr/lib"
 )
+export RUSTFLAGS="-C linker=$PI1_TOOLS_DIR/bin/arm-linux-gnueabihf-gcc ${PI1_LIB_DIRS[@]/#/-L}"
 
-# Collect Paths
-SYSROOT="/pi-tools/arm-bcm2708/arm-bcm2708hardfp-linux-gnueabi/arm-bcm2708hardfp-linux-gnueabi/sysroot"
-GCC="/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin"
-GCC_SYSROOT="$GCC/gcc-sysroot"
-
-
-export PATH=/pi-tools/arm-bcm2708/gcc-linaro-arm-linux-gnueabihf-raspbian-x64/bin/:$PATH
-
-# Link the compiler
-export TARGET_CC="$GCC/arm-linux-gnueabihf-gcc"
-
-# Create wrapper around gcc to point to rpi sysroot
-echo -e '#!/bin/bash' "\n$TARGET_CC --sysroot $SYSROOT \"\$@\"" > $GCC_SYSROOT
-chmod +x $GCC_SYSROOT
-
-# Add extra target dependencies to our rpi sysroot
-for path in "${DEPS[@]}"; do
-  curl -OL $path
-  dpkg -x $(basename $path) $SYSROOT
-done
-
-# i don't why this is neccessary
-# ln -s ld-linux.so.3 $SYSROOT/lib/ld-linux-armhf.so.3
-
-# point cargo to use gcc wrapper as linker
-echo -e '[target.arm-unknown-linux-gnueabihf]\nlinker = "gcc-sysroot"' > /.cargo/config
-
-# Build
 cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend"


### PR DESCRIPTION
Same as #1044 just for `old-api` also. Both resulting binaries (`dev` and `old-api`) have been tested on my original Pi Zero W without issues.