### PR TITLE
feat: use webpki as rustls roots on non-desktop platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [core] Fix "no native root CA certificates found" on platforms unsupported
+  by `rustls-native-certs`.
+
 ### Removed
 
 ## [0.6.0] - 2024-10-30

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1534,6 +1534,7 @@ dependencies = [
  "tokio-rustls 0.25.0",
  "tower-service",
  "webpki",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -1567,6 +1568,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tower-service",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -1586,6 +1588,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tower-service",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -2900,7 +2903,7 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "webpki-roots",
+ "webpki-roots 0.25.4",
  "winreg",
 ]
 
@@ -3726,6 +3729,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.26.0",
  "tungstenite",
+ "webpki-roots 0.26.7",
 ]
 
 [[package]]
@@ -4095,6 +4099,15 @@ name = "webpki-roots"
 version = "0.25.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f20c57d8d7db6d3b86154206ae5d8fba62dd39573114de97c2cb0578251f8e1"
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
+dependencies = [
+ "rustls-pki-types",
+]
 
 [[package]]
 name = "which"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -32,8 +32,6 @@ http = "1.0"
 hyper = { version = "1.3", features = ["http1", "http2"] }
 hyper-util = { version = "0.1", features = ["client"] }
 http-body-util = "0.1.1"
-hyper-proxy2 = { version = "0.1", default-features = false, features = ["rustls"] }
-hyper-rustls = { version = "0.27.2", features = ["http2"] }
 log = "0.4"
 nonzero_ext = "0.3"
 num-bigint = { version = "0.4", features = ["rand"] }
@@ -58,11 +56,22 @@ thiserror = "1.0"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "parking_lot", "rt", "sync", "time"] }
 tokio-stream = "0.1"
-tokio-tungstenite = { version = "0.24", default-features = false, features = ["rustls-tls-native-roots"] }
 tokio-util = { version = "0.7", features = ["codec"] }
 url = "2"
 uuid = { version = "1", default-features = false, features = ["fast-rng", "v4"] }
 data-encoding = "2.5"
+
+# Eventually, this should use rustls-platform-verifier to unify the platform-specific dependencies
+# but currently, hyper-proxy2 and tokio-tungstenite do not support it.
+[target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
+hyper-proxy2 = { version = "0.1", default-features = false, features = ["rustls"] }
+hyper-rustls = { version = "0.27.2", default-features = false, features = ["aws-lc-rs", "http1", "logging", "tls12", "native-tokio", "http2"] }
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["rustls-tls-native-roots"] }
+
+[target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))'.dependencies]
+hyper-proxy2 = { version = "0.1", default-features = false, features = ["rustls-webpki"] }
+hyper-rustls = { version = "0.27.2", default-features = false, features = ["aws-lc-rs", "http1", "logging", "tls12", "webpki-tokio", "http2"] }
+tokio-tungstenite = { version = "0.24", default-features = false, features = ["rustls-tls-webpki-roots"] }
 
 [build-dependencies]
 rand = "0.8"


### PR DESCRIPTION
Automatically choose to use `rustls-webpki` if the platform doesn't support `rustls-native-certs` (ie: non-desktop platforms).

Main motivation is `rustls-native-certs` is not supported by all platforms, and therefore HTTPs calls will error with 0 native roots

Partially fixes: #1399