### PR TITLE
Fixes pulseaudio backend linking error by installing libpulse0 package …

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -25,6 +25,7 @@ RUN apt-get update
 
 RUN apt-get install -y curl git build-essential crossbuild-essential-arm64 crossbuild-essential-armel crossbuild-essential-armhf crossbuild-essential-mipsel pkg-config
 RUN apt-get install -y libasound2-dev libasound2-dev:arm64 libasound2-dev:armel libasound2-dev:armhf libasound2-dev:mipsel
+RUN apt-get install -y libpulse0 libpulse0:arm64 libpulse0:armel libpulse0:armhf
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/root/.cargo/bin/:${PATH}"


### PR DESCRIPTION
…for all architectures (excepts mipsel, which remains broken)