### PR TITLE
Credentials with access token (oauth)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,8 @@ https://github.com/librespot-org/librespot
 - [core] Cache resolved access points during runtime (breaking)
 - [core] `FileId` is moved out of `SpotifyId`. For now it will be re-exported.
 - [core] Report actual platform data on login
+- [core] Support `Session` authentication with a Spotify access token
+- [core] `Credentials.username` is now an `Option` (breaking) 
 - [main] `autoplay {on|off}` now acts as an override. If unspecified, `librespot`
   now follows the setting in the Connect client that controls it. (breaking)
 - [metadata] Most metadata is now retrieved with the `spclient` (breaking)
@@ -95,6 +97,7 @@ https://github.com/librespot-org/librespot
 - [main] Add an event worker thread that runs async to the main thread(s) but
   sync to itself to prevent potential data races for event consumers
 - [metadata] All metadata fields in the protobufs are now exposed (breaking)
+- [oauth] Standalone module to obtain Spotify access token using OAuth authorization code flow.
 - [playback] Explicit tracks are skipped if the controlling Connect client has
   disabled such content. Applications that use librespot as a library without
   Connect should use the 'filter-explicit-content' user attribute in the session.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ version = "0.5.0-dev"
 path = "protocol"
 version = "0.5.0-dev"
 
