### PR TITLE
Build debian package with github actions

### DIFF
--- a/.github/workflows/build_deb_pkg.yml
+++ b/.github/workflows/build_deb_pkg.yml
@@ -1,0 +1,36 @@
+name: build librespot debian package for stable
+
+on:
+  pull_request:
+  push:
+    paths-ignore:
+      - '*.md'
+
+jobs:
+  build-librespot-debs:
+    strategy:
+      matrix:
+        architecture: [amd64, armhf, arm64]
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          path: build-rust-deb-action
+      - uses: actions/checkout@v4
+        with:
+          repository: librespot-org/librespot
+          path: librespot
+      - uses: catango/build-rust-deb-action@master
+        id: build
+        with:
+          host-build-deps: libclang-14-dev cmake
+          target-build-deps: libasound2-dev
+          target-arch: ${{ matrix.architecture }}
+          # bindget-cli 0.71 breaks build
+          rust-buildtools: bindgen-cli@0.70.1
+          source-dir: librespot
+      - uses: actions/upload-artifact@v4
+        with:
+          name: librespot-${{ matrix.architecture }}
+          path: ${{ steps.build.outputs.artifact-dir }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- [build] Add Github workflow to build multiarch debian package
 - [connect] Add `seek_to` field to `SpircLoadCommand` (breaking)
 - [connect] Add `repeat_track` field to `SpircLoadCommand` (breaking)
 - [connect] Add `pause` parameter to `Spirc::disconnect` method (breaking)


### PR DESCRIPTION
Build debian package for architectures amd64, armhf and arm64 with github actions. Default build settings are used and linked against libraries of the respective debian version. New github action build-rust-deb-action is used that leverages cargo-deb in a dockerized environment.