### PR TITLE
Fix/clippy

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,9 @@ FROM rust:${rust_version}-${debian_version}
 
 ARG DEBIAN_FRONTEND=noninteractive
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
+ENV RUST_BACKTRACE=1
+ENV RUSTFLAGS=-Dwarnings
+
 
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot"
 version = "0.5.0-dev"
-rust-version = "1.61"
+rust-version = "1.71"
 authors = ["Librespot Org"]
 license = "MIT"
 description = "An open source client library for Spotify, with support for Spotify Connect"

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-audio"
 version = "0.5.0-dev"
-rust-version = "1.61"
+rust-version = "1.71"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The audio fetching logic for librespot"
 license = "MIT"

--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-connect"
 version = "0.5.0-dev"
-rust-version = "1.61"
+rust-version = "1.71"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The discovery and Spotify Connect logic for librespot"
 license = "MIT"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-core"
 version = "0.5.0-dev"
-rust-version = "1.61"
+rust-version = "1.71"
 authors = ["Paul Lietar <paul@lietar.net>"]
 build = "build.rs"
 description = "The core functionality provided by librespot"

--- a/core/src/config.rs
+++ b/core/src/config.rs
@@ -43,12 +43,13 @@ impl Default for SessionConfig {
     }
 }
 
-#[derive(Clone, Copy, Debug, Hash, PartialOrd, Ord, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, Hash, PartialOrd, Ord, PartialEq, Eq, Default)]
 pub enum DeviceType {
     Unknown = 0,
     Computer = 1,
     Tablet = 2,
     Smartphone = 3,
+    #[default]
     Speaker = 4,
     Tv = 5,
     Avr = 6,
@@ -129,11 +130,5 @@ impl fmt::Display for DeviceType {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let str: &str = self.into();
         f.write_str(str)
-    }
-}
-
-impl Default for DeviceType {
-    fn default() -> DeviceType {
-        DeviceType::Speaker
     }
 }

--- a/core/src/mercury/types.rs
+++ b/core/src/mercury/types.rs
@@ -51,12 +51,13 @@ impl From<MercuryError> for Error {
 
 impl std::fmt::Display for MercuryMethod {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match *self {
-            MercuryMethod::Get => write!(f, "GET"),
-            MercuryMethod::Sub => write!(f, "SUB"),
-            MercuryMethod::Unsub => write!(f, "UNSUB"),
-            MercuryMethod::Send => write!(f, "SEND"),
-        }
+        let s = match *self {
+            MercuryMethod::Get => "GET",
+            MercuryMethod::Sub => "SUB",
+            MercuryMethod::Unsub => "UNSUB",
+            MercuryMethod::Send => "SEND",
+        };
+        write!(f, "{}", s)
     }
 }
 

--- a/core/src/mercury/types.rs
+++ b/core/src/mercury/types.rs
@@ -49,15 +49,14 @@ impl From<MercuryError> for Error {
     }
 }
 
