### PR TITLE
Exposing service to both IPv4 and IPv6, addressing remaining issues from #

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ https://github.com/librespot-org/librespot
 - [core] `Credentials.username` is now an `Option` (breaking)
 - [core] `Session::connect` tries multiple access points, retrying each one.
 - [core] Each access point connection now timesout after 3 seconds.
+- [core] Listen on both IPV4 and IPV6 on non-windows hosts
 - [main] `autoplay {on|off}` now acts as an override. If unspecified, `librespot`
   now follows the setting in the Connect client that controls it. (breaking)
 - [metadata] Most metadata is now retrieved with the `spclient` (breaking)

--- a/discovery/src/server.rs
+++ b/discovery/src/server.rs
@@ -4,9 +4,9 @@ use std::{
     convert::Infallible,
     net::{IpAddr, SocketAddr, TcpListener},
     pin::Pin,
+    str::FromStr,
     sync::{Arc, Mutex},
     task::{Context, Poll},
-    str::FromStr
 };
 
 use aes::cipher::{KeyIvInit, StreamCipher};

--- a/discovery/src/server.rs
+++ b/discovery/src/server.rs
@@ -2,10 +2,11 @@ use std::{
     borrow::Cow,
     collections::BTreeMap,
     convert::Infallible,
-    net::{Ipv4Addr, SocketAddr, TcpListener},
+    net::{IpAddr, SocketAddr, TcpListener},
     pin::Pin,
     sync::{Arc, Mutex},
     task::{Context, Poll},
+    str::FromStr
 };
 
 use aes::cipher::{KeyIvInit, StreamCipher};
@@ -266,7 +267,7 @@ pub struct DiscoveryServer {
 impl DiscoveryServer {
     pub fn new(config: Config, port: &mut u16) -> Result<Self, Error> {
         let (discovery, cred_rx) = RequestHandler::new(config);
-        let address = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), *port);
+        let address = SocketAddr::new(IpAddr::from_str("::0").unwrap(), *port);
 
         let (close_tx, close_rx) = oneshot::channel();
 


### PR DESCRIPTION
This is meant to address the remaining issues ("touch-up") in #1307, to get the changes ready for inclusion for release.