### PR TITLE
Rework session keep-alive logic v2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1777,6 +1777,7 @@ dependencies = [
  "once_cell",
  "parking_lot",
  "pbkdf2",
+ "pin-project-lite",
  "priority-queue",
  "protobuf",
  "quick-xml",

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,6 +44,7 @@ num-traits = "0.2"
 once_cell = "1"
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
+pin-project-lite = "0.2"
 priority-queue = "2.0"
 protobuf = "3.5"
 quick-xml = { version = "0.36.1", features = ["serialize"] }

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -755,11 +755,16 @@ where
                     // TODO: Optionally reconnect (with cached/last credentials?)
                     return Poll::Ready(Err(io::Error::new(
                         io::ErrorKind::TimedOut,
-                        "session lost connection to server",
+                        format!(
+                            "session lost connection to server ({:?})",
+                            this.keep_alive_state
+                        ),
                     )));
                 }
                 PendingPong => {
                     trace!("Sending Pong");
+                    // TODO: Ideally, this should flush the `Framed<TcpStream> as Sink`
+                    // before starting the timeout.
                     let _ = session.send_packet(PacketType::Pong, vec![0, 0, 0, 0]);
                     *this.keep_alive_state = ExpectingPongAck;
                     this.timeout


### PR DESCRIPTION
Another approach to #1357 using the ideas from https://github.com/librespot-org/librespot/pull/1357#issuecomment-2386938448.

This looks like a big change, but much of it is just moving around code: `fn dispatch` is now a part of `DispatchTask` such that it has access to the fields of `DispatchTask` (namely, the timeout and state of the keepalive state machinery).

This is a little different from @roderickvd's idea: I've kept the `KeepAliveState` enum instead of just the `ping_received` flag, and instead there's only a single `Sleep` future around. The deadline of the latter is modified as required.

EDIT: Split into a few more commits now to make this easier to review. For testing, keep-alive events are logged at `TRACE` level.

Fixes #1340 
Closes #1357