### PR TITLE
Fix latest clippy warnings on master

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -678,7 +678,7 @@ fn get_setup() -> Setup {
                     // Don't log creds.
                     trace!("\t\t{} \"XXXXXXXX\"", opt);
                 } else {
-                    let value = matches.opt_str(opt).unwrap_or_else(|| "".to_string());
+                    let value = matches.opt_str(opt).unwrap_or_default();
                     if value.is_empty() {
                         trace!("\t\t{}", opt);
                     } else {

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -128,7 +128,7 @@ pub fn run_program_on_events(event: PlayerEvent, onevent: &str) -> Option<io::Re
     let mut v: Vec<&str> = onevent.split_whitespace().collect();
     info!("Running {:?} with environment variables {:?}", v, env_vars);
     Some(
-        AsyncCommand::new(&v.remove(0))
+        AsyncCommand::new(v.remove(0))
             .args(&v)
             .envs(env_vars.iter())
             .spawn(),
@@ -147,7 +147,7 @@ pub fn emit_sink_event(sink_status: SinkStatus, onevent: &str) -> io::Result<Exi
     let mut v: Vec<&str> = onevent.split_whitespace().collect();
     info!("Running {:?} with environment variables {:?}", v, env_vars);
 
-    Command::new(&v.remove(0))
+    Command::new(v.remove(0))
         .args(&v)
         .envs(env_vars.iter())
         .spawn()?


### PR DESCRIPTION
Same as #1076 but without the `fmt` fix.