### PR TITLE
fix: change spotify version needed in clientoken to use semantic format

### DIFF
--- a/core/src/version.rs
+++ b/core/src/version.rs
@@ -19,6 +19,9 @@ pub const BUILD_ID: &str = env!("LIBRESPOT_BUILD_ID");
 /// The protocol version of the Spotify desktop client.
 pub const SPOTIFY_VERSION: u64 = 117300517;
 
+/// The semantic version of the Spotify desktop client.
+pub const SPOTIFY_SEMANTIC_VERSION: &str = "1.2.31.1205.g4d59ad7c";
+
 /// The protocol version of the Spotify mobile app.
 pub const SPOTIFY_MOBILE_VERSION: &str = "8.6.84";
 
@@ -28,6 +31,6 @@ pub const FALLBACK_USER_AGENT: &str = "Spotify/117300517 Linux/0 (librespot)";
 pub fn spotify_version() -> String {
     match std::env::consts::OS {
         "android" | "ios" => SPOTIFY_MOBILE_VERSION.to_owned(),
-        _ => SPOTIFY_VERSION.to_string(),
+        _ => SPOTIFY_SEMANTIC_VERSION.to_string(),
     }
 }


### PR DESCRIPTION
Fixes #1261 