### PR TITLE
Make audio fetch parameters tunable

### DIFF
--- a/audio/src/lib.rs
+++ b/audio/src/lib.rs
@@ -7,5 +7,4 @@ mod fetch;
 mod range_set;
 
 pub use decrypt::AudioDecrypt;
-pub use fetch::{AudioFile, AudioFileError, StreamLoaderController};
-pub use fetch::{MINIMUM_DOWNLOAD_SIZE, READ_AHEAD_BEFORE_PLAYBACK, READ_AHEAD_DURING_PLAYBACK};
+pub use fetch::{AudioFetchParams, AudioFile, AudioFileError, StreamLoaderController};

--- a/playback/src/decoder/symphonia_decoder.rs
+++ b/playback/src/decoder/symphonia_decoder.rs
@@ -36,7 +36,7 @@ impl SymphoniaDecoder {
         R: MediaSource + 'static,
     {
         let mss_opts = MediaSourceStreamOptions {
-            buffer_len: librespot_audio::MINIMUM_DOWNLOAD_SIZE,
+            buffer_len: librespot_audio::AudioFetchParams::get().minimum_download_size,
         };
         let mss = MediaSourceStream::new(Box::new(input), mss_opts);
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -24,10 +24,7 @@ use symphonia::core::io::MediaSource;
 use tokio::sync::{mpsc, oneshot};
 
 use crate::{
-    audio::{
-        AudioDecrypt, AudioFile, StreamLoaderController, READ_AHEAD_BEFORE_PLAYBACK,
-        READ_AHEAD_DURING_PLAYBACK,
-    },
+    audio::{AudioDecrypt, AudioFetchParams, AudioFile, StreamLoaderController},
     audio_backend::Sink,
     config::{Bitrate, NormalisationMethod, NormalisationType, PlayerConfig},
     convert::Converter,
@@ -2223,13 +2220,14 @@ impl PlayerInternal {
             ..
         } = self.state
         {
+            let read_ahead_during_playback = AudioFetchParams::get().read_ahead_during_playback;
             // Request our read ahead range
             let request_data_length =
-                (READ_AHEAD_DURING_PLAYBACK.as_secs_f32() * bytes_per_second as f32) as usize;
+                (read_ahead_during_playback.as_secs_f32() * bytes_per_second as f32) as usize;
 
             // Request the part we want to wait for blocking. This effectively means we wait for the previous request to partially complete.
             let wait_for_data_length =
-                (READ_AHEAD_BEFORE_PLAYBACK.as_secs_f32() * bytes_per_second as f32) as usize;
+                (read_ahead_during_playback.as_secs_f32() * bytes_per_second as f32) as usize;
 
             stream_loader_controller
                 .fetch_next_and_wait(request_data_length, wait_for_data_length)


### PR DESCRIPTION
This change collects all those audio fetch parameters that were defined as static constants into a dedicated struct, AudioFetchParams. This struct can be read and set statically, allowing a user of the library to modify those parameters without the need to recompile.