### PR TITLE
Handle 'None' uri or empty string uri in transfer command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Fix "play" command not handled if missing "offset" property
 - [discovery] Fix libmdns zerconf setup errors not propagating to the main task.
 - [metadata] `Show::trailer_uri` is now optional since it isn't always present (breaking)
+- [connect] Handle transfer of playback with empty "uri" field
 
 ### Removed
 

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -342,7 +342,7 @@ impl ConnectState {
                 Err(StateError::InvalidTrackUri(Some(uri.clone())))?
             }
             (Some(uri), _) if !uri.is_empty() => SpotifyId::from_uri(uri)?,
-            (None, Some(gid)) if !gid.is_empty() => SpotifyId::from_raw(gid)?,
+            (_, Some(gid)) if !gid.is_empty() => SpotifyId::from_raw(gid)?,
             _ => Err(StateError::InvalidTrackUri(None))?,
         };
 


### PR DESCRIPTION
Fixes #1438 

The `uri` field of `ContextTrack` protobuf message was an empty string in my case.
The pattern matching here accepted only `None` so did not try to get the track by `gid`.
Once we reach this final matcher, `uri` is either `None` or an empty string so this should not cause any issues.