### PR TITLE
Don't fail to parse playlists if some tracks have invalid IDs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ https://github.com/librespot-org/librespot
   now follows the setting in the Connect client that controls it. (breaking)
 - [metadata] Most metadata is now retrieved with the `spclient` (breaking)
 - [metadata] Playlists are moved to the `playlist4_external` protobuf (breaking)
+- [metadata] Playlists with invalid tracks will now load with invalid tracks filtered out
 - [playback] The audio decoder has been switched from `lewton` to `Symphonia`.
   This improves the Vorbis sound quality, adds support for MP3 as well as for
   FLAC in the future. (breaking)

--- a/metadata/src/playlist/item.rs
+++ b/metadata/src/playlist/item.rs
@@ -71,7 +71,13 @@ impl TryFrom<&PlaylistItemsMessage> for PlaylistItemList {
         Ok(Self {
             position: list_items.get_pos(),
             is_truncated: list_items.get_truncated(),
-            items: list_items.get_items().try_into()?,
+            items: PlaylistItems(
+                list_items
+                    .get_items()
+                    .iter()
+                    .filter_map(|i| i.try_into().ok())
+                    .collect(),
+            ),
             meta_items: list_items.get_meta_items().try_into()?,
         })
     }

--- a/metadata/src/playlist/list.rs
+++ b/metadata/src/playlist/list.rs
@@ -79,7 +79,8 @@ impl Playlist {
         let length = tracks.len();
         let expected_length = self.length as usize;
         if length != expected_length {
-            warn!(
+            // likely caused by some invalid (local) track IDs
+            info!(
                 "Got {} tracks, but the list should contain {} tracks.",
                 length, expected_length,
             );


### PR DESCRIPTION
Allow playlists to load even if they have some tracks with invalid IDs. This happens most commonly when playlists have local tracks. This is unfortunately fairly common on public playlists.