### PR TITLE
Fix initial volume showing zero but playing full volume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+### Fixed 
+
+- [connect] Fixes initial volume showing zero despite playing in full volume instead
+
 ## [0.5.0] - 2024-10-15
 
 This version is be a major departure from the architecture up until now. It

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1509,7 +1509,7 @@ impl SpircTask {
     fn set_volume(&mut self, volume: u16) {
         let old_volume = self.device.volume();
         let new_volume = volume as u32;
-        if old_volume != new_volume {
+        if old_volume != new_volume || self.mixer.volume() != volume {
             self.device.set_volume(new_volume);
             self.mixer.set_volume(volume);
             if let Some(cache) = self.session.cache() {


### PR DESCRIPTION
Initial device volume shows `0`, which is why the intial volume is not properly set. Mixer-volume shows the correct volume for this case.

Fixes #1325 