### PR TITLE
Expose service to both IPv4 and IPv6

### DIFF
--- a/discovery/src/server.rs
+++ b/discovery/src/server.rs
@@ -2,10 +2,11 @@ use std::{
     borrow::Cow,
     collections::BTreeMap,
     convert::Infallible,
-    net::{Ipv4Addr, SocketAddr, TcpListener},
+    net::{IpAddr, SocketAddr, TcpListener},
     pin::Pin,
     sync::Arc,
     task::{Context, Poll},
+    str::FromStr
 };
 
 use aes::cipher::{KeyIvInit, StreamCipher};
@@ -251,7 +252,7 @@ pub struct DiscoveryServer {
 impl DiscoveryServer {
     pub fn new(config: Config, port: &mut u16) -> Result<Self, Error> {
         let (discovery, cred_rx) = RequestHandler::new(config);
-        let address = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), *port);
+        let address = SocketAddr::new(IpAddr::from_str("::0").unwrap(), *port);
 
         let (close_tx, close_rx) = oneshot::channel();
 

--- a/discovery/src/server.rs
+++ b/discovery/src/server.rs
@@ -4,9 +4,9 @@ use std::{
     convert::Infallible,
     net::{IpAddr, SocketAddr, TcpListener},
     pin::Pin,
+    str::FromStr,
     sync::Arc,
     task::{Context, Poll},
-    str::FromStr
 };
 
 use aes::cipher::{KeyIvInit, StreamCipher};


### PR DESCRIPTION
Change to listen to [::0] given this will make the application listen on both ipv4 and ipv6. This is useful to enable support for ipv6 only networks. 
Given most users will be on v4 only or dual stacked networks it is of course important to make sure that works, in my testing i have not found any case where this change created a problem for those devices.
