### PR TITLE
Fix pause state when transferring playback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [discovery] Fix libmdns zerconf setup errors not propagating to the main task.
 - [metadata] `Show::trailer_uri` is now optional since it isn't always present (breaking)
 - [connect] Handle transfer of playback with empty "uri" field
+- [connect] Correctly apply playing/paused state when transferring playback
 
 ### Removed
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1140,7 +1140,7 @@ impl SpircTask {
             _ => 0,
         };
 
-        let is_playing = matches!(transfer.playback.is_paused, Some(is_playing) if is_playing);
+        let is_playing = !transfer.playback.is_paused();
 
         if self.connect_state.current_track(|t| t.is_autoplay()) || autoplay {
             debug!("currently in autoplay context, async resolving autoplay for {ctx_uri}");


### PR DESCRIPTION
The play/paused state was inverted. So if we were playing something it would not resume after loading.
`is_paused()` defaults to `false` if `None`, so by default it plays. Not sure if that's correct behavior, I guess the field being called `is_paused` seems to imply that playing is the default state.