### PR TITLE
Fix latest clippy warnings

### DIFF
--- a/examples/play.rs
+++ b/examples/play.rs
@@ -2,7 +2,10 @@ use std::{env, process::exit};
 
 use librespot::{
     core::{
-        authentication::Credentials, config::SessionConfig, session::Session, spotify_id::{SpotifyId, SpotifyItemType},
+        authentication::Credentials,
+        config::SessionConfig,
+        session::Session,
+        spotify_id::{SpotifyId, SpotifyItemType},
     },
     playback::{
         audio_backend,

--- a/src/main.rs
+++ b/src/main.rs
@@ -695,7 +695,7 @@ fn get_setup() -> Setup {
                     // Don't log creds.
                     trace!("\t\t{} \"XXXXXXXX\"", opt);
                 } else {
-                    let value = matches.opt_str(opt).unwrap_or_else(|| "".to_string());
+                    let value = matches.opt_str(opt).unwrap_or_default();
                     if value.is_empty() {
                         trace!("\t\t{}", opt);
                     } else {

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -286,7 +286,7 @@ fn run_program(env_vars: HashMap<&str, String>, onevent: &str) {
         onevent, env_vars
     );
 
-    match Command::new(&v.remove(0))
+    match Command::new(v.remove(0))
         .args(&v)
         .envs(env_vars.iter())
         .spawn()


### PR DESCRIPTION
Fixes
```
warning: the borrowed expression implements the required traits
   --> src/player_event_handler.rs:289:24
    |
289 |     match Command::new(&v.remove(0))
    |                        ^^^^^^^^^^^^ help: change this to: `v.remove(0)`
    |
    = note: `#[warn(clippy::needless_borrow)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#needless_borrow

warning: use of `.unwrap_or_else(..)` to construct default value
   --> src/main.rs:698:33
    |
698 |                     let value = matches.opt_str(opt).unwrap_or_else(|| "".to_string());
    |                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `matches.opt_str(opt).unwrap_or_default()`
    |
    = note: `#[warn(clippy::unwrap_or_else_default)]` on by default
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_else_default
```