### PR TITLE
core: retry session connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,7 +56,8 @@ https://github.com/librespot-org/librespot
 - [core] `FileId` is moved out of `SpotifyId`. For now it will be re-exported.
 - [core] Report actual platform data on login
 - [core] Support `Session` authentication with a Spotify access token
-- [core] `Credentials.username` is now an `Option` (breaking) 
+- [core] `Credentials.username` is now an `Option` (breaking)
+- [core] `Session::connect` tries multiple access points, retrying each one.
 - [main] `autoplay {on|off}` now acts as an override. If unspecified, `librespot`
   now follows the setting in the Connect client that controls it. (breaking)
 - [metadata] Most metadata is now retrieved with the `spclient` (breaking)


### PR DESCRIPTION
When session connection fails, retry the access point. If still fails for a non-auth-login reason, repeat for the other access points. Also some logging tweaks.

When blocking ap-gew1.spotify.com, now I see each a retry for each AP on that host, until it finds an AP on a different host and succeeds.  

```
[2024-09-20T22:41:44Z DEBUG librespot_core::http_client] Requesting https://apresolve.spotify.com/?type=accesspoint&type=dealer&type=spclient
[2024-09-20T22:41:44Z INFO  librespot_core::session] Connecting to AP "ap-gew1.spotify.com:4070"
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Connection failed: Connection refused (os error 111)
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Retry access point...
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Connection failed: Connection refused (os error 111)
[2024-09-20T22:41:44Z WARN  librespot_core::session] Try another access point...
[2024-09-20T22:41:44Z INFO  librespot_core::session] Connecting to AP "ap-gew1.spotify.com:443"
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Connection failed: Connection refused (os error 111)
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Retry access point...
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Connection failed: Connection refused (os error 111)
[2024-09-20T22:41:44Z WARN  librespot_core::session] Try another access point...
[2024-09-20T22:41:44Z INFO  librespot_core::session] Connecting to AP "ap-gew1.spotify.com:80"
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Connection failed: Connection refused (os error 111)
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Retry access point...
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Connection failed: Connection refused (os error 111)
[2024-09-20T22:41:44Z WARN  librespot_core::session] Try another access point...
[2024-09-20T22:41:44Z INFO  librespot_core::session] Connecting to AP "ap-guc3.spotify.com:4070"
[2024-09-20T22:41:44Z DEBUG librespot_core::connection] Authenticating with AP using AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS
[2024-09-20T22:41:45Z INFO  librespot_core::session] Authenticated as 'XXX' !
```
When using bad credentials, it does not retry:
```
[2024-09-20T23:12:15Z DEBUG librespot_core::http_client] Requesting https://apresolve.spotify.com/?type=accesspoint&type=dealer&type=spclient
[2024-09-20T23:12:15Z INFO  librespot_core::session] Connecting to AP "ap-gew1.spotify.com:4070"
[2024-09-20T23:12:15Z DEBUG librespot_core::connection] Authenticating with AP using AUTHENTICATION_SPOTIFY_TOKEN
[2024-09-20T23:12:15Z ERROR librespot] could not initialize spirc: Permission denied { Login failed with reason: Bad credentials }
```