### PR TITLE
Get token with client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [core] Add `get_token_with_client_id()` to get a token for a specific vlient ID
 - [core] Add `login` (mobile) and `auth_token` retrieval via login5
 - [core] Add `OS` and `os_version` to `config.rs`
 - [discovery] Added a new MDNS/DNS-SD backend which connects to Avahi via D-Bus.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [core] Add `get_token_with_client_id()` to get a token for a specific vlient ID
+- [core] Add `get_token_with_client_id()` to get a token for a specific client ID
 - [core] Add `login` (mobile) and `auth_token` retrieval via login5
 - [core] Add `OS` and `os_version` to `config.rs`
 - [discovery] Added a new MDNS/DNS-SD backend which connects to Avahi via D-Bus.

--- a/core/src/token.rs
+++ b/core/src/token.rs
@@ -61,7 +61,7 @@ impl TokenProvider {
     // scopes must be comma-separated
     pub async fn get_token(&self, scopes: &str) -> Result<Token, Error> {
         let client_id = self.session().client_id();
-        return self.get_token_with_client_id(scopes, &client_id).await;
+        self.get_token_with_client_id(scopes, &client_id).await
     }
 
     pub async fn get_token_with_client_id(

--- a/core/src/token.rs
+++ b/core/src/token.rs
@@ -61,6 +61,11 @@ impl TokenProvider {
     // scopes must be comma-separated
     pub async fn get_token(&self, scopes: &str) -> Result<Token, Error> {
         let client_id = self.session().client_id();
+        return self.get_token_with_client_id(scopes, &client_id).await;
+    }
+
+    // scopes must be comma-separated
+    pub async fn get_token_with_client_id(&self, scopes: &str, client_id: &str) -> Result<Token, Error> {
         if client_id.is_empty() {
             return Err(Error::invalid_argument("Client ID cannot be empty"));
         }

--- a/core/src/token.rs
+++ b/core/src/token.rs
@@ -58,6 +58,9 @@ impl TokenProvider {
         })
     }
 
+    // Not all combinations of scopes and client ID are allowed.
+    // Depending on the client ID currently used, the function may return an error for specific scopes.
+    // In this case get_token_with_client_id() can be used, where an appropriate client ID can be provided.
     // scopes must be comma-separated
     pub async fn get_token(&self, scopes: &str) -> Result<Token, Error> {
         let client_id = self.session().client_id();

--- a/core/src/token.rs
+++ b/core/src/token.rs
@@ -64,8 +64,11 @@ impl TokenProvider {
         return self.get_token_with_client_id(scopes, &client_id).await;
     }
 
-    // scopes must be comma-separated
-    pub async fn get_token_with_client_id(&self, scopes: &str, client_id: &str) -> Result<Token, Error> {
+    pub async fn get_token_with_client_id(
+        &self,
+        scopes: &str,
+        client_id: &str,
+    ) -> Result<Token, Error> {
         if client_id.is_empty() {
             return Err(Error::invalid_argument("Client ID cannot be empty"));
         }


### PR DESCRIPTION
Fixes https://github.com/librespot-org/librespot/issues/1331

This PR fixes the issue for getting a token error when providing a specific combination of scopes and client_id. A new function `get_token_with_client_id()` was added to be able to provide a specific client_id when asking for a token. 

The original `get_token()` function was kept in order to be fully backward compatible and not break any get_token() function call (for v0.5.0 and dev).