### PR TITLE
Respect disabled normalisation with maximum volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,7 @@ https://github.com/librespot-org/librespot
   from the beginning
 - [playback] Handle disappearing and invalid devices better
 - [playback] Handle seek, pause, and play commands while loading
+- [playback] Handle disabled normalisation correctly when using fixed volume
 - [metadata] Fix missing colon when converting named spotify IDs to URIs
 
 ## [0.4.2] - 2022-07-29

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1545,7 +1545,10 @@ impl PlayerInternal {
                         // dynamic method, there may still be peaks that we want to shave off.
 
                         // No matter the case we apply volume attenuation last if there is any.
-                        if !self.config.normalisation && volume < 1.0 {
+                        if !self.config.normalisation && volume >= 1.0 {
+                            // do not alter sample
+                        }
+                        else if !self.config.normalisation && volume < 1.0 {
                             for sample in data.iter_mut() {
                                 *sample *= volume;
                             }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1545,12 +1545,11 @@ impl PlayerInternal {
                         // dynamic method, there may still be peaks that we want to shave off.
 
                         // No matter the case we apply volume attenuation last if there is any.
-                        if !self.config.normalisation && volume >= 1.0 {
-                            // do not alter sample
-                        }
-                        else if !self.config.normalisation && volume < 1.0 {
-                            for sample in data.iter_mut() {
-                                *sample *= volume;
+                        if !self.config.normalisation {
+                            if volume < 1.0 {
+                                for sample in data.iter_mut() {
+                                    *sample *= volume;
+                                }
                             }
                         } else if self.config.normalisation_method == NormalisationMethod::Basic
                             && (normalisation_factor < 1.0 || volume < 1.0)


### PR DESCRIPTION
I've noticed an issue with my CPU usage on a really low end device while playing music with maximum volume. When volume is equal to 1.0 and normalisation is disabled the first condition failed (as it should) and librespot didn't check whether the normalisation was disabled anymore - it just normalised the song anyway using self.config.normalisation_method.