### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,29 @@
+# syntax=docker/dockerfile:1
+ARG debian_version=slim-bookworm
+ARG rust_version=1.70.0
+FROM rust:${rust_version}-${debian_version}
+
+ARG DEBIAN_FRONTEND=noninteractive
+ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        git \
+        nano\
+        openssh-server  \
+        # for rust-analyzer vscode plugin
+        pkg-config \
+        # developer dependencies
+        libunwind-dev \
+        libpulse-dev \
+        portaudio19-dev \
+        libasound2-dev \
+        libsdl2-dev \
+        gstreamer1.0-dev \
+        libgstreamer-plugins-base1.0-dev \
+        libavahi-compat-libdnssd-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN rustup component add rustfmt && \
+    rustup component add clippy && \
+    cargo install cargo-hack

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "Librespot Devcontainer",
+  "dockerFile": "Dockerfile",
+	// Use 'postCreateCommand' to run commands after the container is created.
+	//"postCreateCommand": "",
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {
+				"dev.containers.copyGitConfig": true
+			},
+			"extensions": [
+				"eamodio.gitlens",
+        		"github.vscode-github-actions",
+				"rust-lang.rust-analyzer"
+			]
+		}
+	},
+  "containerEnv": {
+    "GIT_EDITOR": "nano"
+  }
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+ }


### PR DESCRIPTION
This adds a devcontainer for easier development (e.g. in vscode) using the current MSRV 1.70.0. It's based on the official rust image.