### PR TITLE
[Discovery] Support add user with access token

### DIFF
--- a/core/src/authentication.rs
+++ b/core/src/authentication.rs
@@ -41,7 +41,7 @@ impl Credentials {
             auth_data: password.into().into_bytes(),
         }
     }
-    
+
     pub fn with_access_token(username: impl Into<String>, token: impl Into<String>) -> Credentials {
         Credentials {
             username: username.into(),

--- a/core/src/authentication.rs
+++ b/core/src/authentication.rs
@@ -41,6 +41,14 @@ impl Credentials {
             auth_data: password.into().into_bytes(),
         }
     }
+    
+    pub fn with_access_token(username: impl Into<String>, token: impl Into<String>) -> Credentials {
+        Credentials {
+            username: username.into(),
+            auth_type: AuthenticationType::AUTHENTICATION_SPOTIFY_TOKEN,
+            auth_data: token.into().into_bytes(),
+        }
+    }
 
     pub fn with_blob(
         username: impl Into<String>,


### PR DESCRIPTION
Hi,
I have added this changes in order to support adding the client to my account using and access token with the "streaming" scope through the addUser action. It's inspired by the project https://github.com/TimotheeGerber/spotify-connect.
 
Do you think this can this be merged agains the 0.4.x version and included in the next 0.4.x release? Or is better that I open a pr agains the dev branch?

Hope the code is ok I don't have too much experience with rust.

Regards!

Related to:
https://github.com/librespot-org/librespot/issues/1086#issuecomment-1381871262
https://github.com/librespot-org/librespot/pull/1098
