### PR TITLE
Cargo replace hex with faster-hex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -480,6 +480,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "faster-hex"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2a2b11eda1d40935b26cf18f6833c526845ae8c41e58d09af6adeb6f0269183"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,9 +1341,9 @@ name = "librespot"
 version = "0.5.0-dev"
 dependencies = [
  "env_logger",
+ "faster-hex",
  "futures-util",
  "getopts",
- "hex",
  "librespot-audio",
  "librespot-connect",
  "librespot-core",
@@ -1400,11 +1409,11 @@ dependencies = [
  "bytes",
  "dns-sd",
  "env_logger",
+ "faster-hex",
  "form_urlencoded",
  "futures-core",
  "futures-util",
  "governor",
- "hex",
  "hmac",
  "http",
  "httparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,9 +51,9 @@ version = "0.5.0-dev"
 
 [dependencies]
 env_logger =  { version = "0.10", default-features = false, features = ["color", "humantime", "auto-color"] }
+faster-hex = "0.9"
 futures-util = { version = "0.3", default_features = false }
 getopts = "0.2"
-hex = "0.4"
 log = "0.4"
 rpassword = "7.0"
 sha1 = "0.10"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -19,11 +19,11 @@ base64 = "0.21"
 byteorder = "1.4"
 bytes = "1"
 dns-sd = { version = "0.1", optional = true }
+faster-hex = "0.9"
 form_urlencoded = "1.0"
 futures-core = "0.3"
 futures-util = { version = "0.3", features = ["alloc", "bilock", "sink", "unstable"] }
 governor = { version = "0.6", default-features = false, features = ["std", "jitter"] }
-hex = "0.4"
 hmac = "0.12"
 httparse = "1.7"
 http = "0.2"

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -6,6 +6,7 @@ use std::{
 
 use byteorder::{BigEndian, ByteOrder};
 use bytes::Bytes;
+use faster_hex::{hex_decode, hex_string_upper};
 use futures_util::future::IntoStream;
 use http::header::HeaderValue;
 use hyper::{
@@ -279,20 +280,23 @@ impl SpClient {
                         let hash_cash_challenge = challenge.evaluate_hashcash_parameters();
 
                         let ctx = vec![];
-                        let prefix = hex::decode(&hash_cash_challenge.prefix).map_err(|e| {
-                            Error::failed_precondition(format!(
+                        let mut prefix = Vec::with_capacity(hash_cash_challenge.prefix.len() / 2);
+                        if let Err(e) =
+                            hex_decode(hash_cash_challenge.prefix.as_bytes(), &mut prefix)
+                        {
+                            return Err(Error::failed_precondition(format!(
                                 "Unable to decode hash cash challenge: {e}"
-                            ))
-                        })?;
+                            )));
+                        }
                         let length = hash_cash_challenge.length;
 
-                        let mut suffix = vec![0; 0x10];
+                        let mut suffix = [0u8; 0x10];
                         let answer = Self::solve_hash_cash(&ctx, &prefix, length, &mut suffix);
 
                         match answer {
                             Ok(_) => {
                                 // the suffix must be in uppercase
-                                let suffix = hex::encode(suffix).to_uppercase();
+                                let suffix = hex_string_upper(&suffix);
 
                                 let mut answer_message = ClientTokenRequest::new();
                                 answer_message.request_type =
@@ -302,7 +306,7 @@ impl SpClient {
                                 let challenge_answers = answer_message.mut_challenge_answers();
 
                                 let mut challenge_answer = ChallengeAnswer::new();
-                                challenge_answer.mut_hash_cash().suffix = suffix.to_string();
+                                challenge_answer.mut_hash_cash().suffix = suffix;
                                 challenge_answer.ChallengeType =
                                     ChallengeType::CHALLENGE_HASH_CASH.into();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use faster_hex::hex_string;
 use futures_util::StreamExt;
 use log::{debug, error, info, trace, warn};
 use sha1::{Digest, Sha1};
@@ -39,7 +40,7 @@ mod player_event_handler;
 use player_event_handler::{run_program_on_sink_events, EventHandler};
 
 fn device_id(name: &str) -> String {
-    hex::encode(Sha1::digest(name.as_bytes()))
+    hex_string(&Sha1::digest(name.as_bytes()))
 }
 
 fn usage(program: &str, opts: &getopts::Options) -> String {


### PR DESCRIPTION
Hi, long time listener, first time caller...

I'm doing some work on the `spotify_id` module for another project including replacing the bespoke hex encode/decode there with a library call and I started using `hex` because it is a dependency of both `librespot` and `librespot-core` already... but `hex` doesn't appear to be maintained and it lacks really obvious stuff like symmetry between its traits and its functions and major performance issues (that we admittedly don't really care about here, yet).

Anyway, looking around `crates.io`, I came across `faster-hex` which is still far from perfect but the maintainers seem active and likely responsive. So I patched `librespot` and `librespot-core` to use it instead.

Unfortunately, I couldn't work out how to test the hashcash challenge. I tried changing my `OS` but that either crashes (for `"android"`) or fails with 400 (for `"ios"`). I included the improved logging I added to try to understand these issues.

If you could review the changes and let me know how to test the hashcash challenge (or test it yourself or confirm that LGTY), I would be grateful. I will be sending along my `spotify_id` refactoring changeset soon.

Thanks!