### PR TITLE
discovery: don't panic on libmdns errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   on Android platform.
 - [core] Fix "Invalid Credentials" when using a Keymaster access token and
   client ID on Android platform.
-= [connect] Fix "play" command not handled if missing "offset" property
+- [connect] Fix "play" command not handled if missing "offset" property
+- [discovery] Fix libmdns zerconf setup errors not propagating to the main task.
 
 ### Removed
 

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -396,7 +396,7 @@ fn launch_libmdns(
 
     let task_handle = tokio::task::spawn_blocking(move || {
         let inner = move || -> Result<(), DiscoveryError> {
-            let svc = if !zeroconf_ip.is_empty() {
+            let responder = if !zeroconf_ip.is_empty() {
                 libmdns::Responder::spawn_with_ip_list(
                     &tokio::runtime::Handle::current(),
                     zeroconf_ip,
@@ -404,9 +404,9 @@ fn launch_libmdns(
             } else {
                 libmdns::Responder::spawn(&tokio::runtime::Handle::current())
             }
-            .map_err(|e| DiscoveryError::DnsSdError(Box::new(e)))
-            .unwrap()
-            .register(
+            .map_err(|e| DiscoveryError::DnsSdError(Box::new(e)))?;
+
+            let svc = responder.register(
                 DNS_SD_SERVICE_NAME.to_owned(),
                 name.into_owned(),
                 port,


### PR DESCRIPTION
Small improvement to discovery error handling (in fact, with the design of the code with an `inner` method which allows using the `?` operator, I suspect this was the intended code in the first place). Partially fixes #1404 by yielding the error to the main task, which can exit librespot an in turn give the service manager a chance to restart.

In detail: On panic, the discovery task crashes, but the main program is not notified of this. Returning an error will result in the Discovery stream yielding None, serving as notification to the application (which might shutdown with error, for example, if no other means of authentication is available).