### PR TITLE
Fix testcases for cross compilation

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,7 +241,13 @@ jobs:
 
       - name: Install the cross compiler rust targets
         run: rustup target add ${{ matrix.target }}
-      
+
+      - name: Update and Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake libclang1
+
+      - name: Install bindgen-cli
+        run: cargo install --force --locked bindgen-cli
+
       - name: Install cross compiler
         run: |
             if [ ${{ matrix.target }} = "armv7-unknown-linux-gnueabihf" ]; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [test] Missing bindgen breaks crossbuild on recent runners. Now installing latest bindgen in addition.
 - [core] Fix "no native root CA certificates found" on platforms unsupported
   by `rustls-native-certs`.
 - [core] Fix all APs rejecting with "TryAnotherAP" when connecting session


### PR DESCRIPTION
Downgrade bindgen version to 0.70.1 to fix test cases. New bindgen versions break cross build