+[dependencies.librespot-oauth]
+path = "oauth"
+version = "0.5.0-dev"
+
 [dependencies]
 data-encoding = "2.5"
 env_logger =  { version = "0.11.2", default-features = false, features = ["color", "humantime", "auto-color"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -9,6 +9,10 @@ license = "MIT"
 repository = "https://github.com/librespot-org/librespot"
 edition = "2021"
 
+[dependencies.librespot-oauth]
+path = "../oauth"
+version = "0.5.0-dev"
+
 [dependencies.librespot-protocol]
 path = "../protocol"
 version = "0.5.0-dev"

--- a/core/src/authentication.rs
+++ b/core/src/authentication.rs
@@ -50,11 +50,19 @@ impl Credentials {
     ///
     /// let creds = Credentials::with_password("my account", "my password");
     /// ```
-    pub fn with_password(username: impl Into<String>, password: impl Into<String>) -> Credentials {
-        Credentials {
+    pub fn with_password(username: impl Into<String>, password: impl Into<String>) -> Self {
+        Self {
             username: username.into(),
             auth_type: AuthenticationType::AUTHENTICATION_USER_PASS,
             auth_data: password.into().into_bytes(),
+        }
+    }
+
+    pub fn with_access_token(username: impl Into<String>, token: impl Into<String>) -> Self {
+        Self {
+            username: username.into(),
+            auth_type: AuthenticationType::AUTHENTICATION_SPOTIFY_TOKEN,
+            auth_data: token.into().into_bytes(),
         }
     }
 
@@ -62,7 +70,7 @@ impl Credentials {
         username: impl Into<String>,
         encrypted_blob: impl AsRef<[u8]>,
         device_id: impl AsRef<[u8]>,
-    ) -> Result<Credentials, Error> {
+    ) -> Result<Self, Error> {
         fn read_u8<R: Read>(stream: &mut R) -> io::Result<u8> {
             let mut data = [0u8];
             stream.read_exact(&mut data)?;
@@ -136,7 +144,7 @@ impl Credentials {
         read_u8(&mut cursor)?;
         let auth_data = read_bytes(&mut cursor)?;
 
-        Ok(Credentials {
+        Ok(Self {
             username,
             auth_type,
             auth_data,

--- a/core/src/authentication.rs
+++ b/core/src/authentication.rs
@@ -29,7 +29,7 @@ impl From<AuthenticationError> for Error {
 /// The credentials are used to log into the Spotify API.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
 pub struct Credentials {
-    pub username: String,
+    pub username: Option<String>,
 
     #[serde(serialize_with = "serialize_protobuf_enum")]
     #[serde(deserialize_with = "deserialize_protobuf_enum")]
@@ -52,15 +52,15 @@ impl Credentials {
     /// ```
     pub fn with_password(username: impl Into<String>, password: impl Into<String>) -> Self {
         Self {
-            username: username.into(),
+            username: Some(username.into()),
             auth_type: AuthenticationType::AUTHENTICATION_USER_PASS,
             auth_data: password.into().into_bytes(),
         }
     }
 
-    pub fn with_access_token(username: impl Into<String>, token: impl Into<String>) -> Self {
+    pub fn with_access_token(token: impl Into<String>) -> Self {
         Self {
-            username: username.into(),
+            username: None,
             auth_type: AuthenticationType::AUTHENTICATION_SPOTIFY_TOKEN,
             auth_data: token.into().into_bytes(),
         }
@@ -145,7 +145,7 @@ impl Credentials {
         let auth_data = read_bytes(&mut cursor)?;
 
         Ok(Self {
-            username,
+            username: Some(username),
             auth_type,
             auth_data,
         })

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -133,6 +133,7 @@ pub async fn authenticate(
     let cmd = PacketType::Login;
     let data = packet.write_to_bytes()?;
 
+    debug!("Authenticating with AP using {:?}", credentials.auth_type);
     transport.send((cmd as u8, data)).await?;
     let (cmd, data) = transport
         .next()

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -99,10 +99,12 @@ pub async fn authenticate(
     };
 
     let mut packet = ClientResponseEncrypted::new();
-    packet
-        .login_credentials
-        .mut_or_insert_default()
-        .set_username(credentials.username);
+    if let Some(username) = credentials.username {
+        packet
+            .login_credentials
+            .mut_or_insert_default()
+            .set_username(username);
+    }
     packet
         .login_credentials
         .mut_or_insert_default()
@@ -145,7 +147,7 @@ pub async fn authenticate(
             let welcome_data = APWelcome::parse_from_bytes(data.as_ref())?;
 
             let reusable_credentials = Credentials {
-                username: welcome_data.canonical_username().to_owned(),
+                username: Some(welcome_data.canonical_username().to_owned()),
                 auth_type: welcome_data.reusable_auth_credentials_type(),
                 auth_data: welcome_data.reusable_auth_credentials().to_owned(),
             };

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -172,8 +172,12 @@ impl Session {
             }
         };
 
-        info!("Authenticated as \"{}\" !", reusable_credentials.username);
-        self.set_username(&reusable_credentials.username);
+        let username = reusable_credentials
+            .username
+            .as_ref()
+            .map_or("UNKNOWN", |s| s.as_str());
+        info!("Authenticated as '{username}' !");
+        self.set_username(username);
         if let Some(cache) = self.cache() {
             if store_credentials {
                 let cred_changed = cache

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -77,6 +77,7 @@ struct SessionData {
     client_brand_name: String,
     client_model_name: String,
     connection_id: String,
+    auth_data: Vec<u8>,
     time_delta: i64,
     invalid: bool,
     user_data: UserData,
@@ -178,6 +179,7 @@ impl Session {
             .map_or("UNKNOWN", |s| s.as_str());
         info!("Authenticated as '{username}' !");
         self.set_username(username);
+        self.set_auth_data(&reusable_credentials.auth_data);
         if let Some(cache) = self.cache() {
             if store_credentials {
                 let cred_changed = cache
@@ -473,6 +475,14 @@ impl Session {
 
     pub fn set_username(&self, username: &str) {
         username.clone_into(&mut self.0.data.write().user_data.canonical_username);
+    }
+
+    pub fn auth_data(&self) -> Vec<u8> {
+        self.0.data.read().auth_data.clone()
+    }
+
+    pub fn set_auth_data(&self, auth_data: &[u8]) {
+        self.0.data.write().auth_data = auth_data.to_owned();
     }
 
     pub fn country(&self) -> String {

--- a/examples/get_token.rs
+++ b/examples/get_token.rs
@@ -36,7 +36,7 @@ async fn main() {
 
     // Now create a new session with that token.
     let session = Session::new(session_config, None);
-    let credentials = Credentials::with_access_token(username, token.access_token);
+    let credentials = Credentials::with_access_token(token.access_token);
     println!("Connecting with token..");
     match session.connect(credentials, false).await {
         Ok(()) => println!("Session username: {:#?}", session.username()),

--- a/examples/get_token.rs
+++ b/examples/get_token.rs
@@ -7,23 +7,39 @@ const SCOPES: &str =
 
 #[tokio::main]
 async fn main() {
-    let session_config = SessionConfig::default();
+    let mut session_config = SessionConfig::default();
 
     let args: Vec<_> = env::args().collect();
-    if args.len() != 3 {
-        eprintln!("Usage: {} USERNAME PASSWORD", args[0]);
+    if args.len() == 4 {
+        session_config.client_id = args[3].clone()
+    } else if args.len() != 3 {
+        eprintln!("Usage: {} USERNAME PASSWORD [CLIENT_ID]", args[0]);
         return;
     }
+    let username = &args[1];
+    let password = &args[2];
 
-    println!("Connecting...");
-    let credentials = Credentials::with_password(&args[1], &args[2]);
-    let session = Session::new(session_config, None);
-
-    match session.connect(credentials, false).await {
-        Ok(()) => println!(
-            "Token: {:#?}",
+    let session = Session::new(session_config.clone(), None);
+    let credentials = Credentials::with_password(username, password);
+    println!("Connecting with password..");
+    let token = match session.connect(credentials, false).await {
+        Ok(()) => {
+            println!("Session username: {:#?}", session.username());
             session.token_provider().get_token(SCOPES).await.unwrap()
-        ),
+        }
+        Err(e) => {
+            println!("Error connecting: {}", e);
+            return;
+        }
+    };
+    println!("Token: {:#?}", token);
+
+    // Now create a new session with that token.
+    let session = Session::new(session_config, None);
+    let credentials = Credentials::with_access_token(username, token.access_token);
+    println!("Connecting with token..");
+    match session.connect(credentials, false).await {
+        Ok(()) => println!("Session username: {:#?}", session.username()),
         Err(e) => println!("Error connecting: {}", e),
     }
 }

--- a/examples/get_token.rs
+++ b/examples/get_token.rs
@@ -1,17 +1,21 @@
 use std::env;
 
 use librespot::core::{authentication::Credentials, config::SessionConfig, session::Session};
-use librespot::protocol::authentication::AuthenticationType;
 
 const SCOPES: &str =
     "streaming,user-read-playback-state,user-modify-playback-state,user-read-currently-playing";
 
 #[tokio::main]
 async fn main() {
+    let mut builder = env_logger::Builder::new();
+    builder.parse_filters("librespot=trace");
+    builder.init();
+
     let mut session_config = SessionConfig::default();
 
     let args: Vec<_> = env::args().collect();
     if args.len() == 3 {
+        // Only special client IDs have sufficient privileges e.g. Spotify's.
         session_config.client_id = args[2].clone()
     } else if args.len() != 2 {
         eprintln!("Usage: {} ACCESS_TOKEN [CLIENT_ID]", args[0]);
@@ -31,23 +35,6 @@ async fn main() {
         }
     };
 
-    // This will fail. You can't use keymaster from an access token authed session.
-    // let token = session.token_provider().get_token(SCOPES).await.unwrap();
-
-    // Instead, derive stored credentials and auth a new session using those.
-    let stored_credentials = Credentials {
-        username: Some(session.username()),
-        auth_type: AuthenticationType::AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS,
-        auth_data: session.auth_data(),
-    };
-    let session2 = Session::new(session_config, None);
-    match session2.connect(stored_credentials, false).await {
-        Ok(()) => println!("Session username: {:#?}", session2.username()),
-        Err(e) => {
-            println!("Error connecting: {}", e);
-            return;
-        }
-    };
-    let token = session2.token_provider().get_token(SCOPES).await.unwrap();
+    let token = session.token_provider().get_token(SCOPES).await.unwrap();
     println!("Got me a token: {token:#?}");
 }

--- a/examples/get_token.rs
+++ b/examples/get_token.rs
@@ -1,6 +1,7 @@
 use std::env;
 
 use librespot::core::{authentication::Credentials, config::SessionConfig, session::Session};
+use librespot::protocol::authentication::AuthenticationType;
 
 const SCOPES: &str =
     "streaming,user-read-playback-state,user-modify-playback-state,user-read-currently-playing";
@@ -10,36 +11,43 @@ async fn main() {
     let mut session_config = SessionConfig::default();
 
     let args: Vec<_> = env::args().collect();
-    if args.len() == 4 {
-        session_config.client_id = args[3].clone()
-    } else if args.len() != 3 {
-        eprintln!("Usage: {} USERNAME PASSWORD [CLIENT_ID]", args[0]);
+    if args.len() == 3 {
+        session_config.client_id = args[2].clone()
+    } else if args.len() != 2 {
+        eprintln!("Usage: {} ACCESS_TOKEN [CLIENT_ID]", args[0]);
         return;
     }
-    let username = &args[1];
-    let password = &args[2];
+    let access_token = &args[1];
 
+    // Now create a new session with that token.
     let session = Session::new(session_config.clone(), None);
-    let credentials = Credentials::with_password(username, password);
-    println!("Connecting with password..");
-    let token = match session.connect(credentials, false).await {
-        Ok(()) => {
-            println!("Session username: {:#?}", session.username());
-            session.token_provider().get_token(SCOPES).await.unwrap()
+    let credentials = Credentials::with_access_token(access_token);
+    println!("Connecting with token..");
+    match session.connect(credentials, false).await {
+        Ok(()) => println!("Session username: {:#?}", session.username()),
+        Err(e) => {
+            println!("Error connecting: {e}");
+            return;
         }
+    };
+
+    // This will fail. You can't use keymaster from an access token authed session.
+    // let token = session.token_provider().get_token(SCOPES).await.unwrap();
+
+    // Instead, derive stored credentials and auth a new session using those.
+    let stored_credentials = Credentials {
+        username: Some(session.username()),
+        auth_type: AuthenticationType::AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS,
+        auth_data: session.auth_data(),
+    };
+    let session2 = Session::new(session_config, None);
+    match session2.connect(stored_credentials, false).await {
+        Ok(()) => println!("Session username: {:#?}", session2.username()),
         Err(e) => {
             println!("Error connecting: {}", e);
             return;
         }
     };
-    println!("Token: {:#?}", token);
-
-    // Now create a new session with that token.
-    let session = Session::new(session_config, None);
-    let credentials = Credentials::with_access_token(token.access_token);
-    println!("Connecting with token..");
-    match session.connect(credentials, false).await {
-        Ok(()) => println!("Session username: {:#?}", session.username()),
-        Err(e) => println!("Error connecting: {}", e),
-    }
+    let token = session2.token_provider().get_token(SCOPES).await.unwrap();
+    println!("Got me a token: {token:#?}");
 }

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -22,13 +22,13 @@ async fn main() {
     let audio_format = AudioFormat::default();
 
     let args: Vec<_> = env::args().collect();
-    if args.len() != 4 {
-        eprintln!("Usage: {} USERNAME PASSWORD TRACK", args[0]);
+    if args.len() != 3 {
+        eprintln!("Usage: {} ACCESS_TOKEN TRACK", args[0]);
         return;
     }
-    let credentials = Credentials::with_password(&args[1], &args[2]);
+    let credentials = Credentials::with_access_token(&args[1]);
 
-    let mut track = SpotifyId::from_base62(&args[3]).unwrap();
+    let mut track = SpotifyId::from_base62(&args[2]).unwrap();
     track.item_type = SpotifyItemType::Track;
 
     let backend = audio_backend::find(None).unwrap();

--- a/examples/play_connect.rs
+++ b/examples/play_connect.rs
@@ -28,16 +28,16 @@ async fn main() {
     let connect_config = ConnectConfig::default();
 
     let mut args: Vec<_> = env::args().collect();
-    let context_uri = if args.len() == 4 {
+    let context_uri = if args.len() == 3 {
         args.pop().unwrap()
-    } else if args.len() == 3 {
+    } else if args.len() == 2 {
         String::from("spotify:album:79dL7FLiJFOO0EoehUHQBv")
     } else {
-        eprintln!("Usage: {} USERNAME PASSWORD (ALBUM URI)", args[0]);
+        eprintln!("Usage: {} ACCESS_TOKEN (ALBUM URI)", args[0]);
         return;
     };
 
-    let credentials = Credentials::with_password(&args[1], &args[2]);
+    let credentials = Credentials::with_access_token(&args[1]);
     let backend = audio_backend::find(None).unwrap();
 
     println!("Connecting...");

--- a/examples/playlist_tracks.rs
+++ b/examples/playlist_tracks.rs
@@ -13,13 +13,13 @@ async fn main() {
     let session_config = SessionConfig::default();
 
     let args: Vec<_> = env::args().collect();
-    if args.len() != 4 {
-        eprintln!("Usage: {} USERNAME PASSWORD PLAYLIST", args[0]);
+    if args.len() != 3 {
+        eprintln!("Usage: {} ACCESS_TOKEN PLAYLIST", args[0]);
         return;
     }
-    let credentials = Credentials::with_password(&args[1], &args[2]);
+    let credentials = Credentials::with_access_token(&args[1]);
 
-    let plist_uri = SpotifyId::from_uri(&args[3]).unwrap_or_else(|_| {
+    let plist_uri = SpotifyId::from_uri(&args[2]).unwrap_or_else(|_| {
         eprintln!(
             "PLAYLIST should be a playlist URI such as: \
                 \"spotify:playlist:37i9dQZF1DXec50AjHrNTq\""

--- a/oauth/Cargo.toml
+++ b/oauth/Cargo.toml
@@ -14,9 +14,5 @@ oauth2 = "4.4"
 thiserror = "1.0"
 url = "2.2"
 
-[dependencies.librespot-core]
-path = "../core"
-version = "0.5.0-dev"
-
 [dev-dependencies]
 env_logger =  { version = "0.11.2", default-features = false, features = ["color", "humantime", "auto-color"] }

--- a/oauth/Cargo.toml
+++ b/oauth/Cargo.toml
@@ -17,3 +17,6 @@ url = "2.2"
 [dependencies.librespot-core]
 path = "../core"
 version = "0.5.0-dev"
+
+[dev-dependencies]
+env_logger =  { version = "0.11.2", default-features = false, features = ["color", "humantime", "auto-color"] }

--- a/oauth/Cargo.toml
+++ b/oauth/Cargo.toml
@@ -2,8 +2,8 @@
 name = "librespot-oauth"
 version = "0.5.0-dev"
 rust-version = "1.73"
-authors = ["Paul Lietar <paul@lietar.net>"]
-description = "Spotify OAuth"
+authors = ["Nick Steel <nick@nsteel.co.uk>"]
+description = "OAuth authorization code flow with PKCE for obtaining a Spotify access token"
 license = "MIT"
 repository = "https://github.com/librespot-org/librespot"
 edition = "2021"

--- a/oauth/Cargo.toml
+++ b/oauth/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "librespot-oauth"
+version = "0.5.0-dev"
+rust-version = "1.73"
+authors = ["Paul Lietar <paul@lietar.net>"]
+description = "Spotify OAuth"
+license = "MIT"
+repository = "https://github.com/librespot-org/librespot"
+edition = "2021"
+
+[dependencies]
+log = "0.4"
+oauth2 = "4.4"
+url = "2.2"
+
+[dependencies.librespot-core]
+path = "../core"
+version = "0.5.0-dev"

--- a/oauth/Cargo.toml
+++ b/oauth/Cargo.toml
@@ -11,6 +11,7 @@ edition = "2021"
 [dependencies]
 log = "0.4"
 oauth2 = "4.4"
+thiserror = "1.0"
 url = "2.2"
 
 [dependencies.librespot-core]

--- a/oauth/examples/oauth.rs
+++ b/oauth/examples/oauth.rs
@@ -1,0 +1,13 @@
+use librespot_core::SessionConfig;
+use librespot_oauth::get_access_token;
+
+fn main() {
+    let mut builder = env_logger::Builder::new();
+    builder.parse_filters("librespot=trace");
+    builder.init();
+    
+    match get_access_token(&SessionConfig::default().client_id,  vec!["streaming"], Some(1337)) {
+        Ok(token) => println!("Success: {token:#?}"),
+        Err(e) => println!("Failed: {e}"),
+    };
+}

--- a/oauth/examples/oauth.rs
+++ b/oauth/examples/oauth.rs
@@ -1,16 +1,14 @@
-use librespot_core::SessionConfig;
 use librespot_oauth::get_access_token;
+
+// You can use any client ID here but it must be configured to allow redirect URI http://127.0.0.1
+const SPOTIFY_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
 
 fn main() {
     let mut builder = env_logger::Builder::new();
     builder.parse_filters("librespot=trace");
     builder.init();
 
-    match get_access_token(
-        &SessionConfig::default().client_id,
-        vec!["streaming"],
-        Some(1337),
-    ) {
+    match get_access_token(SPOTIFY_CLIENT_ID, vec!["streaming"], Some(1337)) {
         Ok(token) => println!("Success: {token:#?}"),
         Err(e) => println!("Failed: {e}"),
     };

--- a/oauth/examples/oauth.rs
+++ b/oauth/examples/oauth.rs
@@ -1,14 +1,31 @@
+use std::env;
+
 use librespot_oauth::get_access_token;
 
-// You can use any client ID here but it must be configured to allow redirect URI http://127.0.0.1
 const SPOTIFY_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
+const SPOTIFY_REDIRECT_URI: &str = "http://127.0.0.1:8898/login";
 
 fn main() {
     let mut builder = env_logger::Builder::new();
     builder.parse_filters("librespot=trace");
     builder.init();
 
-    match get_access_token(SPOTIFY_CLIENT_ID, vec!["streaming"], Some(1337)) {
+    let args: Vec<_> = env::args().collect();
+    let (client_id, redirect_uri, scopes) = if args.len() == 4 {
+        // You can use your own client ID, along with it's associated redirect URI.
+        (
+            args[1].as_str(),
+            args[2].as_str(),
+            args[3].split(',').collect::<Vec<&str>>(),
+        )
+    } else if args.len() == 1 {
+        (SPOTIFY_CLIENT_ID, SPOTIFY_REDIRECT_URI, vec!["streaming"])
+    } else {
+        eprintln!("Usage: {} [CLIENT_ID REDIRECT_URI SCOPES]", args[0]);
+        return;
+    };
+
+    match get_access_token(client_id, redirect_uri, scopes) {
         Ok(token) => println!("Success: {token:#?}"),
         Err(e) => println!("Failed: {e}"),
     };

--- a/oauth/examples/oauth.rs
+++ b/oauth/examples/oauth.rs
@@ -5,8 +5,12 @@ fn main() {
     let mut builder = env_logger::Builder::new();
     builder.parse_filters("librespot=trace");
     builder.init();
-    
-    match get_access_token(&SessionConfig::default().client_id,  vec!["streaming"], Some(1337)) {
+
+    match get_access_token(
+        &SessionConfig::default().client_id,
+        vec!["streaming"],
+        Some(1337),
+    ) {
         Ok(token) => println!("Success: {token:#?}"),
         Err(e) => println!("Failed: {e}"),
     };

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -20,47 +20,104 @@ use std::io;
 use std::{
     io::{BufRead, BufReader, Write},
     net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
-    process::exit,
     sync::mpsc,
 };
+use thiserror::Error;
 use url::Url;
 
-fn get_code(redirect_url: &str) -> AuthorizationCode {
-    let url = Url::parse(redirect_url).unwrap();
+#[derive(Debug, Error)]
+pub enum OAuthError {
+    #[error("Unable to parse redirect URI {uri} ({e})")]
+    AuthCodeBadUri { uri: String, e: url::ParseError },
+
+    #[error("Auth code param not found in URI {uri}")]
+    AuthCodeNotFound { uri: String },
+
+    #[error("Failed to read redirect URI from stdin")]
+    AuthCodeStdinRead,
+
+    #[error("Failed to bind server to {addr} ({e})")]
+    AuthCodeListenerBind { addr: SocketAddr, e: io::Error },
+
+    #[error("Listener terminated without accepting a connection")]
+    AuthCodeListenerTerminated,
+
+    #[error("Failed to read redirect URI from HTTP request")]
+    AuthCodeListenerRead,
+
+    #[error("Failed to parse redirect URI from HTTP request")]
+    AuthCodeListenerParse,
+
+    #[error("Failed to write HTTP response")]
+    AuthCodeListenerWrite,
+
+    #[error("Invalid Spotify OAuth URI")]
+    InvalidSpotifyUri,
+
+    #[error("Invalid Redirect URI {uri} ({e})")]
+    InvalidRedirectUri { uri: String, e: url::ParseError },
+
+    #[error("Failed to recieve code")]
+    Recv,
+
+    #[error("Failed to exchange code for access token ({e})")]
+    ExchangeCode { e: String },
+}
+
+/// Return code query-string parameter from the redirect URI.
+fn get_code(redirect_url: &str) -> Result<AuthorizationCode, OAuthError> {
+    let url = Url::parse(redirect_url).map_err(|e| OAuthError::AuthCodeBadUri {
+        uri: redirect_url.to_string(),
+        e,
+    })?;
     let code = url
         .query_pairs()
         .find(|(key, _)| key == "code")
         .map(|(_, code)| AuthorizationCode::new(code.into_owned()))
-        .unwrap();
-    code
+        .ok_or(OAuthError::AuthCodeNotFound {
+            uri: redirect_url.to_string(),
+        })?;
+
+    Ok(code)
 }
 
-fn get_authcode_stdin() -> AuthorizationCode {
+/// Prompt for redirect URI on stdin and return auth code.
+fn get_authcode_stdin() -> Result<AuthorizationCode, OAuthError> {
     println!("Provide redirect URL");
     let mut buffer = String::new();
-    let stdin = io::stdin(); // We get `Stdin` here.
-    stdin.read_line(&mut buffer).unwrap();
+    let stdin = io::stdin();
+    stdin
+        .read_line(&mut buffer)
+        .map_err(|_| OAuthError::AuthCodeStdinRead)?;
 
     get_code(buffer.trim())
 }
 
-fn get_authcode_listener(socket_address: SocketAddr) -> AuthorizationCode {
-    // A very naive implementation of the redirect server.
-    let listener = TcpListener::bind(socket_address).unwrap();
-
+/// Spawn HTTP server on provided socket to accept OAuth callback and return auth code.
+fn get_authcode_listener(socket_address: SocketAddr) -> Result<AuthorizationCode, OAuthError> {
+    let listener =
+        TcpListener::bind(socket_address).map_err(|e| OAuthError::AuthCodeListenerBind {
+            addr: socket_address,
+            e,
+        })?;
     info!("OAuth server listening on {:?}", socket_address);
 
     // The server will terminate itself after collecting the first code.
-    let Some(mut stream) = listener.incoming().flatten().next() else {
-        panic!("listener terminated without accepting a connection");
-    };
-
+    let mut stream = listener
+        .incoming()
+        .flatten()
+        .next()
+        .ok_or(OAuthError::AuthCodeListenerTerminated)?;
     let mut reader = BufReader::new(&stream);
-
     let mut request_line = String::new();
-    reader.read_line(&mut request_line).unwrap();
+    reader
+        .read_line(&mut request_line)
+        .map_err(|_| OAuthError::AuthCodeListenerRead)?;
 
-    let redirect_url = request_line.split_whitespace().nth(1).unwrap();
+    let redirect_url = request_line
+        .split_whitespace()
+        .nth(1)
+        .ok_or(OAuthError::AuthCodeListenerParse)?;
     let code = get_code(&("http://localhost".to_string() + redirect_url));
 
     let message = "Go back to your terminal :)";
@@ -69,59 +126,48 @@ fn get_authcode_listener(socket_address: SocketAddr) -> AuthorizationCode {
         message.len(),
         message
     );
-    stream.write_all(response.as_bytes()).unwrap();
+    stream
+        .write_all(response.as_bytes())
+        .map_err(|_| OAuthError::AuthCodeListenerWrite)?;
 
     code
 }
 
-// TODO: Return a Result?
 // TODO: Pass in redirect_address instead since the redirect host depends on client ID?
-// TODO: Pass in scopes.
-pub fn get_access_token(client_id: &str, redirect_port: u16) -> String {
+/// Obtain a Spotify access token using the authorization code with PKCE OAuth flow.
+pub fn get_access_token(
+    client_id: &str,
+    scopes: Vec<&str>,
+    redirect_port: Option<u16>,
+) -> Result<String, OAuthError> {
     // Must use host 127.0.0.1 with Spotify Desktop client ID.
-    let redirect_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), redirect_port);
+    let redirect_address = SocketAddr::new(
+        IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
+        redirect_port.unwrap_or_default(),
+    );
     let redirect_uri = format!("http://{redirect_address}/login");
 
+    let auth_url = AuthUrl::new("https://accounts.spotify.com/authorize".to_string())
+        .map_err(|_| OAuthError::InvalidSpotifyUri)?;
+    let token_url = TokenUrl::new("https://accounts.spotify.com/api/token".to_string())
+        .map_err(|_| OAuthError::InvalidSpotifyUri)?;
     let client = BasicClient::new(
         ClientId::new(client_id.to_string()),
         None,
-        AuthUrl::new("https://accounts.spotify.com/authorize".to_string()).unwrap(),
-        Some(TokenUrl::new("https://accounts.spotify.com/api/token".to_string()).unwrap()),
+        auth_url,
+        Some(token_url),
     )
-    .set_redirect_uri(RedirectUrl::new(redirect_uri).expect("Invalid redirect URL"));
+    .set_redirect_uri(RedirectUrl::new(redirect_uri.clone()).map_err(|e| {
+        OAuthError::InvalidRedirectUri {
+            uri: redirect_uri,
+            e,
+        }
+    })?);
 
     let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
 
     // Generate the full authorization URL.
     // Some of these scopes are unavailable for custom client IDs. Which?
-    let scopes = vec![
-        "app-remote-control",
-        "playlist-modify",
-        "playlist-modify-private",
-        "playlist-modify-public",
-        "playlist-read",
-        "playlist-read-collaborative",
-        "playlist-read-private",
-        "streaming",
-        "ugc-image-upload",
-        "user-follow-modify",
-        "user-follow-read",
-        "user-library-modify",
-        "user-library-read",
-        "user-modify",
-        "user-modify-playback-state",
-        "user-modify-private",
-        "user-personalized",
-        "user-read-birthdate",
-        "user-read-currently-playing",
-        "user-read-email",
-        "user-read-play-history",
-        "user-read-playback-position",
-        "user-read-playback-state",
-        "user-read-private",
-        "user-read-recently-played",
-        "user-top-read",
-    ];
     let scopes: Vec<oauth2::Scope> = scopes.into_iter().map(|s| Scope::new(s.into())).collect();
     let (auth_url, _) = client
         .authorize_url(CsrfToken::new_random)
@@ -131,11 +177,11 @@ pub fn get_access_token(client_id: &str, redirect_port: u16) -> String {
 
     println!("Browse to: {}", auth_url);
 
-    let code = if redirect_port > 0 {
+    let code = if redirect_port.is_some() {
         get_authcode_listener(redirect_address)
     } else {
         get_authcode_stdin()
-    };
+    }?;
     debug!("Exchange {code:?} for access token");
 
     // Do this sync in another thread because I am too stupid to make the async version work.
@@ -146,19 +192,13 @@ pub fn get_access_token(client_id: &str, redirect_port: u16) -> String {
             .exchange_code(code)
             .set_pkce_verifier(pkce_verifier)
             .request(http_client);
-        tx.send(resp).unwrap();
+        if let Err(e) = tx.send(resp) {
+            error!("OAuth channel send error: {e}");
+        }
     });
-    let token_response = rx.recv().unwrap();
-    let token = match token_response {
-        Ok(tok) => {
-            trace!("Obtained new access token: {tok:?}");
-            tok
-        }
-        Err(e) => {
-            error!("Failed to exchange code for access token: {e:?}");
-            exit(1);
-        }
-    };
+    let token_response = rx.recv().map_err(|_| OAuthError::Recv)?;
+    let token = token_response.map_err(|e| OAuthError::ExchangeCode { e: e.to_string() })?;
+    trace!("Obtained new access token: {token:?}");
 
-    token.access_token().secret().to_string()
+    Ok(token.access_token().secret().to_string())
 }

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -1,3 +1,15 @@
+//! Provides a Spotify access token using the OAuth authorization code flow
+//! with PKCE.
+//!
+//! Assuming sufficient scopes, the returned access token may be used with Spotify's
+//! Web API, and/or to establish a new Session with [`librespot_core`].
+//!
+//! The authorization code flow is an interactive process which requires a web browser
+//! to complete. The resulting code must then be provided back from the browser to this
+//! library for exchange into an access token. Providing the code can be automatic via
+//! a spawned http server (mimicking Spotify's client), or manually via stdin. The latter
+//! is appropriate for headless systems.
+
 use log::{debug, error, info, trace};
 use oauth2::reqwest::http_client;
 use oauth2::{

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -178,7 +178,11 @@ pub fn get_access_token(
 
     // Generate the full authorization URL.
     // Some of these scopes are unavailable for custom client IDs. Which?
-    let request_scopes: Vec<oauth2::Scope> = scopes.clone().into_iter().map(|s| Scope::new(s.into())).collect();
+    let request_scopes: Vec<oauth2::Scope> = scopes
+        .clone()
+        .into_iter()
+        .map(|s| Scope::new(s.into()))
+        .collect();
     let (auth_url, _) = client
         .authorize_url(CsrfToken::new_random)
         .add_scopes(request_scopes)
@@ -211,11 +215,10 @@ pub fn get_access_token(
     trace!("Obtained new access token: {token:?}");
 
     let token_scopes: Vec<String> = match token.scopes() {
-        Some(s) => s.into_iter().map(|s| s.to_string()).collect(),
+        Some(s) => s.iter().map(|s| s.to_string()).collect(),
         _ => scopes.into_iter().map(|s| s.to_string()).collect(),
     };
-    Ok(
-        AccessToken {
+    Ok(AccessToken {
         access_token: token.access_token().secret().to_string(),
         refresh_token: token.refresh_token().unwrap().secret().to_string(),
         expires_at: Instant::now() + token.expires_in().unwrap_or(Duration::from_secs(3600)),

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -1,0 +1,147 @@
+use log::{debug, error, info, trace};
+use oauth2::reqwest::http_client;
+use oauth2::{
+    basic::BasicClient, AuthUrl, AuthorizationCode, ClientId, CsrfToken, PkceCodeChallenge,
+    RedirectUrl, Scope, TokenResponse, TokenUrl,
+};
+use std::io;
+use std::{
+    io::{BufRead, BufReader, Write},
+    net::{IpAddr, Ipv4Addr, SocketAddr, TcpListener},
+    process::exit,
+    sync::mpsc,
+};
+use url::Url;
+
+fn get_authcode_stdin() -> AuthorizationCode {
+    println!("Provide code");
+    let mut buffer = String::new();
+    let stdin = io::stdin(); // We get `Stdin` here.
+    stdin.read_line(&mut buffer).unwrap();
+
+    AuthorizationCode::new(buffer.trim().into())
+}
+
+fn get_authcode_listener(socket_address: SocketAddr) -> AuthorizationCode {
+    // A very naive implementation of the redirect server.
+    let listener = TcpListener::bind(socket_address).unwrap();
+
+    info!("OAuth server listening on {:?}", socket_address);
+
+    // The server will terminate itself after collecting the first code.
+    let Some(mut stream) = listener.incoming().flatten().next() else {
+        panic!("listener terminated without accepting a connection");
+    };
+
+    let mut reader = BufReader::new(&stream);
+
+    let mut request_line = String::new();
+    reader.read_line(&mut request_line).unwrap();
+
+    let redirect_url = request_line.split_whitespace().nth(1).unwrap();
+    let url = Url::parse(&("http://localhost".to_string() + redirect_url)).unwrap();
+
+    let code = url
+        .query_pairs()
+        .find(|(key, _)| key == "code")
+        .map(|(_, code)| AuthorizationCode::new(code.into_owned()))
+        .unwrap();
+
+    let message = "Go back to your terminal :)";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-length: {}\r\n\r\n{}",
+        message.len(),
+        message
+    );
+    stream.write_all(response.as_bytes()).unwrap();
+
+    code
+}
+
+// TODO: Return a Result?
+// TODO: Pass in redirect_address instead since the redirect host depends on client ID?
+pub fn get_access_token(client_id: &str, redirect_port: u16) -> String {
+    // Must use host 127.0.0.1 with Spotify Desktop client ID.
+    let redirect_address = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), redirect_port);
+    let redirect_uri = format!("http://{redirect_address}/login");
+
+    let client = BasicClient::new(
+        ClientId::new(client_id.to_string()),
+        None,
+        AuthUrl::new("https://accounts.spotify.com/authorize".to_string()).unwrap(),
+        Some(TokenUrl::new("https://accounts.spotify.com/api/token".to_string()).unwrap()),
+    )
+    .set_redirect_uri(RedirectUrl::new(redirect_uri).expect("Invalid redirect URL"));
+
+    let (pkce_challenge, pkce_verifier) = PkceCodeChallenge::new_random_sha256();
+
+    // Generate the full authorization URL.
+    // Some of these scopes are unavailable for custom client IDs. Which?
+    let scopes = vec![
+        "app-remote-control",
+        "playlist-modify",
+        "playlist-modify-private",
+        "playlist-modify-public",
+        "playlist-read",
+        "playlist-read-collaborative",
+        "playlist-read-private",
+        "streaming",
+        "ugc-image-upload",
+        "user-follow-modify",
+        "user-follow-read",
+        "user-library-modify",
+        "user-library-read",
+        "user-modify",
+        "user-modify-playback-state",
+        "user-modify-private",
+        "user-personalized",
+        "user-read-birthdate",
+        "user-read-currently-playing",
+        "user-read-email",
+        "user-read-play-history",
+        "user-read-playback-position",
+        "user-read-playback-state",
+        "user-read-private",
+        "user-read-recently-played",
+        "user-top-read",
+    ];
+    let scopes: Vec<oauth2::Scope> = scopes.into_iter().map(|s| Scope::new(s.into())).collect();
+    let (auth_url, _) = client
+        .authorize_url(CsrfToken::new_random)
+        .add_scopes(scopes)
+        .set_pkce_challenge(pkce_challenge)
+        .url();
+
+    println!("Browse to: {}", auth_url);
+
+    let code = if redirect_port > 0 {
+        get_authcode_listener(redirect_address)
+    } else {
+        get_authcode_stdin()
+    };
+    debug!("Exchange {code:?} for access token");
+
+    // Do this sync in another thread because I am too stupid to make the async version work.
+    let (tx, rx) = mpsc::channel();
+    let client_clone = client.clone();
+    std::thread::spawn(move || {
+        let resp = client_clone
+            .exchange_code(code)
+            .set_pkce_verifier(pkce_verifier)
+            .request(http_client);
+        tx.send(resp).unwrap();
+    });
+    let token_response = rx.recv().unwrap();
+    let token = match token_response {
+        Ok(tok) => {
+            trace!("Obtained new access token: {tok:?}");
+            tok
+        }
+        Err(e) => {
+            error!("Failed to exchange code for access token: {e:?}");
+            exit(1);
+        }
+    };
+
+    token.access_token().secret().to_string()
+}

--- a/publish.sh
+++ b/publish.sh
@@ -6,7 +6,7 @@ DRY_RUN='false'
 WORKINGDIR="$( cd "$(dirname "$0")" ; pwd -P )"
 cd $WORKINGDIR
 
-crates=( "protocol" "core" "discovery" "audio" "metadata" "playback" "connect" "librespot" )
+crates=( "protocol" "core" "discovery" "oauth" "audio" "metadata" "playback" "connect" "librespot" )
 
 OS=`uname`
 function replace_in_file() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub use librespot_connect as connect;
 pub use librespot_core as core;
 pub use librespot_discovery as discovery;
 pub use librespot_metadata as metadata;
+pub use librespot_oauth as oauth;
 pub use librespot_playback as playback;
 pub use librespot_protocol as protocol;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1095,7 +1095,7 @@ fn get_setup() -> Setup {
                 Some(Credentials::with_password(username, password))
             } else {
                 match cached_creds {
-                    Some(creds) if username == creds.username => Some(creds),
+                    Some(creds) if Some(&username) == creds.username.as_ref() => Some(creds),
                     _ => {
                         let prompt = &format!("Password for {username}: ");
                         match rpassword::prompt_password(prompt) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1804,10 +1804,14 @@ async fn main() {
         last_credentials = Some(credentials);
         connecting = true;
     } else if setup.enable_oauth {
+        let port_str = match setup.oauth_port {
+            Some(port) => format!(":{port}"),
+            _ => String::new(),
+        };
         let access_token = match librespot::oauth::get_access_token(
             &setup.session_config.client_id,
+            &format!("http://127.0.0.1{port_str}/login"),
             OAUTH_SCOPES.to_vec(),
-            setup.oauth_port,
         ) {
             Ok(token) => token.access_token,
             Err(e) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1345,7 +1345,7 @@ fn get_setup() -> Setup {
                     OAUTH_SCOPES.to_vec(),
                     token_port,
                 ) {
-                    Ok(token) => token,
+                    Ok(token) => token.access_token,
                     Err(e) => {
                         error!("Failed to get Spotify access token: {e}");
                         exit(1);


### PR DESCRIPTION
I don't know if this oauth stuff really belongs in core, it doesn't feel quite right there so I added a new module. That new module could be useful standalone so it makes sense. If someone wants to take this and do something else that is fine by me. 

This also leaves the token stuff a bit messy. We now provide two ways to get an access token:
1. `session.token_provider().get_token("your,scopes")` using keymaster (Mercury)
2. `session.spclient().auth_token()` using login5 (HTTP) 

Both methods work (for session auth and playback) when you authenticate your session using a password or stored credentials. However, method 1 doesn't work when you authenticate your session using a spotify token (obtained using either method). 

I think we want to get rid of this annoying pitfall. We could:
a) Get rid of method 1 altogether
b) Method 1 use method 2 under the hood
c) Change session authentication so when stored-creds are not used, it auths to obtain them and then re-auths using them.

Fixes #1308