-impl ToString for MercuryMethod {
-    fn to_string(&self) -> String {
+impl std::fmt::Display for MercuryMethod {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match *self {
-            MercuryMethod::Get => "GET",
-            MercuryMethod::Sub => "SUB",
-            MercuryMethod::Unsub => "UNSUB",
-            MercuryMethod::Send => "SEND",
+            MercuryMethod::Get => write!(f, "GET"),
+            MercuryMethod::Sub => write!(f, "SUB"),
+            MercuryMethod::Unsub => write!(f, "UNSUB"),
+            MercuryMethod::Send => write!(f, "SEND"),
         }
-        .to_owned()
     }
 }
 

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -358,7 +358,7 @@ impl Session {
                 loop {
                     match reader.read_event_into(&mut buf) {
                         Ok(Event::Start(ref element)) => {
-                            current_element = std::str::from_utf8(element)?.to_owned()
+                            std::str::from_utf8(element)?.clone_into(&mut current_element)
                         }
                         Ok(Event::End(_)) => {
                             current_element = String::new();
@@ -428,7 +428,7 @@ impl Session {
     }
 
     pub fn set_client_id(&self, client_id: &str) {
-        self.0.data.write().client_id = client_id.to_owned();
+        client_id.clone_into(&mut self.0.data.write().client_id);
     }
 
     pub fn client_name(&self) -> String {
@@ -436,7 +436,7 @@ impl Session {
     }
 
     pub fn set_client_name(&self, client_name: &str) {
-        self.0.data.write().client_name = client_name.to_owned();
+        client_name.clone_into(&mut self.0.data.write().client_name);
     }
 
     pub fn client_brand_name(&self) -> String {
@@ -444,7 +444,7 @@ impl Session {
     }
 
     pub fn set_client_brand_name(&self, client_brand_name: &str) {
-        self.0.data.write().client_brand_name = client_brand_name.to_owned();
+        client_brand_name.clone_into(&mut self.0.data.write().client_brand_name);
     }
 
     pub fn client_model_name(&self) -> String {
@@ -452,7 +452,7 @@ impl Session {
     }
 
     pub fn set_client_model_name(&self, client_model_name: &str) {
-        self.0.data.write().client_model_name = client_model_name.to_owned();
+        client_model_name.clone_into(&mut self.0.data.write().client_model_name);
     }
 
     pub fn connection_id(&self) -> String {
@@ -460,7 +460,7 @@ impl Session {
     }
 
     pub fn set_connection_id(&self, connection_id: &str) {
-        self.0.data.write().connection_id = connection_id.to_owned();
+        connection_id.clone_into(&mut self.0.data.write().connection_id);
     }
 
     pub fn username(&self) -> String {
@@ -468,7 +468,7 @@ impl Session {
     }
 
     pub fn set_username(&self, username: &str) {
-        self.0.data.write().user_data.canonical_username = username.to_owned();
+        username.clone_into(&mut self.0.data.write().user_data.canonical_username);
     }
 
     pub fn country(&self) -> String {

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -239,9 +239,9 @@ impl SpClient {
                 let android_data = platform_data.mut_android();
                 android_data.android_version = os_version;
                 android_data.api_version = 31;
-                android_data.device_name = "Pixel".to_owned();
-                android_data.model_str = "GF5KQ".to_owned();
-                android_data.vendor = "Google".to_owned();
+                "Pixel".clone_into(&mut android_data.device_name);
+                "GF5KQ".clone_into(&mut android_data.model_str);
+                "Google".clone_into(&mut android_data.vendor);
             }
             "macos" => {
                 let macos_data = platform_data.mut_desktop_macos();

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-discovery"
 version = "0.5.0-dev"
-rust-version = "1.61"
+rust-version = "1.71"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The discovery logic for librespot"
 license = "MIT"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-metadata"
 version = "0.5.0-dev"
-rust-version = "1.61"
+rust-version = "1.71"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The metadata logic for librespot"
 license = "MIT"

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-playback"
 version = "0.5.0-dev"
-rust-version = "1.61"
+rust-version = "1.71"
 authors = ["Sasha Hilton <sashahilton00@gmail.com>"]
 description = "The audio playback logic for librespot"
 license = "MIT"

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-protocol"
 version = "0.5.0-dev"
-rust-version = "1.61"
+rust-version = "1.71"
 authors = ["Paul Liétar <paul@lietar.net>"]
 build = "build.rs"
 description = "The protobuf logic for communicating with Spotify servers"


### PR DESCRIPTION
Fixes the clippy warning that occur with v1.78. being the new stable. This made the test fail (e.g [here](https://github.com/librespot-org/librespot/actions/runs/9043092501/job/24850355483)).
Addressed the following warnings:
- https://rust-lang.github.io/rust-clippy/master/index.html#/to_string_trait_impl
- https://rust-lang.github.io/rust-clippy/master/index.html#/assigning_clones
- https://rust-lang.github.io/rust-clippy/master/index.html#/incompatible_msrv
- https://rust-lang.github.io/rust-clippy/master/index.html#/derivable_impls

Sidenote: set the environment variables `RUST_BACKTRACE` and `RUSTFLAGS` in the devcontainer the same as they are in the github action workflow file.