### PR TITLE
Cargo replace hex with data-encoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,9 +389,9 @@ checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e66c9d817f1720209181c316d28635c050fa304f9c79e47a520882661b7308"
+checksum = "7e962a19be5cfc3f3bf6dd8f61eb50107f356ad6270fbb3ed41476571db78be5"
 
 [[package]]
 name = "der"
@@ -1331,10 +1331,10 @@ dependencies = [
 name = "librespot"
 version = "0.5.0-dev"
 dependencies = [
+ "data-encoding",
  "env_logger",
  "futures-util",
  "getopts",
- "hex",
  "librespot-audio",
  "librespot-connect",
  "librespot-core",
@@ -1398,13 +1398,13 @@ dependencies = [
  "base64 0.21.5",
  "byteorder",
  "bytes",
+ "data-encoding",
  "dns-sd",
  "env_logger",
  "form_urlencoded",
  "futures-core",
  "futures-util",
  "governor",
- "hex",
  "hmac",
  "http",
  "httparse",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,10 +50,10 @@ path = "protocol"
 version = "0.5.0-dev"
 
 [dependencies]
+data-encoding = "2.5"
 env_logger =  { version = "0.10", default-features = false, features = ["color", "humantime", "auto-color"] }
 futures-util = { version = "0.3", default_features = false }
 getopts = "0.2"
-hex = "0.4"
 log = "0.4"
 rpassword = "7.0"
 sha1 = "0.10"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -23,7 +23,6 @@ form_urlencoded = "1.0"
 futures-core = "0.3"
 futures-util = { version = "0.3", features = ["alloc", "bilock", "sink", "unstable"] }
 governor = { version = "0.6", default-features = false, features = ["std", "jitter"] }
-hex = "0.4"
 hmac = "0.12"
 httparse = "1.7"
 http = "0.2"
@@ -57,6 +56,7 @@ tokio-tungstenite = { version = "*", default-features = false, features = ["rust
 tokio-util = { version = "0.7", features = ["codec"] }
 url = "2"
 uuid = { version = "1", default-features = false, features = ["fast-rng", "v4"] }
+data-encoding = "2.5"
 
 [build-dependencies]
 rand = "0.8"

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -16,17 +16,17 @@ pub struct SessionConfig {
     pub autoplay: Option<bool>,
 }
 
-impl Default for SessionConfig {
-    fn default() -> SessionConfig {
+impl SessionConfig {
+    pub(crate) fn default_for_os(os: &str) -> Self {
         let device_id = uuid::Uuid::new_v4().as_hyphenated().to_string();
-        let client_id = match std::env::consts::OS {
+        let client_id = match os {
             "android" => ANDROID_CLIENT_ID,
             "ios" => IOS_CLIENT_ID,
             _ => KEYMASTER_CLIENT_ID,
         }
         .to_owned();
 
-        SessionConfig {
+        Self {
             client_id,
             device_id,
             proxy: None,
@@ -34,6 +34,12 @@ impl Default for SessionConfig {
             tmp_dir: std::env::temp_dir(),
             autoplay: None,
         }
+    }
+}
+
+impl Default for SessionConfig {
+    fn default() -> Self {
+        Self::default_for_os(std::env::consts::OS)
     }
 }
 

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -190,9 +190,10 @@ impl SpClient {
         // on macOS and Windows. On Android and iOS we can send a platform-specific client ID and are
         // then presented with a hash cash challenge. On Linux, we have to pass the old keymaster ID.
         // We delegate most of this logic to `SessionConfig`.
-        let client_id = match OS {
+        let os = OS;
+        let client_id = match os {
             "macos" | "windows" => self.session().client_id(),
-            _ => SessionConfig::default().client_id,
+            os => SessionConfig::default_for_os(os).client_id,
         };
         client_data.client_id = client_id;
 
@@ -207,7 +208,7 @@ impl SpClient {
         let os_version = sys.os_version().unwrap_or_else(|| String::from("0"));
         let kernel_version = sys.kernel_version().unwrap_or_else(|| String::from("0"));
 
-        match OS {
+        match os {
             "windows" => {
                 let os_version = os_version.parse::<f32>().unwrap_or(10.) as i32;
                 let kernel_version = kernel_version.parse::<i32>().unwrap_or(21370);

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -270,7 +270,10 @@ impl SpClient {
             match ClientTokenResponseType::from_i32(message.response_type.value()) {
                 // depending on the platform, you're either given a token immediately
                 // or are presented a hash cash challenge to solve first
-                Some(ClientTokenResponseType::RESPONSE_GRANTED_TOKEN_RESPONSE) => break message,
+                Some(ClientTokenResponseType::RESPONSE_GRANTED_TOKEN_RESPONSE) => {
+                    debug!("Received a granted token");
+                    break message;
+                }
                 Some(ClientTokenResponseType::RESPONSE_CHALLENGES_RESPONSE) => {
                     debug!("Received a hash cash challenge, solving...");
 
@@ -480,11 +483,14 @@ impl SpClient {
                 HeaderValue::from_str(&format!("{} {}", token.token_type, token.access_token,))?,
             );
 
-            if let Ok(client_token) = self.client_token().await {
-                headers_mut.insert(CLIENT_TOKEN, HeaderValue::from_str(&client_token)?);
-            } else {
-                // currently these endpoints seem to work fine without it
-                warn!("Unable to get client token. Trying to continue without...");
+            match self.client_token().await {
+                Ok(client_token) => {
+                    let _ = headers_mut.insert(CLIENT_TOKEN, HeaderValue::from_str(&client_token)?);
+                }
+                Err(e) => {
+                    // currently these endpoints seem to work fine without it
+                    warn!("Unable to get client token: {e} Trying to continue without...")
+                }
             }
 
             last_response = self.session().http_client().request_body(request).await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+use data_encoding::HEXLOWER;
 use futures_util::StreamExt;
 use log::{debug, error, info, trace, warn};
 use sha1::{Digest, Sha1};
@@ -39,7 +40,7 @@ mod player_event_handler;
 use player_event_handler::{run_program_on_sink_events, EventHandler};
 
 fn device_id(name: &str) -> String {
-    hex::encode(Sha1::digest(name.as_bytes()))
+    HEXLOWER.encode(&Sha1::digest(name.as_bytes()))
 }
 
 fn usage(program: &str, opts: &getopts::Options) -> String {


### PR DESCRIPTION
Ok, let's try #1227 again but now with more feeling...

`data-encoding` was already a transitive dependency of tungstenite so this changeset strictly reduces the dep set of the project.

I've also added some improved logging and made it easier to spoof the OS type by moving the side effect to a single line in `spclient` and parameterizing the use sites.

I tested the hashcash challenge with `"ios"` and found I could stream music (but there were other complaints about 502 responses to some requests and sometimes my decrepit machine was too slow to solve the challenge).