### PR TITLE
Docker cross compile - remove MIPS target platform

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -2,7 +2,7 @@
 # Build the docker image from the root of the project with the following command :
 # $ docker build -t librespot-cross -f contrib/Dockerfile .
 #
-# The resulting image can be used to build librespot for linux x86_64, armhf, armel, mipsel, aarch64
+# The resulting image can be used to build librespot for linux x86_64, armhf, armel, aarch64
 # $ docker run -v /tmp/librespot-build:/build librespot-cross
 #
 # The compiled binaries will be located in /tmp/librespot-build
@@ -22,11 +22,10 @@ RUN echo "deb http://archive.debian.org/debian-security stretch/updates main" >>
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armhf
 RUN dpkg --add-architecture armel
-RUN dpkg --add-architecture mipsel
 RUN apt-get update
 
-RUN apt-get install -y curl git build-essential crossbuild-essential-arm64 crossbuild-essential-armel crossbuild-essential-armhf crossbuild-essential-mipsel pkg-config
-RUN apt-get install -y libasound2-dev libasound2-dev:arm64 libasound2-dev:armel libasound2-dev:armhf libasound2-dev:mipsel
+RUN apt-get install -y curl git build-essential crossbuild-essential-arm64 crossbuild-essential-armel crossbuild-essential-armhf pkg-config
+RUN apt-get install -y libasound2-dev libasound2-dev:arm64 libasound2-dev:armel libasound2-dev:armhf
 RUN apt-get install -y libpulse0 libpulse0:arm64 libpulse0:armel libpulse0:armhf
 
 RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.73 -y
@@ -34,13 +33,11 @@ ENV PATH="/root/.cargo/bin/:${PATH}"
 RUN rustup target add aarch64-unknown-linux-gnu
 RUN rustup target add arm-unknown-linux-gnueabi
 RUN rustup target add arm-unknown-linux-gnueabihf
-RUN rustup target add mipsel-unknown-linux-gnu
 
 RUN mkdir /.cargo && \
     echo '[target.aarch64-unknown-linux-gnu]\nlinker = "aarch64-linux-gnu-gcc"' > /.cargo/config && \
     echo '[target.arm-unknown-linux-gnueabihf]\nlinker = "arm-linux-gnueabihf-gcc"' >> /.cargo/config && \
-    echo '[target.arm-unknown-linux-gnueabi]\nlinker = "arm-linux-gnueabi-gcc"' >> /.cargo/config && \
-    echo '[target.mipsel-unknown-linux-gnu]\nlinker = "mipsel-linux-gnu-gcc"' >> /.cargo/config
+    echo '[target.arm-unknown-linux-gnueabi]\nlinker = "arm-linux-gnueabi-gcc"' >> /.cargo/config
 
 ENV CARGO_TARGET_DIR /build
 ENV CARGO_HOME /build/cache
@@ -48,7 +45,6 @@ ENV PKG_CONFIG_ALLOW_CROSS=1
 ENV PKG_CONFIG_PATH_aarch64-unknown-linux-gnu=/usr/lib/aarch64-linux-gnu/pkgconfig/
 ENV PKG_CONFIG_PATH_arm-unknown-linux-gnueabihf=/usr/lib/arm-linux-gnueabihf/pkgconfig/
 ENV PKG_CONFIG_PATH_arm-unknown-linux-gnueabi=/usr/lib/arm-linux-gnueabi/pkgconfig/
-ENV PKG_CONFIG_PATH_mipsel-unknown-linux-gnu=/usr/lib/mipsel-linux-gnu/pkgconfig/
 
 ADD . /src
 WORKDIR /src

--- a/contrib/docker-build.sh
+++ b/contrib/docker-build.sh
@@ -5,4 +5,3 @@ cargo build --release --no-default-features --features alsa-backend
 cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features alsa-backend
 cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features alsa-backend
 cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features alsa-backend
-cargo build --release --target mipsel-unknown-linux-gnu --no-default-features --features alsa-backend


### PR DESCRIPTION
Follow up to #1297 and #1298

Given that:

- MSRV was moved up to 1.73.
- Even with rust 1.71 the MIPS target did not build successfully.
- Apparently there is hardly any interest in maintaining the MIPS platform.
- Last but not least - the Docker image for cross-compilation did not build - since MIPS target was demoted to tier 3 at 1.72.

I propose to remove the **MIPS** architecture entirely from the Docker image for cross compilation.

After these changes, I was able to:

- Build the Docker image.
- Cross compile for all remaining platforms.
- Verify that **x86_64** and **aarch64** binaries work fine on Ubuntu 22.04 (regular PC) and Raspberry PI OS (64-bit/bookworm/Raspberry Pi 3) respectively.