### PR TITLE
Remove actions-rs/toolchain

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,11 +68,7 @@ jobs:
         uses: actions/checkout@v3.5.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain ${{ matrix.toolchain }}  -y
 
       - name: Get Rustc version
         id: get-rustc-version
@@ -120,11 +116,7 @@ jobs:
         uses: actions/checkout@v3.5.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          profile: minimal
-          override: true
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain ${{ matrix.toolchain }}  -y
 
       - name: Get Rustc version
         id: get-rustc-version
@@ -167,12 +159,7 @@ jobs:
         uses: actions/checkout@v3.5.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          target: ${{ matrix.target }}
-          toolchain: ${{ matrix.toolchain }}
-          override: true
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal --default-toolchain ${{ matrix.toolchain }}  -y
 
       - name: Get Rustc version
         id: get-rustc-version
@@ -208,12 +195,7 @@ jobs:
         uses: actions/checkout@v3.5.0
 
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: ${{ matrix.toolchain }}
-          override: true
-          components: clippy
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --profile default --default-toolchain ${{ matrix.toolchain }}  -y
 
       - name: Get Rustc version
         id: get-rustc-version
@@ -243,16 +225,11 @@ jobs:
 
   fmt:
     needs: clippy
-    name: cargo +${{ matrix.toolchain }} fmt
+    name: cargo fmt
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v3.5.0
       - name: Install toolchain
-        uses: actions-rs/toolchain@v1.0.7
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: rustfmt
+        run: curl https://sh.rustup.rs -sSf | sh -s -- --profile default --default-toolchain stable  -y
       - run: cargo fmt --all -- --check


### PR DESCRIPTION
This PR removes the `actions-rs/toolchain` action from the `test.yml`. The respective [repo](https://github.com/actions-rs/toolchain) is unmaintained since 3 years and recent Github changes are not accounted for. This causes actions in all repo using this action to trigger massive warnings.

![Screenshot at 2023-04-11 22-43-26](https://user-images.githubusercontent.com/26622301/231284244-caa2444d-d14b-4364-99bd-505a346da16b.png)

___

This PR replaces the action with a direct download and run of `rustup`, preserving the wanted profile and toolchain.