### PR TITLE
Update cross-compile docker image: `contrib/Dockerfile`

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -13,17 +13,18 @@
 # $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features alsa-backend
 # $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features alsa-backend
 
-FROM debian:stretch
+FROM debian:bookworm
 
-RUN echo "deb http://archive.debian.org/debian stretch main"                   > /etc/apt/sources.list
-RUN echo "deb http://archive.debian.org/debian stretch-proposed-updates main" >> /etc/apt/sources.list
-RUN echo "deb http://archive.debian.org/debian-security stretch/updates main" >> /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian bookworm-updates main" >> /etc/apt/sources.list
+RUN echo "deb http://deb.debian.org/debian-security bookworm-security main" >> /etc/apt/sources.list
 
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armhf
 RUN dpkg --add-architecture armel
 RUN apt-get update
 
+RUN apt-get install -y cmake libclang-dev
 RUN apt-get install -y curl git build-essential crossbuild-essential-arm64 crossbuild-essential-armel crossbuild-essential-armhf pkg-config
 RUN apt-get install -y libasound2-dev libasound2-dev:arm64 libasound2-dev:armel libasound2-dev:armhf
 RUN apt-get install -y libpulse0 libpulse0:arm64 libpulse0:armel libpulse0:armhf
@@ -33,14 +34,15 @@ ENV PATH="/root/.cargo/bin/:${PATH}"
 RUN rustup target add aarch64-unknown-linux-gnu
 RUN rustup target add arm-unknown-linux-gnueabi
 RUN rustup target add arm-unknown-linux-gnueabihf
+RUN cargo install bindgen-cli
 
 RUN mkdir /.cargo && \
     echo '[target.aarch64-unknown-linux-gnu]\nlinker = "aarch64-linux-gnu-gcc"' > /.cargo/config && \
     echo '[target.arm-unknown-linux-gnueabihf]\nlinker = "arm-linux-gnueabihf-gcc"' >> /.cargo/config && \
     echo '[target.arm-unknown-linux-gnueabi]\nlinker = "arm-linux-gnueabi-gcc"' >> /.cargo/config
 
-ENV CARGO_TARGET_DIR /build
-ENV CARGO_HOME /build/cache
+ENV CARGO_TARGET_DIR=/build
+ENV CARGO_HOME=/build/cache
 ENV PKG_CONFIG_ALLOW_CROSS=1
 ENV PKG_CONFIG_PATH_aarch64-unknown-linux-gnu=/usr/lib/aarch64-linux-gnu/pkgconfig/
 ENV PKG_CONFIG_PATH_arm-unknown-linux-gnueabihf=/usr/lib/arm-linux-gnueabihf/pkgconfig/


### PR DESCRIPTION
Fixes docker image's cross compile issues for `arm-unknown-linux-gnueabihf`.

Not sure if changes are desirable upstream, but fixed this for myself and thought that others might find it useful. 

```bash
error: failed to run custom build command for `aws-lc-sys v0.21.2`

Caused by:
  process didn't exit successfully: `/build/release/build/aws-lc-sys-d28a1b34df617185/build-script-main` (exit status: 101)
  --- stdout
  cargo:rerun-if-env-changed=AWS_LC_SYS_NO_PREFIX
  cargo:rerun-if-env-changed=AWS_LC_SYS_INTERNAL_BINDGEN
  cargo:rerun-if-env-changed=AWS_LC_SYS_EXTERNAL_BINDGEN
  cargo:rerun-if-env-changed=AWS_LC_SYS_NO_ASM
  cargo:rerun-if-env-changed=AWS_LC_SYS_CFLAGS
  cargo:rerun-if-env-changed=AWS_LC_SYS_PREBUILT_NASM
  cargo:rerun-if-env-changed=AWS_LC_SYS_C_STD
  cargo:rerun-if-env-changed=AWS_LC_SYS_CMAKE_BUILDER
  cargo:rerun-if-env-changed=AWS_LC_SYS_STATIC
  cargo:rerun-if-env-changed=CMAKE

  --- stderr
  Missing dependency: cmake
  thread 'main' panicked at /build/cache/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.21.2/builder/main.rs:315:40:
  called `Result::unwrap()` on an `Err` value: "Required build dependency is missing. Halting build."
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
warning: build failed, waiting for other jobs to finish...
...
cargo:warning=Generating bindings - external bindgen. Platform: arm-unknown-linux-gnueabihf
...
 --- stderr
  Consider installing the bindgen-cli: `cargo install --force --locked bindgen-cli`
  See our User Guide for more information about bindgen:https://aws.github.io/aws-lc-rs/index.html
  Failure invoking external bindgen! External bindgen command failed.
  thread 'main' panicked at /build/cache/registry/src/index.crates.io-6f17d22bba15001f/aws-lc-sys-0.21.2/builder/main.rs:559:5:
```