### PR TITLE
Fix clippy warnings

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     future::Future,
     pin::Pin,
     sync::atomic::{AtomicUsize, Ordering},
@@ -9,7 +8,7 @@ use std::{
 
 use futures_util::{stream::FusedStream, FutureExt, StreamExt};
 
-use protobuf::{self, Message};
+use protobuf::Message;
 use rand::prelude::SliceRandom;
 use thiserror::Error;
 use tokio::sync::mpsc;

--- a/core/src/cdn_url.rs
+++ b/core/src/cdn_url.rs
@@ -1,7 +1,4 @@
-use std::{
-    convert::TryFrom,
-    ops::{Deref, DerefMut},
-};
+use std::ops::{Deref, DerefMut};
 
 use protobuf::Message;
 use thiserror::Error;

--- a/core/src/connection/handshake.rs
+++ b/core/src/connection/handshake.rs
@@ -2,7 +2,7 @@ use std::{env::consts::ARCH, io};
 
 use byteorder::{BigEndian, ByteOrder, WriteBytesExt};
 use hmac::{Hmac, Mac};
-use protobuf::{self, Message};
+use protobuf::Message;
 use rand::{thread_rng, RngCore};
 use rsa::{BigUint, Pkcs1v15Sign, RsaPublicKey};
 use sha1::{Digest, Sha1};

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -7,7 +7,7 @@ use std::io;
 
 use futures_util::{SinkExt, StreamExt};
 use num_traits::FromPrimitive;
-use protobuf::{self, Message};
+use protobuf::Message;
 use thiserror::Error;
 use tokio::net::TcpStream;
 use tokio_util::codec::Framed;

--- a/core/src/date.rs
+++ b/core/src/date.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, fmt::Debug, ops::Deref};
+use std::{fmt::Debug, ops::Deref};
 
 use time::{
     error::ComponentRange, format_description::well_known::Iso8601, Date as _Date, OffsetDateTime,

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -513,13 +513,7 @@ impl Session {
     }
 
     pub fn get_user_attribute(&self, key: &str) -> Option<String> {
-        self.0
-            .data
-            .read()
-            .user_data
-            .attributes
-            .get(key)
-            .map(Clone::clone)
+        self.0.data.read().user_data.attributes.get(key).cloned()
     }
 
     fn weak(&self) -> SessionWeak {

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -1,8 +1,4 @@
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt,
-    ops::Deref,
-};
+use std::{fmt, ops::Deref};
 
 use thiserror::Error;
 

--- a/metadata/src/album.rs
+++ b/metadata/src/album.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::{TryFrom, TryInto},
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/artist.rs
+++ b/metadata/src/artist.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::{TryFrom, TryInto},
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/availability.rs
+++ b/metadata/src/availability.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/episode.rs
+++ b/metadata/src/episode.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::{TryFrom, TryInto},
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/image.rs
+++ b/metadata/src/image.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::{TryFrom, TryInto},
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/playlist/annotation.rs
+++ b/metadata/src/playlist/annotation.rs
@@ -1,4 +1,3 @@
-use std::convert::TryFrom;
 use std::fmt::Debug;
 
 use protobuf::Message;

--- a/metadata/src/playlist/attribute.rs
+++ b/metadata/src/playlist/attribute.rs
@@ -1,6 +1,5 @@
 use std::{
     collections::HashMap,
-    convert::TryFrom,
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/playlist/diff.rs
+++ b/metadata/src/playlist/diff.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, fmt::Debug};
+use std::fmt::Debug;
 
 use super::operation::PlaylistOperations;
 

--- a/metadata/src/playlist/item.rs
+++ b/metadata/src/playlist/item.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::{TryFrom, TryInto},
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/playlist/list.rs
+++ b/metadata/src/playlist/list.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::{TryFrom, TryInto},
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/playlist/operation.rs
+++ b/metadata/src/playlist/operation.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/sale_period.rs
+++ b/metadata/src/sale_period.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::TryFrom,
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/metadata/src/show.rs
+++ b/metadata/src/show.rs
@@ -1,7 +1,4 @@
-use std::{
-    convert::{TryFrom, TryInto},
-    fmt::Debug,
-};
+use std::fmt::Debug;
 
 use crate::{
     availability::Availabilities, copyright::Copyrights, episode::Episodes, image::Images,

--- a/metadata/src/track.rs
+++ b/metadata/src/track.rs
@@ -1,5 +1,4 @@
 use std::{
-    convert::{TryFrom, TryInto},
     fmt::Debug,
     ops::{Deref, DerefMut},
 };

--- a/playback/src/audio_backend/pipe.rs
+++ b/playback/src/audio_backend/pipe.rs
@@ -66,6 +66,7 @@ impl Sink for StdoutSink {
                     OpenOptions::new()
                         .write(true)
                         .create(true)
+                        .truncate(true)
                         .open(file)
                         .map_err(|e| StdoutError::OpenFailure {
                             file: file.to_string(),


### PR DESCRIPTION
Fixes a clippy warning that occured in [recent tests](https://github.com/librespot-org/librespot/actions/runs/8401256234/job/23275718451?pr=1269) regarding `map_clone` (https://rust-lang.github.io/rust-clippy/master/index.html#/map_clone) and file creation without explicite defining truncation behavior (https://rust-lang.github.io/rust-clippy/master/index.html#/suspicious_open_options)
