### PR TITLE
Update quick-xml

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -79,7 +79,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -561,7 +561,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -676,9 +676,9 @@ dependencies = [
 
 [[package]]
 name = "glib"
-version = "0.17.5"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfb53061756195d76969292c2d2e329e01259276524a9bae6c9b73af62854773"
+checksum = "6cbc688e6c33f2fd89d83864a9e6caaaef83b5f608922b99ac184e436d15b623"
 dependencies = [
  "bitflags",
  "futures-channel",
@@ -699,9 +699,9 @@ dependencies = [
 
 [[package]]
 name = "glib-macros"
-version = "0.17.7"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc4cf346122086f196260783aa58987190dbd5f43bfab01946d2bf9786e8d9ef"
+checksum = "726f25f054ce331f0d971a82a6a85eb4955074d6afbe479e42a63ae9f15f6ac4"
 dependencies = [
  "anyhow",
  "heck",
@@ -1019,9 +1019,9 @@ checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
-version = "0.14.25"
+version = "0.14.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc5e554ff619822309ffd57d8734d77cd5ce6238bc956f037ea06c58238c9899"
+checksum = "ab302d72a6f11a3b910431ff93aae7e773078c769f0a3ef15fb9ec692ed147d4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2188,9 +2188,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.23.1"
+version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11bafc859c6815fbaffbbbf4229ecb767ac913fecb27f9ad4343662e9ef099ea"
+checksum = "0ce5e73202a820a31f8a0ee32ada5e21029c81fd9e3ebf668a40832e4219d9d1"
 dependencies = [
  "memchr",
  "serde",
@@ -2554,14 +2554,14 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.95"
+version = "1.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d721eca97ac802aa7777b701877c8004d950fc142651367300d21c1cc0194744"
+checksum = "057d394a50403bcac12672b2b18fb387ab6d289d957dab67dd201875391e52f1"
 dependencies = [
  "itoa",
  "ryu",
@@ -2773,9 +2773,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.14"
+version = "2.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf316d5356ed6847742d036f8a39c3b8435cac10bd528a4bd461928a6ab34d5"
+checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2848,7 +2848,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -2931,7 +2931,7 @@ checksum = "61a573bdc87985e9d6ddeed1b3d864e8a302c847e40d647746df2f1de209d1ce"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.14",
+ "syn 2.0.15",
 ]
 
 [[package]]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -41,7 +41,7 @@ parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
 priority-queue = "1.2"
 protobuf = "3"
-quick-xml = { version = "0.23", features = ["serialize"] }
+quick-xml = { version = "0.28", features = ["serialize"] }
 rand = "0.8"
 rsa = "0.8.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -309,19 +309,17 @@ impl Session {
                 let mut user_attributes: UserAttributes = HashMap::new();
 
                 loop {
-                    match reader.read_event(&mut buf) {
+                    match reader.read_event_into(&mut buf) {
                         Ok(Event::Start(ref element)) => {
-                            current_element = std::str::from_utf8(element.name())?.to_owned()
+                            current_element = std::str::from_utf8(element)?.to_owned()
                         }
                         Ok(Event::End(_)) => {
                             current_element = String::new();
                         }
                         Ok(Event::Text(ref value)) => {
                             if !current_element.is_empty() {
-                                let _ = user_attributes.insert(
-                                    current_element.clone(),
-                                    value.unescape_and_decode(&reader)?,
-                                );
+                                let _ = user_attributes
+                                    .insert(current_element.clone(), value.unescape()?.to_string());
                             }
                         }
                         Ok(Event::Eof) => break,


### PR DESCRIPTION
This is one of a series of PRs that will update dependencies not included in https://github.com/librespot-org/librespot/pull/1140.

This one updates `quick_xml` from v0.23 to v0.28

The method `unescape_and_decode` ([here](https://docs.rs/quick-xml/0.23.0/quick_xml/events/struct.BytesText.html#method.unescape_and_decode)) was renamed to `unescape` ([here](https://docs.rs/quick-xml/0.28.2/quick_xml/events/struct.BytesText.html#method.unescape)) and now decodes first beore unescaping. The result changed from `String` to `Cow<'a, str>`