### PR TITLE
Adding option and flag to limit sink write rates (concerning #1195)

### DIFF
--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -126,6 +126,7 @@ pub struct PlayerConfig {
     pub bitrate: Bitrate,
     pub gapless: bool,
     pub passthrough: bool,
+    pub limit_sink_write_rate: bool,
 
     pub normalisation: bool,
     pub normalisation_type: NormalisationType,
@@ -155,6 +156,7 @@ impl Default for PlayerConfig {
             normalisation_release_cf: duration_to_coefficient(Duration::from_millis(100)),
             normalisation_knee_db: 5.0,
             passthrough: false,
+            limit_sink_write_rate: false,
             ditherer: Some(mk_ditherer::<TriangularDitherer>),
         }
     }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1662,9 +1662,7 @@ impl PlayerInternal {
                         self.handle_pause();
                     }
 
-                    let prevent_buffering_ahead = true;
-
-                    if prevent_buffering_ahead {
+                    if self.config.limit_sink_write_rate {
                         if let PlayerState::Playing {
                             reported_nominal_start_time,
                             ..

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,7 @@ fn get_setup() -> Setup {
     const ONEVENT: &str = "onevent";
     #[cfg(feature = "passthrough-decoder")]
     const PASSTHROUGH: &str = "passthrough";
+    const LIMIT_SINK_WRITE_RATE: &str = "limit-sink-write";
     const PASSWORD: &str = "password";
     const PROXY: &str = "proxy";
     const QUIET: &str = "quiet";
@@ -266,6 +267,7 @@ fn get_setup() -> Setup {
     const ONEVENT_SHORT: &str = "o";
     #[cfg(feature = "passthrough-decoder")]
     const PASSTHROUGH_SHORT: &str = "P";
+    const LIMIT_SINK_WRITE_RATE_SHORT: &str = "";
     const PASSWORD_SHORT: &str = "p";
     const EMIT_SINK_EVENTS_SHORT: &str = "Q";
     const QUIET_SHORT: &str = "q";
@@ -583,6 +585,12 @@ fn get_setup() -> Setup {
         PASSTHROUGH_SHORT,
         PASSTHROUGH,
         "Pass a raw stream to the output. Only works with the pipe and subprocess backends.",
+    );
+
+    opts.optflag(
+        LIMIT_SINK_WRITE_RATE_SHORT,
+        LIMIT_SINK_WRITE_RATE,
+        "Limits the rate at which librespot writes to the output device. Useful for pipe backend.",
     );
 
     let args: Vec<_> = std::env::args_os()
@@ -1604,10 +1612,13 @@ fn get_setup() -> Setup {
         #[cfg(not(feature = "passthrough-decoder"))]
         let passthrough = false;
 
+        let limit_sink_write_rate = opt_present(LIMIT_SINK_WRITE_RATE);
+
         PlayerConfig {
             bitrate,
             gapless,
             passthrough,
+            limit_sink_write_rate,
             normalisation,
             normalisation_type,
             normalisation_method,


### PR DESCRIPTION
Hello!

Earlier today I opened #1195 which talks about how certain backends without buffering may accept all of the audio packets from librespot as soon as they are available, leading songs to end seconds after they begin. This PR is one option at addressing that.

This PR adds a flag and option called `--limit-sink-write`, which effectively checks if the sink writes are running faster than the speed at which the song should be playing, and if so sleeps for the difference.

I am not sure if this is the best way to be doing this, but it was the most consistent of any method I tried. Limiting based on bitrate alone left the song about 10 seconds ahead on librespot's side, and backed-specific implementation didn't make much sense for me due to my relative lack of knowledge on this topic.

Hopefully this PR is helpful, but if not hopefully it gives y'all a bit of insight into a way of fixing #1195 that does work.

Thanks!