### PR TITLE
Update github actions and add Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: weekly
+    day: saturday
+    time: "10:00"
+  open-pull-requests-limit: 10
+  target-branch: dev

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,10 +65,10 @@ jobs:
             experimental: true
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
@@ -117,10 +117,10 @@ jobs:
           - stable
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.6
         with:
           toolchain: ${{ matrix.toolchain }}
           profile: minimal
@@ -132,7 +132,7 @@ jobs:
         shell: bash
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.3.1
         with:
           path: |
             ~/.cargo/registry/index
@@ -164,10 +164,10 @@ jobs:
           - stable
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           target: ${{ matrix.target }}
@@ -180,7 +180,7 @@ jobs:
         shell: bash
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.3.1
         with:
           path: |
             ~/.cargo/registry/index
@@ -205,10 +205,10 @@ jobs:
         toolchain: [stable]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           toolchain: ${{ matrix.toolchain }}
@@ -221,7 +221,7 @@ jobs:
         shell: bash
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.3.1
         with:
           path: |
             ~/.cargo/registry/index
@@ -247,9 +247,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3.5.0
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@v1.0.6
         with:
           profile: minimal
           toolchain: stable

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Get Rustc version
         id: get-rustc-version
-        run: echo "::set-output name=version::$(rustc -V)"
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache Rust dependencies
@@ -128,7 +128,7 @@ jobs:
 
       - name: Get Rustc version
         id: get-rustc-version
-        run: echo "::set-output name=version::$(rustc -V)"
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache Rust dependencies
@@ -176,7 +176,7 @@ jobs:
 
       - name: Get Rustc version
         id: get-rustc-version
-        run: echo "::set-output name=version::$(rustc -V)"
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache Rust dependencies
@@ -217,7 +217,7 @@ jobs:
 
       - name: Get Rustc version
         id: get-rustc-version
-        run: echo "::set-output name=version::$(rustc -V)"
+        run: echo "version=$(rustc -V)" >> $GITHUB_OUTPUT
         shell: bash
 
       - name: Cache Rust dependencies


### PR DESCRIPTION
Your github actions are quite outdated, thus triggering deprecation warnings when the workflows run.

This PR will
- Update all actions to the latest versions
- Install Dependabot which will create a PR if one of your actions becomes outdated, updating it automatically