### PR TITLE
core: AP connection attempts have 3 sec timeout.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ https://github.com/librespot-org/librespot
 - [core] Support `Session` authentication with a Spotify access token
 - [core] `Credentials.username` is now an `Option` (breaking)
 - [core] `Session::connect` tries multiple access points, retrying each one.
+- [core] Each access point connection now timesout after 3 seconds.
 - [main] `autoplay {on|off}` now acts as an override. If unspecified, `librespot`
   now follows the setting in the Connect client that controls it. (breaking)
 - [metadata] Most metadata is now retrieved with the `spclient` (breaking)

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -3,7 +3,7 @@ mod handshake;
 
 pub use self::{codec::ApCodec, handshake::handshake};
 
-use std::io;
+use std::{io, time::Duration};
 
 use futures_util::{SinkExt, StreamExt};
 use num_traits::FromPrimitive;
@@ -63,7 +63,8 @@ impl From<APLoginFailed> for AuthenticationError {
 }
 
 pub async fn connect(host: &str, port: u16, proxy: Option<&Url>) -> io::Result<Transport> {
-    let socket = crate::socket::connect(host, port, proxy).await?;
+    const TIMEOUT: Duration = Duration::from_secs(3);
+    let socket = tokio::time::timeout(TIMEOUT, crate::socket::connect(host, port, proxy)).await??;
 
     handshake(socket).await
 }


### PR DESCRIPTION
My work network blocks port 4070 and librespot gets stuck indefinitely for me when it tries to use these APs. This allows it to give up after a few seconds and move on to a different port. 