### PR TITLE
Use a single player instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,9 @@ https://github.com/librespot-org/librespot
 - [all] `chrono` replaced with `time` (breaking)
 - [all] `time` updated (CVE-2020-26235)
 - [all] Improve lock contention and performance (breaking)
+- [all] Use a single `player` instance. Eliminates occasional `player` and
+  `audio backend` restarts, which can cause issues with some playback
+  configurations.
 - [audio] Files are now downloaded over the HTTPS CDN (breaking)
 - [audio] Improve file opening and seeking performance (breaking)
 - [core] MSRV is now 1.65 (breaking)

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -663,6 +663,11 @@ impl SpircTask {
     }
 
     fn handle_player_event(&mut self, event: PlayerEvent) -> Result<(), Error> {
+        // update play_request_id
+        if let PlayerEvent::PlayRequestIdChanged { play_request_id } = event {
+            self.play_request_id = Some(play_request_id);
+            return Ok(());
+        }
         // we only process events if the play_request_id matches. If it doesn't, it is
         // an event that belongs to a previous track and only arrives now due to a race
         // condition. In this case we have updated the state already and don't want to
@@ -1462,7 +1467,7 @@ impl SpircTask {
             Some((track, index)) => {
                 self.state.set_playing_track_index(index);
 
-                self.play_request_id = Some(self.player.load(track, start_playing, position_ms));
+                self.player.load(track, start_playing, position_ms);
 
                 self.update_state_position(position_ms);
                 if start_playing {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -3,6 +3,7 @@ use std::{
     future::Future,
     pin::Pin,
     sync::atomic::{AtomicUsize, Ordering},
+    sync::Arc,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -77,8 +78,8 @@ enum SpircPlayStatus {
 type BoxedStream<T> = Pin<Box<dyn FusedStream<Item = T> + Send>>;
 
 struct SpircTask {
-    player: Player,
-    mixer: Box<dyn Mixer>,
+    player: Arc<Player>,
+    mixer: Arc<dyn Mixer>,
 
     sequence: SeqGenerator<u32>,
 
@@ -272,8 +273,8 @@ impl Spirc {
         config: ConnectConfig,
         session: Session,
         credentials: Credentials,
-        player: Player,
-        mixer: Box<dyn Mixer>,
+        player: Arc<Player>,
+        mixer: Arc<dyn Mixer>,
     ) -> Result<(Spirc, impl Future<Output = ()>), Error> {
         let spirc_id = SPIRC_COUNTER.fetch_add(1, Ordering::AcqRel);
         debug!("new Spirc[{}]", spirc_id);

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -40,7 +40,7 @@ async fn main() {
         exit(1);
     }
 
-    let mut player = Player::new(player_config, session, Box::new(NoOpVolume), move || {
+    let player = Player::new(player_config, session, Box::new(NoOpVolume), move || {
         backend(None, audio_format)
     });
 

--- a/examples/play_connect.rs
+++ b/examples/play_connect.rs
@@ -17,6 +17,7 @@ use librespot_metadata::{Album, Metadata};
 use librespot_playback::mixer::{softmixer::SoftMixer, Mixer, MixerConfig};
 use librespot_protocol::spirc::TrackRef;
 use std::env;
+use std::sync::Arc;
 use tokio::join;
 
 #[tokio::main]
@@ -54,7 +55,7 @@ async fn main() {
         session.clone(),
         credentials,
         player,
-        Box::new(SoftMixer::open(MixerConfig::default())),
+        Arc::new(SoftMixer::open(MixerConfig::default())),
     )
     .await
     .unwrap();

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use crate::config::VolumeCtrl;
 
 pub mod mappings;
@@ -5,7 +7,7 @@ use self::mappings::MappedCtrl;
 
 pub struct NoOpVolume;
 
-pub trait Mixer: Send {
+pub trait Mixer: Send + Sync {
     fn open(config: MixerConfig) -> Self
     where
         Self: Sized;
@@ -55,10 +57,10 @@ impl Default for MixerConfig {
     }
 }
 
-pub type MixerFn = fn(MixerConfig) -> Box<dyn Mixer>;
+pub type MixerFn = fn(MixerConfig) -> Arc<dyn Mixer>;
 
-fn mk_sink<M: Mixer + 'static>(config: MixerConfig) -> Box<dyn Mixer> {
-    Box::new(M::open(config))
+fn mk_sink<M: Mixer + 'static>(config: MixerConfig) -> Arc<dyn Mixer> {
+    Arc::new(M::open(config))
 }
 
 pub const MIXERS: &[(&str, MixerFn)] = &[

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -420,7 +420,7 @@ impl Player {
         session: Session,
         volume_getter: Box<dyn VolumeGetter + Send>,
         sink_builder: F,
-    ) -> Self
+    ) -> Arc<Self>
     where
         F: FnOnce() -> Box<dyn Sink> + Send + 'static,
     {
@@ -490,10 +490,10 @@ impl Player {
             debug!("PlayerInternal thread finished.");
         });
 
-        Self {
+        Arc::new(Self {
             commands: Some(cmd_tx),
             thread_handle: Some(handle),
-        }
+        })
     }
 
     pub fn is_invalid(&self) -> bool {
@@ -1388,10 +1388,6 @@ impl Future for PlayerInternal {
                         play_request_id,
                     });
                 }
-            }
-
-            if self.session.is_invalid() {
-                return Poll::Ready(());
             }
 
             if (!self.state.is_playing()) && all_futures_completed_or_not_ready {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -495,6 +495,13 @@ impl Player {
         }
     }
 
+    pub fn is_invalid(&self) -> bool {
+        if let Some(handle) = self.thread_handle.as_ref() {
+            return handle.is_finished();
+        }
+        true
+    }
+
     fn command(&self, cmd: PlayerCommand) {
         if let Some(commands) = self.commands.as_ref() {
             if let Err(e) = commands.send(cmd) {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -105,6 +105,7 @@ enum PlayerCommand {
     Pause,
     Stop,
     Seek(u32),
+    SetSession(Session),
     AddEventSender(mpsc::UnboundedSender<PlayerEvent>),
     SetSinkEventCallback(Option<SinkEventCallback>),
     EmitVolumeChangedEvent(u16),
@@ -536,6 +537,10 @@ impl Player {
 
     pub fn seek(&self, position_ms: u32) {
         self.command(PlayerCommand::Seek(position_ms));
+    }
+
+    pub fn set_session(&self, session: Session) {
+        self.command(PlayerCommand::SetSession(session));
     }
 
     pub fn get_player_event_channel(&self) -> PlayerEventChannel {
@@ -2092,6 +2097,8 @@ impl PlayerInternal {
 
             PlayerCommand::Stop => self.handle_player_stop(),
 
+            PlayerCommand::SetSession(session) => self.session = session,
+
             PlayerCommand::AddEventSender(sender) => self.event_senders.push(sender),
 
             PlayerCommand::SetSinkEventCallback(callback) => self.sink_event_callback = callback,
@@ -2282,6 +2289,7 @@ impl fmt::Debug for PlayerCommand {
             PlayerCommand::Pause => f.debug_tuple("Pause").finish(),
             PlayerCommand::Stop => f.debug_tuple("Stop").finish(),
             PlayerCommand::Seek(position) => f.debug_tuple("Seek").field(&position).finish(),
+            PlayerCommand::SetSession(_) => f.debug_tuple("SetSession").finish(),
             PlayerCommand::AddEventSender(_) => f.debug_tuple("AddEventSender").finish(),
             PlayerCommand::SetSinkEventCallback(_) => {
                 f.debug_tuple("SetSinkEventCallback").finish()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1817,6 +1817,10 @@ async fn main() {
                     exit(1);
                 }
             },
+            _ = async {}, if player.is_invalid() => {
+                error!("Player shut down unexpectedly");
+                exit(1);
+            },
             _ = tokio::signal::ctrl_c() => {
                 break;
             },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1811,6 +1811,9 @@ async fn main() {
 
                 if last_credentials.is_some() && !reconnect_exceeds_rate_limit() {
                     auto_connect_times.push(Instant::now());
+                    if !session.is_invalid() {
+                        session.shutdown();
+                    }
                     connecting = true;
                 } else {
                     error!("Spirc shut down too often. Not reconnecting automatically.");

--- a/src/main.rs
+++ b/src/main.rs
@@ -1762,6 +1762,9 @@ async fn main() {
                             // Continue shutdown in its own task
                             tokio::spawn(spirc_task);
                         }
+                        if !session.is_invalid() {
+                            session.shutdown();
+                        }
 
                         connecting = true;
                     },

--- a/src/main.rs
+++ b/src/main.rs
@@ -1715,6 +1715,31 @@ async fn main() {
         exit(1);
     }
 
+    let mixer_config = setup.mixer_config.clone();
+    let mixer = (setup.mixer)(mixer_config);
+    let player_config = setup.player_config.clone();
+
+    let soft_volume = mixer.get_soft_volume();
+    let format = setup.format;
+    let backend = setup.backend;
+    let device = setup.device.clone();
+    let player = Player::new(player_config, session.clone(), soft_volume, move || {
+        (backend)(device, format)
+    });
+
+    if let Some(player_event_program) = setup.player_event_program.clone() {
+        _event_handler = Some(EventHandler::new(
+            player.get_player_event_channel(),
+            &player_event_program,
+        ));
+
+        if setup.emit_sink_events {
+            player.set_sink_event_callback(Some(Box::new(move |sink_status| {
+                run_program_on_sink_events(sink_status, &player_event_program)
+            })));
+        }
+    }
+
     loop {
         tokio::select! {
             credentials = async {
@@ -1749,32 +1774,16 @@ async fn main() {
             _ = async {}, if connecting && last_credentials.is_some() => {
                 if session.is_invalid() {
                     session = Session::new(setup.session_config.clone(), setup.cache.clone());
+                    player.set_session(session.clone());
                 }
 
-                let mixer_config = setup.mixer_config.clone();
-                let mixer = (setup.mixer)(mixer_config);
-                let player_config = setup.player_config.clone();
                 let connect_config = setup.connect_config.clone();
 
-                let soft_volume = mixer.get_soft_volume();
-                let format = setup.format;
-                let backend = setup.backend;
-                let device = setup.device.clone();
-                let player = Player::new(player_config, session.clone(), soft_volume, move || {
-                    (backend)(device, format)
-                });
-
-                if let Some(player_event_program) = setup.player_event_program.clone() {
-                    _event_handler = Some(EventHandler::new(player.get_player_event_channel(), &player_event_program));
-
-                    if setup.emit_sink_events {
-                        player.set_sink_event_callback(Some(Box::new(move |sink_status| {
-                            run_program_on_sink_events(sink_status, &player_event_program)
-                        })));
-                    }
-                };
-
-                let (spirc_, spirc_task_) = match Spirc::new(connect_config, session.clone(), last_credentials.clone().unwrap_or_default(), player, mixer).await {
+                let (spirc_, spirc_task_) = match Spirc::new(connect_config,
+                                                                session.clone(),
+                                                                last_credentials.clone().unwrap_or_default(),
+                                                                player.clone(),
+                                                                mixer.clone()).await {
                     Ok((spirc_, spirc_task_)) => (spirc_, spirc_task_),
                     Err(e) => {
                         error!("could not initialize spirc: {}", e);

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -21,6 +21,10 @@ impl EventHandler {
                     let mut env_vars = HashMap::new();
 
                     match event {
+                        PlayerEvent::PlayRequestIdChanged { play_request_id } => {
+                            env_vars.insert("PLAYER_EVENT", "play_request_id_changed".to_string());
+                            env_vars.insert("PLAY_REQUEST_ID", play_request_id.to_string());
+                        }
                         PlayerEvent::TrackChanged { audio_item } => {
                             match audio_item.track_id.to_base62() {
                                 Err(e) => {


### PR DESCRIPTION
Create a single player instance, when librespot starts and keep it running over reconnections. In the current implementation the player is recreated on every reconnection, which causes the output device to be recreated too. This creates a racing condition in Jack, which occasionally causes the output device to be created with a different name. This is an issue especially when using Jack's custom routing. I.e. A different user connects via Spotify Connect and Jack doesn't create the configured audio route because of the name change.