### PR TITLE
Draft: RFC supporting single track repeat

### DIFF
--- a/contrib/event_handler_example.py
+++ b/contrib/event_handler_example.py
@@ -26,6 +26,9 @@ elif player_event == 'shuffle_changed':
 elif player_event == 'repeat_changed':
     json_dict['repeat'] = os.environ['REPEAT']
 
+elif player_event == 'repeat_one_changed':
+    json_dict['repeat_one'] = os.environ['REPEAT_ONE']
+
 elif player_event == 'auto_play_changed':
     json_dict['auto_play'] = os.environ['AUTO_PLAY']
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -127,6 +127,7 @@ enum PlayerCommand {
     EmitFilterExplicitContentChangedEvent(bool),
     EmitShuffleChangedEvent(bool),
     EmitRepeatChangedEvent(bool),
+    EmitRepeatOneChangedEvent(bool),
     EmitAutoPlayChangedEvent(bool),
 }
 
@@ -222,6 +223,9 @@ pub enum PlayerEvent {
     },
     RepeatChanged {
         repeat: bool,
+    },
+    RepeatOneChanged {
+        repeat_one: bool,
     },
     AutoPlayChanged {
         auto_play: bool,
@@ -481,7 +485,6 @@ impl Player {
                 player_id,
                 play_request_id_generator: SeqGenerator::new(0),
             };
-
             // While PlayerInternal is written as a future, it still contains blocking code.
             // It must be run by using block_on() in a dedicated thread.
             let runtime = tokio::runtime::Runtime::new().expect("Failed to create Tokio runtime");
@@ -612,6 +615,10 @@ impl Player {
 
     pub fn emit_repeat_changed_event(&self, repeat: bool) {
         self.command(PlayerCommand::EmitRepeatChangedEvent(repeat));
+    }
+
+    pub fn emit_repeat_one_changed_event(&self, repeat_one: bool) {
+        self.command(PlayerCommand::EmitRepeatOneChangedEvent(repeat_one));
     }
 
     pub fn emit_auto_play_changed_event(&self, auto_play: bool) {
@@ -2337,6 +2344,10 @@ impl fmt::Debug for PlayerCommand {
             PlayerCommand::EmitRepeatChangedEvent(repeat) => f
                 .debug_tuple("EmitRepeatChangedEvent")
                 .field(&repeat)
+                .finish(),
+            PlayerCommand::EmitRepeatOneChangedEvent(repeat_one) => f
+                .debug_tuple("EmitRepeatOneChangedEvent")
+                .field(&repeat_one)
                 .finish(),
             PlayerCommand::EmitAutoPlayChangedEvent(auto_play) => f
                 .debug_tuple("EmitAutoPlayChangedEvent")

--- a/protocol/proto/spirc.proto
+++ b/protocol/proto/spirc.proto
@@ -33,6 +33,7 @@ enum MessageType {
     kMessageTypeVolume = 0x1b;
     kMessageTypeShuffle = 0x1c;
     kMessageTypeRepeat = 0x1d;
+    kMessageTypeRepeatOne = 0x1e;
     kMessageTypeVolumeDown = 0x1f;
     kMessageTypeVolumeUp = 0x20;
     kMessageTypeReplace = 0x21;
@@ -92,6 +93,7 @@ message State {
     optional string context_description = 0x8;
     optional bool shuffle = 0xd;
     optional bool repeat = 0xe;
+    optional bool repeat_one = 0xf;
     optional string last_command_ident = 0x14;
     optional uint32 last_command_msgid = 0x15;
     optional bool playing_from_fallback = 0x18;


### PR DESCRIPTION
Thinking of tackling the issue of single-track repeat not being supported.

Note I'm not planning on merging this branch as is as it's broken / logic / ugly doesn't work and doesn't implement the changes I'm discussing. This is more just to describe what I want to do.
 
I'm thinking of doing it in a similar way to that shown here if we want backward compatibility. i.e creating a separate field for repeat_one and handling the logic for that separately.

Or what I'd prefer to do is to make repeat an enum with something like Repeat::Track, Repeat::All, Repeat::Off although I'm pretty sure this will break backwards compatibility. Although I guess I could store it this way in the state but the messages/interface the end user sends can treat it as two different events and what's returned is repeat=true,repeat_one=false seperately for example, preserving backwards compatibility.

I'm new to this project, so sorry if I'm missing something or saying something stupid. Just wanted some feedback before going deeper. Thanks.

Related Issue: https://github.com/librespot-org/librespot/issues/19