### PR TITLE
Fix building Docker image for cross-compilation

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -17,6 +17,10 @@
 
 FROM debian:stretch
 
+RUN echo "deb http://archive.debian.org/debian stretch main"                   > /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian stretch-proposed-updates main" >> /etc/apt/sources.list
+RUN echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
+
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armhf
 RUN dpkg --add-architecture armel
@@ -26,7 +30,7 @@ RUN apt-get update
 RUN apt-get install -y curl git build-essential crossbuild-essential-arm64 crossbuild-essential-armel crossbuild-essential-armhf crossbuild-essential-mipsel pkg-config
 RUN apt-get install -y libasound2-dev libasound2-dev:arm64 libasound2-dev:armel libasound2-dev:armhf libasound2-dev:mipsel
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.71 -y
 ENV PATH="/root/.cargo/bin/:${PATH}"
 RUN rustup target add aarch64-unknown-linux-gnu
 RUN rustup target add arm-unknown-linux-gnueabi


### PR DESCRIPTION
Fix building Docker image for cross-compilation
* Debian **stretch** packages are now available only from **archive.debian.org**
* Use rust **1.71** - MIPS target demoted to tier 3 at **1.72**

With these changes I have been able to cross-compile the 0.4.2 release for my very old RaspberryPi 1.