### PR TITLE
Allow renamed-and-removed-lints

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -6,7 +6,7 @@ FROM rust:${rust_version}-${debian_version}
 ARG DEBIAN_FRONTEND=noninteractive
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"
 ENV RUST_BACKTRACE=1
-ENV RUSTFLAGS=-Dwarnings
+ENV RUSTFLAGS="-D warnings -A renamed-and-removed-lints"
 
 
 RUN apt-get update && \

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ on:
 
 env:
   RUST_BACKTRACE: 1
-  RUSTFLAGS: -D warnings
+  RUSTFLAGS: -D warnings -A renamed-and-removed-lints
 
 # The layering here is as follows:
 #  1. code formatting


### PR DESCRIPTION
Allow [renamed-and-removed-lints](https://doc.rust-lang.org/rustc/lints/listing/warn-by-default.html#renamed-and-removed-lints) for the time being because clippy fails currently for some dependencies warning about 
```
`box_pointers` has been removed: it does not detect other kinds of allocations, and existed only for historical reasons
```
See [here](https://github.com/librespot-org/librespot/actions/runs/10741132401/job/29792281116?pr=1327) for such warnings.