### PR TITLE
Update dependencies

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG debian_version=slim-bookworm
-ARG rust_version=1.73.0
+ARG rust_version=1.74.0
 FROM rust:${rust_version}-${debian_version}
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         toolchain:
-          - "1.73" # MSRV (Minimum supported rust version)
+          - "1.74" # MSRV (Minimum supported rust version)
           - stable
         experimental: [false]
         # Ignore failures in beta
@@ -163,7 +163,7 @@ jobs:
       matrix:
         os: [windows-latest]
         toolchain:
-          - "1.73" # MSRV (Minimum supported rust version)
+          - "1.74" # MSRV (Minimum supported rust version)
           - stable
     steps:
       - name: Checkout code
@@ -206,7 +206,7 @@ jobs:
         os: [ubuntu-latest]
         target: [armv7-unknown-linux-gnueabihf]
         toolchain:
-          - "1.73" # MSRV (Minimum supported rust version)
+          - "1.74" # MSRV (Minimum supported rust version)
           - stable
     steps:
       - name: Checkout code

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ https://github.com/librespot-org/librespot
   configurations.
 - [audio] Files are now downloaded over the HTTPS CDN (breaking)
 - [audio] Improve file opening and seeking performance (breaking)
-- [core] MSRV is now 1.73 (breaking)
+- [core] MSRV is now 1.74 (breaking)
 - [connect] `DeviceType` moved out of `connect` into `core` (breaking)
 - [connect] Update and expose all `spirc` context fields (breaking)
 - [connect] Add `Clone, Defaut` traits to `spirc` contexts

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2434,9 +2434,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.32.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d3a6e5838b60e0e8fa7a43f22ade549a37d61f8bdbe636d0d7816191de969c2"
+checksum = "96a05e2e8efddfa51a84ca47cec303fac86c8541b686d37cac5efc0e094417bc"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2939,16 +2939,15 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.30.12"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "732ffa00f53e6b2af46208fba5718d9662a421049204e156328b66791ffa15ae"
+checksum = "2b92e0bdf838cbc1c4c9ba14f9c97a7ec6cdcd1ae66b10e1e42775a25553f45d"
 dependencies = [
- "cfg-if",
  "core-foundation-sys",
  "libc",
+ "memchr",
  "ntapi",
- "once_cell",
- "windows 0.52.0",
+ "windows 0.54.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2546,9 +2546,9 @@ dependencies = [
 
 [[package]]
 name = "rodio"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1fceb9d127d515af1586d8d0cc601e1245bdb0af38e75c865a156290184f5b3"
+checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
 dependencies = [
  "cpal",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2725,9 +2725,9 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "sdl2"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8356b2697d1ead5a34f40bcc3c5d3620205fe0c7be0a14656223bfeec0258891"
+checksum = "3b498da7d14d1ad6c839729bd4ad6fc11d90a57583605f3b4df2cd709a9cd380"
 dependencies = [
  "bitflags 1.3.2",
  "lazy_static",
@@ -2737,9 +2737,9 @@ dependencies = [
 
 [[package]]
 name = "sdl2-sys"
-version = "0.36.0"
+version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26bcacfdd45d539fb5785049feb0038a63931aa896c7763a2a12e125ec58bd29"
+checksum = "951deab27af08ed9c6068b7b0d05a93c91f0a8eb16b6b816a5e73452a43521d3"
 dependencies = [
  "cfg-if",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
 name = "dasp_sample"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +484,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0350b5cb0331628a5916d6c5c0b72e97393b8b6b03b47a9284f4e7f5a405ffd7"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d48cda787f839151732d396ac69e3473923d54312c070ee21e9effcaa8ca0b1d"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.66",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "206868b8242f27cecce124c19fd88157fbd0dd334df2587f36417bafbc85097b"
+dependencies = [
+ "derive_builder_core",
+ "syn 2.0.66",
 ]
 
 [[package]]
@@ -688,6 +754,18 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "getset"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e45727250e75cc04ff2846a66397da8ef2b3db8e40e0cef4df67950a07621eb9"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1265,6 +1343,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1641,7 +1725,7 @@ dependencies = [
  "tokio-util",
  "url",
  "uuid",
- "vergen",
+ "vergen-gitcl",
 ]
 
 [[package]]
@@ -2265,6 +2349,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2815,6 +2923,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3334,14 +3448,41 @@ dependencies = [
 
 [[package]]
 name = "vergen"
-version = "8.3.1"
+version = "9.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e27d6bdd219887a9eadd19e1c34f32e47fa332301184935c6d9bca26f3cca525"
+checksum = "c32e7318e93a9ac53693b6caccfb05ff22e04a44c7cf8a279051f24c09da286f"
 dependencies = [
  "anyhow",
- "cfg-if",
+ "derive_builder",
  "rustversion",
  "time",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-gitcl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bbdc9746577cb4767f218d320ee0b623d415e8130332f8f562b910b61cc2c4e"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "rustversion",
+ "time",
+ "vergen",
+ "vergen-lib",
+]
+
+[[package]]
+name = "vergen-lib"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e06bee42361e43b60f363bad49d63798d0f42fb1768091812270eca00c784720"
+dependencies = [
+ "anyhow",
+ "derive_builder",
+ "getset",
+ "rustversion",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot"
 version = "0.5.0-dev"
-rust-version = "1.73"
+rust-version = "1.74"
 authors = ["Librespot Org"]
 license = "MIT"
 description = "An open source client library for Spotify, with support for Spotify Connect"
@@ -57,7 +57,7 @@ getopts = "0.2"
 log = "0.4"
 rpassword = "7.0"
 sha1 = "0.10"
-sysinfo = { version = "0.30.5", default-features = false }
+sysinfo = { version = "0.31.3", default-features = false, features = ["system"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["rt", "macros", "signal", "sync", "parking_lot", "process"] }
 url = "2.2"

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-audio"
 version = "0.5.0-dev"
-rust-version = "1.73"
+rust-version = "1.74"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The audio fetching logic for librespot"
 license = "MIT"

--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-connect"
 version = "0.5.0-dev"
-rust-version = "1.73"
+rust-version = "1.74"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The discovery and Spotify Connect logic for librespot"
 license = "MIT"

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -28,7 +28,7 @@ RUN apt-get install -y curl git build-essential crossbuild-essential-arm64 cross
 RUN apt-get install -y libasound2-dev libasound2-dev:arm64 libasound2-dev:armel libasound2-dev:armhf
 RUN apt-get install -y libpulse0 libpulse0:arm64 libpulse0:armel libpulse0:armhf
 
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.73 -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.74 -y
 ENV PATH="/root/.cargo/bin/:${PATH}"
 RUN rustup target add aarch64-unknown-linux-gnu
 RUN rustup target add arm-unknown-linux-gnueabi

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -42,7 +42,7 @@ parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
 priority-queue = "2.0"
 protobuf = "3"
-quick-xml = { version = "0.32", features = ["serialize"] }
+quick-xml = { version = "0.36.1", features = ["serialize"] }
 rand = "0.8"
 rsa = "0.9.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-core"
 version = "0.5.0-dev"
-rust-version = "1.73"
+rust-version = "1.74"
 authors = ["Paul Lietar <paul@lietar.net>"]
 build = "build.rs"
 description = "The core functionality provided by librespot"
@@ -49,7 +49,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha1 = { version = "0.10", features = ["oid"] }
 shannon = "0.2"
-sysinfo = { version = "0.30.5", default-features = false }
+sysinfo = { version = "0.31.3", default-features = false, features = ["system"] }
 thiserror = "1.0"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "parking_lot", "rt", "sync", "time"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -62,7 +62,7 @@ data-encoding = "2.5"
 
 [build-dependencies]
 rand = "0.8"
-vergen = { version = "8", default-features = false, features = ["build", "git", "gitcl"] }
+vergen-gitcl = { version = "1.0.0", default-features = false, features = ["build"] }
 
 [dev-dependencies]
 env_logger = "0.11.2"

--- a/core/build.rs
+++ b/core/build.rs
@@ -1,11 +1,19 @@
 use rand::{distributions::Alphanumeric, Rng};
-use vergen::EmitBuilder;
+use vergen_gitcl::{BuildBuilder, Emitter, GitclBuilder};
 
-fn main() {
-    EmitBuilder::builder()
-        .build_date() // outputs 'VERGEN_BUILD_DATE'
-        .git_sha(true) // outputs 'VERGEN_GIT_SHA', and sets the 'short' flag true
-        .git_commit_date() // outputs 'VERGEN_GIT_COMMIT_DATE'
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let gitcl = GitclBuilder::default()
+        .sha(true) // outputs 'VERGEN_GIT_SHA', and sets the 'short' flag true
+        .commit_date(true) // outputs 'VERGEN_GIT_COMMIT_DATE'
+        .build()?;
+
+    let build = BuildBuilder::default()
+        .build_date(true) // outputs 'VERGEN_BUILD_DATE'
+        .build()?;
+
+    Emitter::default()
+        .add_instructions(&build)?
+        .add_instructions(&gitcl)?
         .emit()
         .expect("Unable to generate the cargo keys!");
     let build_id = match std::env::var("SOURCE_DATE_EPOCH") {
@@ -18,4 +26,5 @@ fn main() {
     };
 
     println!("cargo:rustc-env=LIBRESPOT_BUILD_ID={build_id}");
+    Ok(())
 }

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-discovery"
 version = "0.5.0-dev"
-rust-version = "1.73"
+rust-version = "1.74"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The discovery logic for librespot"
 license = "MIT"

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-metadata"
 version = "0.5.0-dev"
-rust-version = "1.73"
+rust-version = "1.74"
 authors = ["Paul Lietar <paul@lietar.net>"]
 description = "The metadata logic for librespot"
 license = "MIT"

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-playback"
 version = "0.5.0-dev"
-rust-version = "1.73"
+rust-version = "1.74"
 authors = ["Sasha Hilton <sashahilton00@gmail.com>"]
 description = "The audio playback logic for librespot"
 license = "MIT"

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -43,7 +43,7 @@ gstreamer-audio = { version = "0.22.0", optional = true }
 glib            = { version = "0.19.2", optional = true }
 
 # Rodio dependencies
-rodio           = { version = "0.18.1", optional = true, default-features = false }
+rodio           = { version = "0.19.0", optional = true, default-features = false }
 cpal            = { version = "0.15.1", optional = true }
 
 # Container and audio decoder

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -36,7 +36,7 @@ portaudio-rs    = { version = "0.3", optional = true }
 libpulse-binding        = { version = "2", optional = true, default-features = false }
 libpulse-simple-binding = { version = "2", optional = true, default-features = false }
 jack            = { version = "0.11", optional = true }
-sdl2            = { version = "0.36", optional = true }
+sdl2            = { version = "0.37", optional = true }
 gstreamer       = { version = "0.22.1", optional = true }
 gstreamer-app   = { version = "0.22.0", optional = true }
 gstreamer-audio = { version = "0.22.0", optional = true }

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "librespot-protocol"
 version = "0.5.0-dev"
-rust-version = "1.73"
+rust-version = "1.74"
 authors = ["Paul Liétar <paul@lietar.net>"]
 build = "build.rs"
 description = "The protobuf logic for communicating with Spotify servers"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use std::{
     str::FromStr,
     time::{Duration, Instant},
 };
-use sysinfo::System;
+use sysinfo::{ProcessesToUpdate, System};
 use thiserror::Error;
 use url::Url;
 
@@ -1700,7 +1700,7 @@ async fn main() {
             {
                 Ok(d) => break Some(d),
                 Err(e) => {
-                    sys.refresh_processes();
+                    sys.refresh_processes(ProcessesToUpdate::All);
 
                     if System::uptime() <= 1 {
                         debug!("Retrying to initialise discovery: {e}");

--- a/test.sh
+++ b/test.sh
@@ -3,7 +3,7 @@
 set -e
 
 # this script runs the tests and checks that also run as part of the`test.yml` github action workflow
-
+cargo clean
 cargo fmt --all -- --check
 cargo clippy -p librespot-core --no-default-features
 cargo clippy -p librespot-core


### PR DESCRIPTION
Updates


```
/workspaces/librespot/Cargo.toml
dependency  current  upgrade
sysinfo     0.30.13  0.31.3

librespot-core
/workspaces/librespot/core/Cargo.toml
dependency    current  upgrade
quick-xml     0.32.0   0.36.1
sysinfo       0.30.13  0.31.3
vergen        8.3.2    9.0.0

librespot-playback
/workspaces/librespot/playback/Cargo.toml
dependency       current  upgrade
rodio            0.18.1   0.19.0
sdl2             0.36.0   0.37.0
```

MRSV needed to be increased to `1.74.0`

___


I did not update 

```
librespot-playback
/workspaces/librespot/playback/Cargo.toml
dependency       current  upgrade
glib             0.19.9   0.20.2
gstreamer        0.22.7   0.23.1
gstreamer-app    0.22.6   0.23.0
gstreamer-audio  0.22.6   0.23.0

```

because updating them caused downstream issues in `cfg_expr`, [see here.](https://github.com/EmbarkStudios/cfg-expr/issues/73)