### PR TITLE
Dealer: Improve disconnect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [connect] Add `seek_to` field to `SpircLoadCommand` (breaking)
 - [connect] Add `repeat_track` field to `SpircLoadCommand` (breaking)
+- [connect] Add `pause` parameter to `Spirc::disconnect` method (breaking)
 - [playback] Add `track` field to `PlayerEvent::RepeatChanged` (breaking)
 - [core] Add `request_with_options` and `request_with_protobuf_and_options` to `SpClient`
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -438,12 +438,14 @@ impl SpircTask {
                         error!("error updating connect state for volume update: {why}")
                     }
                 },
-                else => {
-                    if let Err(why) = self.handle_disconnect().await {
-                        error!("error during disconnect: {why}")
-                    }
-                    break
-                }
+                else => break,
+            }
+        }
+
+        if !self.shutdown && self.connect_state.is_active() {
+            warn!("unexpected shutdown");
+            if let Err(why) = self.handle_disconnect().await {
+                error!("error during disconnecting: {why}")
             }
         }
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1555,7 +1555,7 @@ impl SpircTask {
             );
 
             if self.session.session_id() != session.session_id {
-                self.session.set_session_id(session.session_id.clone());
+                self.session.set_session_id(&session.session_id);
                 self.connect_state.set_session_id(session.session_id);
             }
         } else {

--- a/core/src/session.rs
+++ b/core/src/session.rs
@@ -389,7 +389,7 @@ impl Session {
         self.0.data.read().session_id.clone()
     }
 
-    pub fn set_session_id(&self, session_id: String) {
+    pub fn set_session_id(&self, session_id: &str) {
         session_id.clone_into(&mut self.0.data.write().session_id);
     }
 


### PR DESCRIPTION
Disconnecting now only handles disconnecting and not pausing/stopping. But because it feels unnatural to call disconnect on the `Spirc` and not having the player pause, the method now provides an additional option to explicitly pause.

improves the behavior in #1419 but doesn't fix it