### PR TITLE
update jack to match alsa requirement

### DIFF
--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -33,7 +33,7 @@ alsa            = { version = "0.6", optional = true }
 portaudio-rs    = { version = "0.3", optional = true }
 libpulse-binding        = { version = "2", optional = true, default-features = false }
 libpulse-simple-binding = { version = "2", optional = true, default-features = false }
-jack            = { version = "0.10", optional = true }
+jack            = { version = "0.11", optional = true }
 sdl2            = { version = "0.35", optional = true }
 gstreamer       = { version = "0.18", optional = true }
 gstreamer-app   = { version = "0.18", optional = true }


### PR DESCRIPTION
Fix up of #1135, which [makes CI fail](https://github.com/librespot-org/librespot/actions/runs/4489824468/jobs/7896132422?pr=1129), due to conflicting requirements for `jack-sys`.

Should I run `cargo update` as well, or is that usually done some time before a release?