### PR TITLE
strongly type `ActivityPeriod`

### DIFF
--- a/core/src/error.rs
+++ b/core/src/error.rs
@@ -1,4 +1,9 @@
-use std::{error, fmt, num::ParseIntError, str::Utf8Error, string::FromUtf8Error};
+use std::{
+    error, fmt,
+    num::{ParseIntError, TryFromIntError},
+    str::Utf8Error,
+    string::FromUtf8Error,
+};
 
 use base64::DecodeError;
 use http::{
@@ -409,6 +414,12 @@ impl From<ParseError> for Error {
 
 impl From<ParseIntError> for Error {
     fn from(err: ParseIntError) -> Self {
+        Self::new(ErrorKind::FailedPrecondition, err)
+    }
+}
+
+impl From<TryFromIntError> for Error {
+    fn from(err: TryFromIntError) -> Self {
         Self::new(ErrorKind::FailedPrecondition, err)
     }
 }

--- a/metadata/src/artist.rs
+++ b/metadata/src/artist.rs
@@ -113,10 +113,10 @@ impl_deref_wrapped!(Biographies, Vec<Biography>);
 #[derive(Debug, Clone)]
 pub enum ActivityPeriod {
     Timespan {
-        start_year: i32,
-        end_year: Option<i32>,
+        start_year: u16,
+        end_year: Option<u16>,
     },
-    Decade(i32),
+    Decade(u16),
 }
 
 #[derive(Debug, Clone, Default)]
@@ -282,10 +282,12 @@ impl TryFrom<&ActivityPeriodMessage> for ActivityPeriod {
             period.has_end_year(),
         ) {
             // (decade, start_year, end_year)
-            (true, false, false) => Self::Decade(period.get_decade()),
+            (true, false, false) => Self::Decade(period.get_decade().try_into()?),
             (false, true, closed_period) => Self::Timespan {
-                start_year: period.get_start_year(),
-                end_year: closed_period.then(|| period.get_end_year()),
+                start_year: period.get_start_year().try_into()?,
+                end_year: closed_period
+                    .then(|| period.get_end_year().try_into())
+                    .transpose()?,
             },
             _ => {
                 return Err(librespot_core::Error::failed_precondition(


### PR DESCRIPTION
From my observations, `ActivityPeriod` **always** comes in one of the following three compositions:

- `decade`
- `start_year` (open timespan)
- `start_year` + `end_year` (closed timespan)

Thus, it probably makes sense to strongly type those variants into `ActivityPeriod`.

I also added two `debug_assert!`s that make sure that the invariants that I assume are always held up. Alternatively, I could also turn them into normal `assert!`s or handle-able exceptions through `TryFrom`. I went for the current variants, since I think it makes most sense, but I'm open to different perspectives!

I've verified my assumptions with the help of the below program for probably around 1000 different artists, so it should be fine? Some example outputs:

- for `spotify:artist:5WUlDfRSoLAfcVSX1WnrxN`: `known good artists: 470 (decades: 203, closed: 4, open: 31)`
- for `spotify:artist:3fMbdgg4jU18AjLCKBhRSm`: `known good artists: 333 (decades: 966, closed: 112, open: 216)`

<details>

```rust
use std::{
    collections::{HashSet, VecDeque},
    env,
    io::Write,
    process::exit,
};

use librespot_core::{spotify_id::SpotifyItemType, Session, SessionConfig, SpotifyId};
use librespot_discovery::Credentials;
use librespot_metadata::{artist::ActivityPeriod, Artist, Metadata};

#[tokio::main]
async fn main() {
    env_logger::init();
    let session_config = SessionConfig::default();

    let args: Vec<_> = env::args().collect();
    if args.len() != 4 && args.len() != 5 {
        eprintln!("Usage: {} USERNAME PASSWORD ARTIST_URI", args[0]);
        return;
    }
    let credentials = Credentials::with_password(&args[1], &args[2]);

    let uri = SpotifyId::from_uri(&args[3]).unwrap_or_else(|_| {
        eprintln!(
            "URI should be a URI such as: \
                \"spotify:artist:5WUlDfRSoLAfcVSX1WnrxN\""
        );
        exit(1);
    });

    if uri.item_type != SpotifyItemType::Artist {
        eprintln!("URI must be of item type artist!");
        exit(1);
    }

    let session = Session::new(session_config, None);
    if let Err(e) = session.connect(credentials, false).await {
        eprintln!("Error connecting: {}", e);
        exit(1);
    }

    let mut decades = 0;
    let mut closed_timespans = 0;
    let mut open_timespans = 0;
    let mut known_artist_ids: HashSet<SpotifyId> = HashSet::new();
    let mut new_artist_ids: VecDeque<SpotifyId> = VecDeque::new();
    new_artist_ids.push_back(uri);
    while let Some(id) = new_artist_ids.pop_front() {
        known_artist_ids.insert(id);
        let artist = Artist::get(&session, &id).await.unwrap();
        for period in artist.activity_periods.0 {
            match period {
                ActivityPeriod::Decade(_) => decades += 1,
                ActivityPeriod::Timespan { end_year, .. } => match end_year {
                    Some(_) => closed_timespans += 1,
                    None => open_timespans += 1,
                },
            }
        }
        for artist in artist.related.0 {
            let id = artist.id;
            if !known_artist_ids.contains(&id) {
                new_artist_ids.push_back(artist.id);
            }
        }
        print!(
            "\rknown good artists: {} (decades: {decades}, \
            closed: {closed_timespans}, open: {open_timespans})",
            known_artist_ids.len()
        );
        std::io::stdout().flush().unwrap();
    }
}

```

</details>