### PR TITLE
Update actions/cache

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -80,7 +80,7 @@ jobs:
         shell: bash
 
       - name: Cache Rust dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3.3.1
         with:
           path: |
             ~/.cargo/registry/index


### PR DESCRIPTION
Updates a forgotten `actions/cache` from `v2` to latest in https://github.com/librespot-org/librespot/pull/1141
Supersedes https://github.com/librespot-org/librespot/pull/1145 