### PR TITLE
Allow to fine-tune the requested stream formats

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,6 +1530,7 @@ dependencies = [
  "librespot-audio",
  "librespot-core",
  "librespot-metadata",
+ "librespot-protocol",
  "log",
  "ogg",
  "parking_lot 0.12.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1373,6 +1373,8 @@ dependencies = [
  "log",
  "rpassword",
  "sha1",
+ "strum",
+ "strum_macros",
  "thiserror",
  "tokio",
  "url",
@@ -1553,6 +1555,8 @@ dependencies = [
  "glob",
  "protobuf",
  "protobuf-codegen",
+ "strum",
+ "strum_macros",
 ]
 
 [[package]]
@@ -2704,6 +2708,25 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "strum"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
+
+[[package]]
+name = "strum_macros"
+version = "0.24.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
 
 [[package]]
 name = "subtle"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ sha1 = "0.10"
 thiserror = "1.0"
 tokio = { version = "1", features = ["rt", "macros", "signal", "sync", "parking_lot", "process"] }
 url = "2.2"
+strum = "0.24"
+strum_macros = "0.24"
 
 [features]
 alsa-backend = ["librespot-playback/alsa-backend"]

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -20,6 +20,10 @@ version = "0.5.0-dev"
 path = "../metadata"
 version = "0.5.0-dev"
 
+[dependencies.librespot-protocol]
+path = "../protocol"
+version = "0.5.0-dev"
+
 [dependencies]
 byteorder = "1"
 futures-util = "0.3"

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -4,6 +4,7 @@ extern crate log;
 use librespot_audio as audio;
 use librespot_core as core;
 use librespot_metadata as metadata;
+use librespot_protocol as protocol;
 
 pub mod audio_backend;
 pub mod config;

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -30,11 +30,11 @@ use crate::{
         READ_AHEAD_DURING_PLAYBACK,
     },
     audio_backend::Sink,
-    config::{Bitrate, NormalisationMethod, NormalisationType, PlayerConfig},
+    config::{AudioFileFormat, NormalisationMethod, NormalisationType, PlayerConfig},
     convert::Converter,
     core::{util::SeqGenerator, Error, Session, SpotifyId},
     decoder::{AudioDecoder, AudioPacket, AudioPacketPosition, SymphoniaDecoder},
-    metadata::audio::{AudioFileFormat, AudioFiles, AudioItem},
+    metadata::audio::{AudioFiles, AudioItem},
     mixer::VolumeGetter,
 };
 
@@ -932,39 +932,8 @@ impl PlayerTrackLoader {
             audio_item.name, audio_item.uri
         );
 
-        // (Most) podcasts seem to support only 96 kbps Ogg Vorbis, so fall back to it
-        let formats = match self.config.bitrate {
-            Bitrate::Bitrate96 => [
-                AudioFileFormat::OGG_VORBIS_96,
-                AudioFileFormat::MP3_96,
-                AudioFileFormat::OGG_VORBIS_160,
-                AudioFileFormat::MP3_160,
-                AudioFileFormat::MP3_256,
-                AudioFileFormat::OGG_VORBIS_320,
-                AudioFileFormat::MP3_320,
-            ],
-            Bitrate::Bitrate160 => [
-                AudioFileFormat::OGG_VORBIS_160,
-                AudioFileFormat::MP3_160,
-                AudioFileFormat::OGG_VORBIS_96,
-                AudioFileFormat::MP3_96,
-                AudioFileFormat::MP3_256,
-                AudioFileFormat::OGG_VORBIS_320,
-                AudioFileFormat::MP3_320,
-            ],
-            Bitrate::Bitrate320 => [
-                AudioFileFormat::OGG_VORBIS_320,
-                AudioFileFormat::MP3_320,
-                AudioFileFormat::MP3_256,
-                AudioFileFormat::OGG_VORBIS_160,
-                AudioFileFormat::MP3_160,
-                AudioFileFormat::OGG_VORBIS_96,
-                AudioFileFormat::MP3_96,
-            ],
-        };
-
         let (format, file_id) =
-            match formats
+            match self.config.file_formats
                 .iter()
                 .find_map(|format| match audio_item.files.get(format) {
                     Some(&file_id) => Some((*format, file_id)),

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -11,7 +11,10 @@ edition = "2021"
 
 [dependencies]
 protobuf = "3"
+strum = "0.24"
+strum_macros = "0.24"
 
 [build-dependencies]
 glob = "0.3"
 protobuf-codegen = "3"
+protobuf = "3"

--- a/protocol/build.rs
+++ b/protocol/build.rs
@@ -4,6 +4,20 @@ use std::{
     path::{Path, PathBuf},
 };
 
+use protobuf_codegen::{
+    Customize,
+    CustomizeCallback,
+};
+use protobuf::reflect::EnumDescriptor;
+
+struct GenStrum;
+
+impl CustomizeCallback for GenStrum {
+    fn enumeration(&self, _enum_type: &EnumDescriptor) -> Customize {
+        Customize::default().before("#[derive(::strum_macros::EnumString,::strum_macros::EnumVariantNames)]")
+    }
+}
+
 fn out_dir() -> PathBuf {
     Path::new(&env::var("OUT_DIR").expect("env")).to_path_buf()
 }
@@ -51,6 +65,7 @@ fn compile() {
         .out_dir(&out_dir)
         .inputs(&slices)
         .include(&proto_dir)
+        .customize_callback(GenStrum)
         .run()
         .expect("Codegen failed.");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1358,15 +1358,15 @@ fn get_setup() -> Setup {
     let player_config = {
         let player_default_config = PlayerConfig::default();
 
-        let bitrate = opt_str(BITRATE)
+        let file_formats = opt_str(BITRATE)
             .as_deref()
             .map(|bitrate| {
                 Bitrate::from_str(bitrate).unwrap_or_else(|_| {
                     invalid_error_msg(BITRATE, BITRATE_SHORT, bitrate, "96, 160, 320", "160");
                     exit(1);
-                })
+                }).file_formats()
             })
-            .unwrap_or(player_default_config.bitrate);
+            .unwrap_or(player_default_config.file_formats);
 
         let gapless = !opt_present(DISABLE_GAPLESS);
 
@@ -1605,7 +1605,7 @@ fn get_setup() -> Setup {
         let passthrough = false;
 
         PlayerConfig {
-            bitrate,
+            file_formats,
             gapless,
             passthrough,
             normalisation,


### PR DESCRIPTION
Requested file formats can be currently controlled only through the bitrate parameter, which translates to one of a few hard-coded priority lists.

Some users may want to specify a different preference list, e.g.:
- request AAC and/or FLAC,
- prefer MP3 over OGG,
- give up on a low-bandwidth connection if a low-bitrate format is unavailable, rather than falling back to a higher bitrate.
