### PR TITLE
Update/dependencies

### DIFF
--- a/.devcontainer/Dockerfile.alpine
+++ b/.devcontainer/Dockerfile.alpine
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 ARG alpine_version=alpine3.18
-ARG rust_version=1.74.0
+ARG rust_version=1.75.0
 FROM rust:${rust_version}-${alpine_version}
 
 ENV CARGO_REGISTRIES_CRATES_IO_PROTOCOL="sparse"

--- a/.devcontainer/Dockerfile.alpine
+++ b/.devcontainer/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG alpine_version=alpine3.18
+ARG alpine_version=alpine3.19
 ARG rust_version=1.75.0
 FROM rust:${rust_version}-${alpine_version}
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,9 +161,9 @@ dependencies = [
 
 [[package]]
 name = "async-io"
-version = "2.3.4"
+version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "444b0228950ee6501b3568d3c93bf1176a1fdbc3b758dcd9475046d30f4dc7e8"
+checksum = "43a2b323ccce0a1d90b449fd71f2a06ca7faa7c54c2751f06c9bd851fc061059"
 dependencies = [
  "async-lock",
  "cfg-if",
@@ -984,9 +984,9 @@ checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-lite"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1fa2f9765705486b33fd2acf1577f8ec449c2ba1f318ae5447697b7c08d210"
+checksum = "cef40d21ae2c515b51041df9ed313ed21e572df340ea58a922a0aefe7e8891a1"
 dependencies = [
  "fastrand",
  "futures-core",
@@ -2118,7 +2118,7 @@ dependencies = [
  "symphonia",
  "thiserror 2.0.7",
  "tokio",
- "zerocopy",
+ "zerocopy 0.8.13",
 ]
 
 [[package]]
@@ -2645,9 +2645,9 @@ checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
 
 [[package]]
 name = "polling"
-version = "3.7.3"
+version = "3.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc2790cd301dec6cd3b7a025e4815cf825724a51c98dccfe6a3e55f05ffb6511"
+checksum = "a604568c3202727d1507653cb121dbd627a58684eb09a820fd746bee38b4442f"
 dependencies = [
  "cfg-if",
  "concurrent-queue",
@@ -2697,7 +2697,7 @@ version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4602,7 +4602,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
  "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67914ab451f3bfd2e69e5e9d2ef3858484e7074d63f204fd166ec391b54de21d"
+dependencies = [
+ "zerocopy-derive 0.8.13",
 ]
 
 [[package]]
@@ -4610,6 +4619,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7988d73a4303ca289df03316bc490e934accf371af6bc745393cf3c2c5c4f25d"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -216,7 +216,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -357,7 +357,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.85",
+ "syn 2.0.90",
  "which",
 ]
 
@@ -376,7 +376,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -685,7 +685,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -696,7 +696,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -749,7 +749,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -759,7 +759,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -829,7 +829,7 @@ checksum = "de0d48a183585823424a4ce1aa132d174a6a81bd540895822eb4c8373a8e49e8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1003,7 +1003,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1124,7 +1124,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -1194,7 +1194,7 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -1771,7 +1771,7 @@ dependencies = [
  "combine",
  "jni-sys",
  "log",
- "thiserror",
+ "thiserror 1.0.65",
  "walkdir",
  "windows-sys 0.45.0",
 ]
@@ -1861,7 +1861,7 @@ dependencies = [
  "multimap",
  "rand",
  "socket2",
- "thiserror",
+ "thiserror 1.0.65",
  "tokio",
 ]
 
@@ -1932,7 +1932,7 @@ dependencies = [
  "log",
  "sha1",
  "sysinfo",
- "thiserror",
+ "thiserror 2.0.7",
  "tokio",
  "url",
 ]
@@ -1952,7 +1952,7 @@ dependencies = [
  "log",
  "parking_lot",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.7",
  "tokio",
 ]
 
@@ -1968,7 +1968,7 @@ dependencies = [
  "protobuf",
  "rand",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.7",
  "tokio",
  "tokio-stream",
  "uuid",
@@ -2019,7 +2019,7 @@ dependencies = [
  "sha1",
  "shannon",
  "sysinfo",
- "thiserror",
+ "thiserror 2.0.7",
  "time",
  "tokio",
  "tokio-stream",
@@ -2056,7 +2056,7 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "sha1",
- "thiserror",
+ "thiserror 2.0.7",
  "tokio",
  "zbus",
 ]
@@ -2073,7 +2073,7 @@ dependencies = [
  "protobuf",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.7",
  "uuid",
 ]
 
@@ -2084,7 +2084,7 @@ dependencies = [
  "env_logger",
  "log",
  "oauth2",
- "thiserror",
+ "thiserror 2.0.7",
  "url",
 ]
 
@@ -2115,7 +2115,7 @@ dependencies = [
  "sdl2",
  "shell-words",
  "symphonia",
- "thiserror",
+ "thiserror 2.0.7",
  "tokio",
  "zerocopy",
 ]
@@ -2239,7 +2239,7 @@ dependencies = [
  "log",
  "ndk-sys",
  "num_enum",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -2354,7 +2354,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2415,7 +2415,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2443,7 +2443,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "sha2",
- "thiserror",
+ "thiserror 1.0.65",
  "url",
 ]
 
@@ -2706,7 +2706,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "64d1ec885c64d0457d564db4ec299b2dae3f9c02808b8ad9c3a089c591b18033"
 dependencies = [
  "proc-macro2",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -2731,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -2746,7 +2746,7 @@ checksum = "a3a7c64d9bf75b1b8d981124c14c179074e8caa7dfe7b6a12e6222ddcd0c8f72"
 dependencies = [
  "once_cell",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -2761,7 +2761,7 @@ dependencies = [
  "protobuf-parse",
  "regex",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -2772,7 +2772,7 @@ checksum = "9b445cf83c9303695e6c423d269759e139b6182d2f1171e18afda7078a764336"
 dependencies = [
  "protobuf",
  "protobuf-support",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -2787,7 +2787,7 @@ dependencies = [
  "protobuf",
  "protobuf-support",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.65",
  "which",
 ]
 
@@ -2797,7 +2797,7 @@ version = "3.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b088fd20b938a875ea00843b6faf48579462630015c3788d397ad6a786663252"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -2960,7 +2960,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
 dependencies = [
  "cpal",
- "thiserror",
+ "thiserror 1.0.65",
 ]
 
 [[package]]
@@ -3230,7 +3230,7 @@ checksum = "de523f781f095e28fa605cdce0f8307e451cc0fd14e2eb4cd2e98a355b147766"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3263,7 +3263,7 @@ checksum = "6c64451ba24fc7a6a2d60fc75dd9c83c90903b19028d4eff35e88fc1e86564e9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3514,9 +3514,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.85"
+version = "2.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5023162dfcd14ef8f32034d8bcd4cc5ddc61ef7a247c024a33e24e1f24d21b56"
+checksum = "919d3b74a5dd0ccd15aeb8f93e7006bd9e14c295087c9896a110f490752bcf31"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3601,7 +3601,16 @@ version = "1.0.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.65",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93605438cbd668185516ab499d589afb7ee1859ea3d5fc8f6b0755e1c7443767"
+dependencies = [
+ "thiserror-impl 2.0.7",
 ]
 
 [[package]]
@@ -3612,7 +3621,18 @@ checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d8749b4531af2117677a5fcd12b1348a3fe2b81e36e61ffeac5c4aa3273e36"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3700,7 +3720,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3835,7 +3855,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -3869,7 +3889,7 @@ dependencies = [
  "rustls 0.23.16",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 1.0.65",
  "utf-8",
 ]
 
@@ -4060,7 +4080,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
  "wasm-bindgen-shared",
 ]
 
@@ -4094,7 +4114,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -4252,7 +4272,7 @@ checksum = "9107ddc059d5b6fbfbffdfa7a7fe3e22a226def0b2608f72e9d552763d3e1ad7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4263,7 +4283,7 @@ checksum = "29bee4b38ea3cde66011baa44dba677c432a78593e202392d1e9070cf2a7fca7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4560,7 +4580,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
  "zvariant_utils",
 ]
 
@@ -4593,7 +4613,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]
 
 [[package]]
@@ -4624,7 +4644,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
  "zvariant_utils",
 ]
 
@@ -4636,5 +4656,5 @@ checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.85",
+ "syn 2.0.90",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1156,13 +1156,14 @@ dependencies = [
 
 [[package]]
 name = "governor"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68a7f542ee6b35af73b06abc0dad1c1bae89964e4e253bc4b587b91c9637867b"
+checksum = "842dc78579ce01e6a1576ad896edc92fca002dd60c9c3746b7fc2bec6fb429d0"
 dependencies = [
  "cfg-if",
- "futures",
+ "futures-sink",
  "futures-timer",
+ "futures-util",
  "no-std-compat",
  "nonzero_ext",
  "parking_lot",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2803,9 +2803,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.37.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "f22f29bdff3987b4d8632ef95fd6424ec7e4e0a57e2f4fc63e489e75357f6a03"
 dependencies = [
  "memchr",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1817,9 +1817,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.168"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "5aaeb2981e0606ca11d79718f8bb01164f1d6ed75080182d3abf017e6d244b6d"
 
 [[package]]
 name = "libloading"
@@ -3531,9 +3531,9 @@ checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
 
 [[package]]
 name = "sysinfo"
-version = "0.31.4"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "355dbe4f8799b304b05e1b0f05fc59b2a18d36645cf169607da45bde2f69a1be"
+checksum = "948512566b1895f93b1592c7574baeb2de842f224f2aab158799ecadb8ebbb46"
 dependencies = [
  "core-foundation-sys",
  "libc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2956,12 +2956,11 @@ dependencies = [
 
 [[package]]
 name = "rodio"
-version = "0.19.0"
+version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6006a627c1a38d37f3d3a85c6575418cfe34a5392d60a686d0071e1c8d427acb"
+checksum = "e7ceb6607dd738c99bc8cb28eff249b7cd5c8ec88b9db96c0608c1480d140fb1"
 dependencies = [
  "cpal",
- "thiserror 1.0.65",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ futures-util = { version = "0.3", default-features = false }
 getopts = "0.2"
 log = "0.4"
 sha1 = "0.10"
-sysinfo = { version = "0.31.3", default-features = false, features = ["system"] }
+sysinfo = { version = "0.33.0", default-features = false, features = ["system"] }
 thiserror = "1.0"
 tokio = { version = "1.40", features = ["rt", "macros", "signal", "sync", "parking_lot", "process"] }
 url = "2.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ getopts = "0.2"
 log = "0.4"
 sha1 = "0.10"
 sysinfo = { version = "0.33.0", default-features = false, features = ["system"] }
-thiserror = "1.0"
+thiserror = "2.0"
 tokio = { version = "1.40", features = ["rt", "macros", "signal", "sync", "parking_lot", "process"] }
 url = "2.2"
 

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -23,5 +23,5 @@ http-body-util = "0.1.1"
 log = "0.4"
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 tempfile = "3"
-thiserror = "1.0"
+thiserror = "2.0"
 tokio = { version = "1", features = ["macros", "parking_lot", "sync"] }

--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -14,7 +14,7 @@ log = "0.4"
 protobuf = "3.5"
 rand = "0.8"
 serde_json = "1.0"
-thiserror = "1.0"
+thiserror = "2.0"
 tokio = { version = "1", features = ["macros", "parking_lot", "sync"] }
 tokio-stream = "0.1"
 uuid = { version = "1.11.0", features = ["v4"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -44,7 +44,7 @@ pbkdf2 = { version = "0.12", default-features = false, features = ["hmac"] }
 pin-project-lite = "0.2"
 priority-queue = "2.0"
 protobuf = "3.5"
-quick-xml = { version = "0.36.1", features = ["serialize"] }
+quick-xml = { version = "0.37.1", features = ["serialize"] }
 rand = "0.8"
 rsa = "0.9.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -52,7 +52,7 @@ serde_json = "1.0"
 sha1 = { version = "0.10", features = ["oid"] }
 shannon = "0.2"
 sysinfo = { version = "0.33.0", default-features = false, features = ["system"] }
-thiserror = "1.0"
+thiserror = "2.0"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "parking_lot", "rt", "sync", "time"] }
 tokio-stream = "0.1"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -25,7 +25,7 @@ bytes = "1"
 form_urlencoded = "1.0"
 futures-core = "0.3"
 futures-util = { version = "0.3", features = ["alloc", "bilock", "sink", "unstable"] }
-governor = { version = "0.6", default-features = false, features = ["std", "jitter"] }
+governor = { version = "0.8", default-features = false, features = ["std", "jitter"] }
 hmac = "0.12"
 httparse = "1.7"
 http = "1.0"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -51,7 +51,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 sha1 = { version = "0.10", features = ["oid"] }
 shannon = "0.2"
-sysinfo = { version = "0.31.3", default-features = false, features = ["system"] }
+sysinfo = { version = "0.33.0", default-features = false, features = ["system"] }
 thiserror = "1.0"
 time = { version = "0.3", features = ["formatting", "parsing"] }
 tokio = { version = "1", features = ["io-util", "macros", "net", "parking_lot", "rt", "sync", "time"] }

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -390,7 +390,7 @@ impl Session {
     }
 
     pub fn set_session_id(&self, session_id: String) {
-        self.0.data.write().session_id = session_id.to_owned();
+        session_id.clone_into(&mut self.0.data.write().session_id);
     }
 
     pub fn device_id(&self) -> &str {
@@ -450,7 +450,7 @@ impl Session {
     }
 
     pub fn set_auth_data(&self, auth_data: &[u8]) {
-        self.0.data.write().auth_data = auth_data.to_owned();
+        auth_data.clone_into(&mut self.0.data.write().auth_data);
     }
 
     pub fn country(&self) -> String {

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -30,7 +30,7 @@ serde_json = "1.0"
 sha1 = "0.10"
 thiserror = "2.0"
 tokio = { version = "1", features = ["parking_lot", "sync", "rt"] }
-zbus = { version = "4", default-features = false, features = ["tokio"], optional = true }
+zbus = { version = "4", default-features = false, features = ["tokio"], optional = true } # zbus > 4 requires a MSRV of 1.80
 
 [dependencies.librespot-core]
 path = "../core"

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -28,7 +28,7 @@ serde = { version = "1", default-features = false, features = ["derive"], option
 serde_repr = "0.1"
 serde_json = "1.0"
 sha1 = "0.10"
-thiserror = "1.0"
+thiserror = "2.0"
 tokio = { version = "1", features = ["parking_lot", "sync", "rt"] }
 zbus = { version = "4", default-features = false, features = ["tokio"], optional = true }
 

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -13,7 +13,7 @@ async-trait = "0.1"
 bytes = "1"
 log = "0.4"
 protobuf = "3.5"
-thiserror = "1"
+thiserror = "2.0"
 uuid = { version = "1", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/oauth/Cargo.toml
+++ b/oauth/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2021"
 [dependencies]
 log = "0.4"
 oauth2 = "4.4"
-thiserror = "1.0"
+thiserror = "2.0"
 url = "2.2"
 
 [dev-dependencies]

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -27,7 +27,7 @@ parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 shell-words = "1.1"
 thiserror = "2.0"
 tokio = { version = "1", features = ["parking_lot", "rt", "rt-multi-thread", "sync"] }
-zerocopy = { version = "0.7.32", features = ["derive"] }
+zerocopy = { version = "0.8.13", features = ["derive"] }
 
 # Backends
 alsa            = { version = "0.9.0", optional = true }

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -42,7 +42,7 @@ gstreamer-audio = { version = "0.23.0", optional = true }
 glib            = { version = "0.20.3", optional = true }
 
 # Rodio dependencies
-rodio           = { version = "0.19.0", optional = true, default-features = false }
+rodio           = { version = "0.20.1", optional = true, default-features = false }
 cpal            = { version = "0.15.1", optional = true }
 
 # Container and audio decoder

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -25,7 +25,7 @@ futures-util = "0.3"
 log = "0.4"
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }
 shell-words = "1.1"
-thiserror = "1"
+thiserror = "2.0"
 tokio = { version = "1", features = ["parking_lot", "rt", "rt-multi-thread", "sync"] }
 zerocopy = { version = "0.7.32", features = ["derive"] }
 

--- a/playback/src/audio_backend/mod.rs
+++ b/playback/src/audio_backend/mod.rs
@@ -48,7 +48,7 @@ macro_rules! sink_as_bytes {
     () => {
         fn write(&mut self, packet: AudioPacket, converter: &mut Converter) -> SinkResult<()> {
             use crate::convert::i24;
-            use zerocopy::AsBytes;
+            use zerocopy::IntoBytes;
             match packet {
                 AudioPacket::Samples(samples) => match self.format {
                     AudioFormat::F64 => self.write_bytes(samples.as_bytes()),

--- a/playback/src/convert.rs
+++ b/playback/src/convert.rs
@@ -1,7 +1,7 @@
 use crate::dither::{Ditherer, DithererBuilder};
-use zerocopy::AsBytes;
+use zerocopy::{Immutable, IntoBytes};
 
-#[derive(AsBytes, Copy, Clone, Debug)]
+#[derive(Immutable, IntoBytes, Copy, Clone, Debug)]
 #[allow(non_camel_case_types)]
 #[repr(transparent)]
 pub struct i24([u8; 3]);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1872,7 +1872,7 @@ async fn main() {
             {
                 Ok(d) => break Some(d),
                 Err(e) => {
-                    sys.refresh_processes(ProcessesToUpdate::All);
+                    sys.refresh_processes(ProcessesToUpdate::All, true);
 
                     if System::uptime() <= 1 {
                         debug!("Retrying to initialise discovery: {e}");

--- a/test.sh
+++ b/test.sh
@@ -19,3 +19,5 @@ cargo check -p librespot-core
 cargo hack check --no-dev-deps --each-feature -p librespot-discovery
 cargo hack check --no-dev-deps --each-feature -p librespot-playback
 cargo hack check --no-dev-deps --each-feature
+
+cargo clean

--- a/test.sh
+++ b/test.sh
@@ -2,6 +2,16 @@
 
 set -e
 
+clean() {
+    # some shells will call EXIT after the INT signal
+    # causing EXIT trap to be executed, so we trap EXIT after INT
+    trap '' EXIT
+    
+    cargo clean
+}
+
+trap clean INT QUIT TERM EXIT
+
 # this script runs the tests and checks that also run as part of the`test.yml` github action workflow
 cargo clean
 cargo fmt --all -- --check
@@ -19,5 +29,3 @@ cargo check -p librespot-core
 cargo hack check --no-dev-deps --each-feature -p librespot-discovery
 cargo hack check --no-dev-deps --each-feature -p librespot-playback
 cargo hack check --no-dev-deps --each-feature
-
-cargo clean


### PR DESCRIPTION
Updates 

```
librespot
/workspaces/librespot/Cargo.toml
dependency  current  upgrade
sysinfo     0.31.4   0.33.0
thiserror   1.0.69   2.0.7

librespot-audio
/workspaces/librespot/audio/Cargo.toml
dependency  current  upgrade
thiserror   1.0.69   2.0.7

librespot-core
/workspaces/librespot/core/Cargo.toml
dependency  current  upgrade
governor    0.6.3    0.8.0
quick-xml   0.36.2   0.37.1
sysinfo     0.31.4   0.33.0
thiserror   1.0.69   2.0.7

librespot-oauth
/workspaces/librespot/oauth/Cargo.toml
dependency  current  upgrade
thiserror   1.0.69   2.0.7

librespot-connect
/workspaces/librespot/connect/Cargo.toml
dependency  current  upgrade
thiserror   1.0.69   2.0.7

librespot-playback
/workspaces/librespot/playback/Cargo.toml
dependency  current  upgrade
rodio       0.19.0   0.20.1
thiserror   1.0.69   2.0.7
zerocopy    0.7.35   0.8.13

librespot-metadata
/workspaces/librespot/metadata/Cargo.toml
dependency  current  upgrade
thiserror   1.0.69   2.0.7

librespot-discovery
/workspaces/librespot/discovery/Cargo.toml
dependency  current  upgrade
thiserror   1.0.69   2.0.7
```