### PR TITLE
Fix `NamedSpotifyId::to_uri`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ https://github.com/librespot-org/librespot
   from the beginning
 - [playback] Handle disappearing and invalid devices better
 - [playback] Handle seek, pause, and play commands while loading
+- [metadata] Fix missing colon when converting named spotify IDs to URIs
 
 ## [0.4.2] - 2022-07-29
 

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -345,6 +345,7 @@ impl NamedSpotifyId {
         let mut dst = String::with_capacity(37 + self.username.len() + item_type.len());
         dst.push_str("spotify:user:");
         dst.push_str(&self.username);
+        dst.push(':');
         dst.push_str(item_type);
         dst.push(':');
         let base_62 = self.to_base62()?;


### PR DESCRIPTION
The encoded URIs were previously missing a colon between the username and item type.