### PR TITLE
Update rodio to 0.17.1 and cpal to 0.15.1 #1191

### DIFF
--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -43,8 +43,8 @@ gstreamer-audio = { version = "0.18", optional = true }
 glib            = { version = "0.15", optional = true }
 
 # Rodio dependencies
-rodio           = { version = "0.15", optional = true, default-features = false }
-cpal            = { version = "0.13", optional = true }
+rodio           = { version = "0.17.1", optional = true, default-features = false }
+cpal            = { version = "0.15.1", optional = true }
 
 # Container and audio decoder
 symphonia = { version = "0.5", default-features = false, features = ["mp3", "ogg", "vorbis"] }


### PR DESCRIPTION
Inherit upstream fix https://github.com/RustAudio/cpal/pull/648