### PR TITLE
Fix elided_named_lifetimes

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1534,7 +1534,7 @@ struct CommandSender<'a> {
 }
 
 impl<'a> CommandSender<'a> {
-    fn new(spirc: &'a mut SpircTask, cmd: MessageType) -> CommandSender<'_> {
+    fn new(spirc: &'a mut SpircTask, cmd: MessageType) -> CommandSender<'a> {
         let mut frame = protocol::spirc::Frame::new();
         // frame version
         frame.set_version(1);
@@ -1549,7 +1549,7 @@ impl<'a> CommandSender<'a> {
         CommandSender { spirc, frame }
     }
 
-    fn recipient(mut self, recipient: &'a str) -> CommandSender<'_> {
+    fn recipient(mut self, recipient: &'a str) -> CommandSender<'a> {
         self.frame.recipient.push(recipient.to_owned());
         self
     }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1534,7 +1534,7 @@ struct CommandSender<'a> {
 }
 
 impl<'a> CommandSender<'a> {
-    fn new(spirc: &'a mut SpircTask, cmd: MessageType) -> CommandSender<'a> {
+    fn new(spirc: &'a mut SpircTask, cmd: MessageType) -> Self {
         let mut frame = protocol::spirc::Frame::new();
         // frame version
         frame.set_version(1);
@@ -1549,13 +1549,13 @@ impl<'a> CommandSender<'a> {
         CommandSender { spirc, frame }
     }
 
-    fn recipient(mut self, recipient: &'a str) -> CommandSender<'a> {
+    fn recipient(mut self, recipient: &'a str) -> Self {
         self.frame.recipient.push(recipient.to_owned());
         self
     }
 
     #[allow(dead_code)]
-    fn state(mut self, state: protocol::spirc::State) -> CommandSender<'a> {
+    fn state(mut self, state: protocol::spirc::State) -> Self {
         *self.frame.state.mut_or_insert_default() = state;
         self
     }


### PR DESCRIPTION
I was compiling `librespot` with the `nightly` toolchain an noticed this warning

```
#10 106.1    Compiling librespot-connect v0.5.0-dev (/librespot/connect)
#10 106.2 warning: elided lifetime has a name
#10 106.2     --> connect/src/spirc.rs:1537:73
#10 106.2      |
#10 106.2 1536 | impl<'a> CommandSender<'a> {
#10 106.2      |      -- lifetime `'a` declared here
#10 106.2 1537 |     fn new(spirc: &'a mut SpircTask, cmd: MessageType) -> CommandSender<'_> {
#10 106.2      |                                                                         ^^ this elided lifetime gets resolved as `'a`
#10 106.2      |
#10 106.2      = note: `#[warn(elided_named_lifetimes)]` on by default
#10 106.2 
#10 106.2 warning: elided lifetime has a name
#10 106.2     --> connect/src/spirc.rs:1552:65
#10 106.2      |
#10 106.2 1536 | impl<'a> CommandSender<'a> {
#10 106.2      |      -- lifetime `'a` declared here
#10 106.2 ...
#10 106.2 1552 |     fn recipient(mut self, recipient: &'a str) -> CommandSender<'_> {
#10 106.2      |                                                                 ^^ this elided lifetime gets resolved as `'a`
#10 106.2 
```

Background: https://github.com/rust-lang/rust/pull/129207

This PR fixes the warning.