### PR TITLE
Fix play track item_type in the examples folder

### DIFF
--- a/examples/play.rs
+++ b/examples/play.rs
@@ -25,7 +25,8 @@ async fn main() {
     }
     let credentials = Credentials::with_password(&args[1], &args[2]);
 
-    let track = SpotifyId::from_base62(&args[3]).unwrap();
+    let mut track = SpotifyId::from_base62(&args[3]).unwrap();
+    track.item_type = SpotifyItemType::Track;
 
     let backend = audio_backend::find(None).unwrap();
 

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -2,7 +2,7 @@ use std::{env, process::exit};
 
 use librespot::{
     core::{
-        authentication::Credentials, config::SessionConfig, session::Session, spotify_id::SpotifyId,
+        authentication::Credentials, config::SessionConfig, session::Session, spotify_id::{SpotifyId, SpotifyItemType},
     },
     playback::{
         audio_backend,


### PR DESCRIPTION
Because of the adding of item_type to SpotifyId and its subsequent switch-case sprawl throughout the codebase, from_base62 is not playable by default. These constructors set the item_type to Unknown.

This was annoying to debug when I ran into this issue so I think the example should be fixed :)

Edit: forgot to add the import for SpotifyItemType which is what the second commit is for. 