### PR TITLE
Recognise OpenBSD as such

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ cargo build --release
 
 # Packages
 
-librespot is also available via official package system on various operating systems such as Linux, FreeBSD, NetBSD. [Repology](https://repology.org/project/librespot/versions) offers a good overview.
+librespot is also available via official package system on various operating systems such as Linux, FreeBSD, NetBSD, OpenBSD. [Repology](https://repology.org/project/librespot/versions) offers a good overview.
 
 [![Packaging status](https://repology.org/badge/vertical-allrepos/librespot.svg)](https://repology.org/project/librespot/versions)
 

--- a/core/src/connection/handshake.rs
+++ b/core/src/connection/handshake.rs
@@ -112,9 +112,13 @@ where
 
     let platform = match std::env::consts::OS {
         "android" => Platform::PLATFORM_ANDROID_ARM,
-        "freebsd" | "netbsd" | "openbsd" => match ARCH {
+        "freebsd" | "netbsd" => match ARCH {
             "x86_64" => Platform::PLATFORM_FREEBSD_X86_64,
             _ => Platform::PLATFORM_FREEBSD_X86,
+        },
+        "openbsd" => match ARCH {
+            "aarch64" => Platform::PLATFORM_OPENBSD_ARM64,
+            _ => Platform::PLATFORM_OPENBSD_X86_64,
         },
         "ios" => match ARCH {
             "aarch64" => Platform::PLATFORM_IPHONE_ARM64,

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -90,7 +90,8 @@ pub async fn authenticate(
 
     let os = match std::env::consts::OS {
         "android" => Os::OS_ANDROID,
-        "freebsd" | "netbsd" | "openbsd" => Os::OS_FREEBSD,
+        "freebsd" | "netbsd" => Os::OS_FREEBSD,
+        "opensbd" => Os::OS_OPENBSD,
         "ios" => Os::OS_IPHONE,
         "linux" => Os::OS_LINUX,
         "macos" => Os::OS_OSX,

--- a/protocol/proto/authentication.proto
+++ b/protocol/proto/authentication.proto
@@ -115,6 +115,7 @@ enum Os {
     OS_MEEGO = 0x14;
     OS_QNXNTO = 0x15;
     OS_BCO = 0x16;
+    OS_OPENBSD = 0x17;
 }
 
 message LibspotifyAppKey {

--- a/protocol/proto/keyexchange.proto
+++ b/protocol/proto/keyexchange.proto
@@ -74,6 +74,8 @@ enum Platform {
     PLATFORM_GENERIC_PARTNER = 0x26;
     PLATFORM_WIN32_X86_64 = 0x27;
     PLATFORM_WATCHOS = 0x28;
+    PLATFORM_OPENBSD_X86_64 = 0x29;
+    PLATFORM_OPENBSD_ARM64 = 0x2a;
 }
 
 enum Fingerprint {


### PR DESCRIPTION
librespot and consumers like spotifyd work fine on at least OpenBSD/amd64 7.4-current;  arm64 builds and should work equally well. Other platforms also have binary packages, but are either hard to get by and/or unlikely to be used at this point (with librespot), so stick with most prominent amd64/x86_64 and arm64/aarch64 to keep it simple.