### PR TITLE
fix: streaming on Android devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [core] Fix all APs rejecting with "TryAnotherAP" when connecting session
+  on Android platform.
+- [core] Fix "Invalid Credentials" when using a Keymaster access token and
+  client ID on Android platform.
+
 ### Removed
 
 ## [0.6.0] - 2024-10-30

--- a/core/src/connection/handshake.rs
+++ b/core/src/connection/handshake.rs
@@ -111,7 +111,6 @@ where
     thread_rng().fill_bytes(&mut client_nonce);
 
     let platform = match crate::config::OS {
-        "android" => Platform::PLATFORM_ANDROID_ARM,
         "freebsd" | "netbsd" | "openbsd" => match ARCH {
             "x86_64" => Platform::PLATFORM_FREEBSD_X86_64,
             _ => Platform::PLATFORM_FREEBSD_X86,
@@ -120,7 +119,12 @@ where
             "aarch64" => Platform::PLATFORM_IPHONE_ARM64,
             _ => Platform::PLATFORM_IPHONE_ARM,
         },
-        "linux" => match ARCH {
+        // Rather than sending `Platform::PLATFORM_ANDROID_ARM` for "android",
+        // we are spoofing "android" as "linux", as otherwise during Session::connect
+        // all APs will reject the client with TryAnotherAP, no matter the credentials
+        // used was obtained via OAuth using KEYMASTER or ANDROID's client ID or
+        // Login5Manager::login
+        "linux" | "android" => match ARCH {
             "arm" | "aarch64" => Platform::PLATFORM_LINUX_ARM,
             "blackfin" => Platform::PLATFORM_LINUX_BLACKFIN,
             "mips" => Platform::PLATFORM_LINUX_MIPS,

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -101,7 +101,7 @@ pub async fn authenticate(
 
     let cpu_family = match std::env::consts::ARCH {
         "blackfin" => CpuFamily::CPU_BLACKFIN,
-        "arm" | "arm64" => CpuFamily::CPU_ARM,
+        "arm" | "aarch64" => CpuFamily::CPU_ARM,
         "ia64" => CpuFamily::CPU_IA64,
         "mips" => CpuFamily::CPU_MIPS,
         "ppc" => CpuFamily::CPU_PPC,

--- a/core/src/login5.rs
+++ b/core/src/login5.rs
@@ -75,6 +75,11 @@ impl Login5Manager {
     async fn login5_request(&self, login: Login_method) -> Result<LoginOk, Error> {
         let client_id = match OS {
             "macos" | "windows" => self.session().client_id(),
+            // StoredCredential is used to get an access_token from Session credentials.
+            // Using the session client_id allows user to use Keymaster on Android/IOS
+            // if their Credentials::with_access_token was obtained there, assuming
+            // they have overriden the SessionConfig::client_id with the Keymaster's.
+            _ if matches!(login, Login_method::StoredCredential(_)) => self.session().client_id(),
             _ => SessionConfig::default().client_id,
         };
 


### PR DESCRIPTION
Fixes: #1399 

I have mostly figured out the nuances and rules to get streaming on Android to work again.

1. If we send `client_hello` that has `platform == Platform::PLATFORM_ANDROID_ARM`, it does not matter what credentials we send to the AP, all APs will error with `TryAnotherAP`, tested true for credentials obtained via
    - oauth flow access_token with Keymaster client ID, requesting `streaming` scope (Credentials::with_access_token)
    - oauth flow access_token with Android client ID, requesting `streaming` scope (Credentials::with_access_token)
    - login5 flow with Android client ID
        ```rs
        let credentials = Credentials {
            username: Some(id),
            auth_type: AuthenticationType::AUTHENTICATION_STORED_SPOTIFY_CREDENTIALS,
            auth_data, // stored_credentials from Login5Manager::login
        };
        ```
    Therefore the idea is to present ourselves as Linux in `client_hello`, additional spoofing isn't required, `authenticate` can still present ourselves as `Android` OS after that. With just this, playback from credentials obtained from `Login5Manager::login` is already working.
2. In the case where on Android and user has an access_token that is obtained via Keymaster client ID, `Login5Manager::login5_request` must use the same Keymaster client ID to get an api access token for `Track::get`. Prior to this PR, on platforms such as Android/IOS where we have specific client IDs, this scenario always fails with `InvalidCredentials`. 
3. Fix one occurrence of `arm64` when matching against `std::env::consts::ARCH`

If this is merged, to get playback on Android working, there's 2 ways.
1. oauth flow using Keymaster client ID, when initializing `Session`, manually override `SessionConfig::client_id` to be Keymaster's client ID, this is the same flow as using librespot on desktop platforms. ([example](https://github.com/SilverMira/librespot_android_cert_issue/blob/5639653f68754fd9e76e6ea8ccd7e7c32598dcc2/rust/src/api/simple.rs#L130))
2. login5 flow and use the `stored_credentials` returned from `Login5Manager::login` as credentials for `Session::connect` ([example](https://github.com/SilverMira/librespot_android_cert_issue/blob/5639653f68754fd9e76e6ea8ccd7e7c32598dcc2/rust/src/api/simple.rs#L36))

Additionally, from my testing, it appears that although we can initiate an oauth flow using Android client ID with scope streaming, I have never gotten it to work with Session::connect, `PremiumAccountRequired` error always appears during `Session::connect`, though in the first place, I couldn't find any references that mentioned this is possible anyways.