### PR TITLE
Parse expiry timestamp from spotifycdn.com CDN URLs (Fixes #1182)

### DIFF
--- a/core/src/cdn_url.rs
+++ b/core/src/cdn_url.rs
@@ -121,6 +121,7 @@ impl TryFrom<CdnUrlMessage> for MaybeExpiringUrls {
                         .into_iter()
                         .find(|(key, _value)| key == "__token__")
                     {
+                        //"https://audio-ak-spotify-com.akamaized.net/audio/4712bc9e47f7feb4ee3450ef2bb545e1d83c3d54?__token__=exp=1688165560~hmac=4e661527574fab5793adb99cf04e1c2ce12294c71fe1d39ffbfabdcfe8ce3b41",
                         if let Some(mut start) = token.1.find("exp=") {
                             start += 4;
                             if token.1.len() >= start {
@@ -137,7 +138,21 @@ impl TryFrom<CdnUrlMessage> for MaybeExpiringUrls {
                         } else {
                             String::new()
                         }
+                    } else if let Some(token) = url
+                        .query_pairs()
+                        .into_iter()
+                        .find(|(key, _value)| key == "Expires")
+                    {
+                        //"https://audio-gm-off.spotifycdn.com/audio/4712bc9e47f7feb4ee3450ef2bb545e1d83c3d54?Expires=1688165560~FullPath~hmac=IIZA28qptl8cuGLq15-SjHKHtLoxzpy_6r_JpAU4MfM=",
+                        if let Some(end) = token.1.find('~') {
+                            // this is the only valid invariant for spotifycdn.com
+                            let slice = &token.1[..end];
+                            String::from(&slice[..end])
+                        } else {
+                            String::new()
+                        }
                     } else if let Some(query) = url.query() {
+                        //"https://audio4-fa.scdn.co/audio/4712bc9e47f7feb4ee3450ef2bb545e1d83c3d54?1688165560_0GKSyXjLaTW1BksFOyI4J7Tf9tZDbBUNNPu9Mt4mhH4=",
                         let mut items = query.split('_');
                         if let Some(first) = items.next() {
                             // this is the only valid invariant for scdn.co


### PR DESCRIPTION
The CDN URLs list now includes spotifycdn.com which has a different format. It was being erroneously interpreted using the scdn.co format and trying to parse non-digit characters as a timestamp.

It was trying to interpret the entire query string of "https://audio-gm-off.spotifycdn.com/audio/4712bc9e47f7feb4ee3450ef2bb545e1d83c3d54?Expires=1688165560~FullPath~hmac=IIZA28qptl8cuGLq15-SjHKHtLoxzpy_6r_JpAU4MfM=" as a number. 

Maybe it would be better to match on the domain? Or at least catch the `parse()` error and just pretend it's not expiring?