### PR TITLE
Remove .cargo/config.toml and set link compiler on CI with CARGO_TARGET_<triple>_LINKER

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,0 @@
-
-[target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -240,6 +240,9 @@ jobs:
       - name: Install cross compiler toolchain
         run: sudo apt-get install -y gcc-arm-linux-gnueabihf
       
+      - name: Set target link compiler
+        run: echo "CARGO_TARGET_ARMV7_UNKNOWN-LINUX-GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+      
       - name: Build
         run: cargo build --verbose --target ${{ matrix.target }} --no-default-features
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -154,7 +154,7 @@ jobs:
       - run: cargo hack check --each-feature
 
   test-windows:
-    needs: test-linux
+    needs: clippy
     name: cargo +${{ matrix.toolchain }} check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     continue-on-error: false
@@ -201,7 +201,7 @@ jobs:
 
   test-cross-arm:
     name: cross +${{ matrix.toolchain }} build ${{ matrix.target }}
-    needs: test-linux
+    needs: clippy
     runs-on: ${{ matrix.os }}
     continue-on-error: false
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,7 +241,7 @@ jobs:
         run: sudo apt-get install -y gcc-arm-linux-gnueabihf
       
       - name: Set target link compiler
-        run: echo "CARGO_TARGET_ARMV7_UNKNOWN-LINUX-GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+        run: echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
       
       - name: Build
         run: cargo build --verbose --target ${{ matrix.target }} --no-default-features

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -234,14 +234,24 @@ jobs:
             target
           key: ${{ runner.os }}-${{ matrix.target }}-${{ steps.get-rustc-version.outputs.version }}-${{ hashFiles('Cargo.lock') }}
 
-      - name: Install the cross compiler targets
+      - name: Install the cross compiler rust targets
         run: rustup target add ${{ matrix.target }}
       
-      - name: Install cross compiler toolchain
-        run: sudo apt-get install -y gcc-arm-linux-gnueabihf
+      - name: Install cross compiler
+        run: |
+            if [ ${{ matrix.target }} = "armv7-unknown-linux-gnueabihf" ]; then
+              sudo apt-get install -y gcc-arm-linux-gnueabihf
+            fi
       
       - name: Set target link compiler
-        run: echo "CARGO_TARGET_ARMV7_UNKNOWN_LINUX_GNUEABIHF_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+        run: |
+            # Convert target to uppercase and replace - with _
+            target=${{ matrix.target }}
+            target=${target^^}  
+            target=${target//-/_}
+            if [ ${{ matrix.target }} = "armv7-unknown-linux-gnueabihf" ]; then
+              echo "CARGO_TARGET_${target}_LINKER=arm-linux-gnueabihf-gcc" >> $GITHUB_ENV
+            fi
       
       - name: Build
         run: cargo build --verbose --target ${{ matrix.target }} --no-default-features

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 target
+.cargo
 spotify_appkey.key
 .vagrant/
 .project


### PR DESCRIPTION
PR https://github.com/librespot-org/librespot/pull/1318 changed the workflow for cross-compiling from `cross` to nativ `cargo`cross compiling. To set the correct linker, `.cargo/config.toml` was used. However, this has unexpected consequences for native builds on armv7 using another compiler. See https://github.com/librespot-org/librespot/commit/78a8c61f8544f57b46788e0458e36210d26b2bdb#commitcomment-146451253

This PR reverts the addition of `.cargo/config.toml` and sets the linker on CI with `CARGO_TARGET_<triple>_LINKER` env.