### PR TITLE
Shuffle tracks in place

### DIFF
--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 futures-util = "0.3"
 log = "0.4"
 protobuf = "3.5"
-rand = "0.8"
+rand = { version = "0.8", default-features = false, features = ["small_rng"] }
 serde_json = "1.0"
 thiserror = "2.0"
 tokio = { version = "1", features = ["macros", "parking_lot", "sync"] }

--- a/connect/src/context_resolver.rs
+++ b/connect/src/context_resolver.rs
@@ -317,7 +317,7 @@ impl ContextResolver {
         let res = if let Some(transfer_state) = transfer_state.take() {
             state.finish_transfer(transfer_state)
         } else if state.shuffling_context() {
-            state.shuffle()
+            state.shuffle(None)
         } else if matches!(active_ctx, Ok(ctx) if ctx.index.track == 0) {
             // has context, and context is not touched
             // when the index is not zero, the next index was already evaluated elsewhere

--- a/connect/src/lib.rs
+++ b/connect/src/lib.rs
@@ -7,5 +7,6 @@ use librespot_protocol as protocol;
 
 mod context_resolver;
 mod model;
+pub mod shuffle_vec;
 pub mod spirc;
 pub mod state;

--- a/connect/src/shuffle_vec.rs
+++ b/connect/src/shuffle_vec.rs
@@ -1,10 +1,10 @@
-use rand::{Rng, SeedableRng};
+use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::{
     ops::{Deref, DerefMut},
     vec::IntoIter,
 };
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ShuffleVec<T> {
     vec: Vec<T>,
     indices: Option<Vec<usize>>,
@@ -45,12 +45,6 @@ impl<T> From<Vec<T>> for ShuffleVec<T> {
     }
 }
 
-impl<T> Default for ShuffleVec<T> {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
 impl<T> ShuffleVec<T> {
     pub fn new() -> Self {
         Self {
@@ -60,7 +54,7 @@ impl<T> ShuffleVec<T> {
     }
 
     pub fn shuffle_with_seed(&mut self, seed: u64) {
-        self.shuffle_with_rng(rand::rngs::StdRng::seed_from_u64(seed))
+        self.shuffle_with_rng(SmallRng::seed_from_u64(seed))
     }
 
     pub fn shuffle_with_rng(&mut self, mut rng: impl Rng) {
@@ -97,7 +91,7 @@ impl<T> ShuffleVec<T> {
 
 #[cfg(test)]
 mod test {
-    use crate::shuffle_vec::ShuffleVec;
+    use super::*;
     use rand::Rng;
 
     #[test]

--- a/connect/src/shuffle_vec.rs
+++ b/connect/src/shuffle_vec.rs
@@ -1,13 +1,19 @@
-use rand::Rng;
+use rand::{Rng, SeedableRng};
 use std::{
     ops::{Deref, DerefMut},
     vec::IntoIter,
 };
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ShuffleVec<T> {
     vec: Vec<T>,
     indices: Option<Vec<usize>>,
+}
+
+impl<T: PartialEq> PartialEq for ShuffleVec<T> {
+    fn eq(&self, other: &Self) -> bool {
+        self.vec == other.vec
+    }
 }
 
 impl<T> Deref for ShuffleVec<T> {
@@ -33,18 +39,36 @@ impl<T> IntoIterator for ShuffleVec<T> {
     }
 }
 
-impl<T> ShuffleVec<T> {
-    pub fn new(vec: Vec<T>) -> Self {
+impl<T> From<Vec<T>> for ShuffleVec<T> {
+    fn from(vec: Vec<T>) -> Self {
         Self { vec, indices: None }
     }
+}
 
-    pub fn shuffle(&mut self) {
+impl<T> Default for ShuffleVec<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> ShuffleVec<T> {
+    pub fn new() -> Self {
+        Self {
+            vec: Vec::new(),
+            indices: None,
+        }
+    }
+
+    pub fn shuffle_with_seed(&mut self, seed: u64) {
+        self.shuffle_with_rng(rand::rngs::StdRng::seed_from_u64(seed))
+    }
+
+    pub fn shuffle_with_rng(&mut self, mut rng: impl Rng) {
         if self.indices.is_some() {
             self.unshuffle()
         }
 
         let indices = {
-            let mut rng = rand::thread_rng();
             (1..self.vec.len())
                 .rev()
                 .map(|i| rng.gen_range(0..i + 1))
@@ -68,5 +92,32 @@ impl<T> ShuffleVec<T> {
             let n = indices[self.vec.len() - i - 1];
             self.vec.swap(n, i);
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::shuffle_vec::ShuffleVec;
+    use rand::Rng;
+
+    #[test]
+    fn test_shuffle_with_seed() {
+        let seed = rand::thread_rng().gen_range(0..10000000000000);
+
+        let vec = (0..100).collect::<Vec<_>>();
+        let base_vec: ShuffleVec<i32> = vec.into();
+
+        let mut shuffled_vec = base_vec.clone();
+        shuffled_vec.shuffle_with_seed(seed);
+
+        let mut different_shuffled_vec = base_vec.clone();
+        different_shuffled_vec.shuffle_with_seed(seed);
+
+        assert_eq!(shuffled_vec, different_shuffled_vec);
+
+        let mut unshuffled_vec = shuffled_vec.clone();
+        unshuffled_vec.unshuffle();
+
+        assert_eq!(base_vec, unshuffled_vec);
     }
 }

--- a/connect/src/shuffle_vec.rs
+++ b/connect/src/shuffle_vec.rs
@@ -1,0 +1,72 @@
+use rand::Rng;
+use std::{
+    ops::{Deref, DerefMut},
+    vec::IntoIter,
+};
+
+#[derive(Debug)]
+pub struct ShuffleVec<T> {
+    vec: Vec<T>,
+    indices: Option<Vec<usize>>,
+}
+
+impl<T> Deref for ShuffleVec<T> {
+    type Target = Vec<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.vec
+    }
+}
+
+impl<T> DerefMut for ShuffleVec<T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.vec.as_mut()
+    }
+}
+
+impl<T> IntoIterator for ShuffleVec<T> {
+    type Item = T;
+    type IntoIter = IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.vec.into_iter()
+    }
+}
+
+impl<T> ShuffleVec<T> {
+    pub fn new(vec: Vec<T>) -> Self {
+        Self { vec, indices: None }
+    }
+
+    pub fn shuffle(&mut self) {
+        if self.indices.is_some() {
+            self.unshuffle()
+        }
+
+        let indices = {
+            let mut rng = rand::thread_rng();
+            (1..self.vec.len())
+                .rev()
+                .map(|i| rng.gen_range(0..i + 1))
+                .collect()
+        };
+
+        for (i, &rnd_ind) in (1..self.vec.len()).rev().zip(&indices) {
+            self.vec.swap(i, rnd_ind);
+        }
+
+        self.indices = Some(indices)
+    }
+
+    pub fn unshuffle(&mut self) {
+        let indices = match self.indices.take() {
+            Some(indices) => indices,
+            None => return,
+        };
+
+        for i in 1..self.vec.len() {
+            let n = indices[self.vec.len() - i - 1];
+            self.vec.swap(n, i);
+        }
+    }
+}

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -746,9 +746,6 @@ impl SpircTask {
 
         use protobuf::Message;
 
-        // todo: handle received pages from transfer, important to not always shuffle the first 10 tracks
-        //  also important when the dealer is restarted, currently we just shuffle again, but at least
-        //  the 10 tracks provided should be used and after that the new shuffle context
         match TransferState::parse_from_bytes(&cluster.transfer_data) {
             Ok(transfer_state) => self.handle_transfer(transfer_state)?,
             Err(why) => error!("failed to take over control: {why}"),
@@ -1205,7 +1202,7 @@ impl SpircTask {
             if self.context_resolver.has_next() {
                 self.connect_state.update_queue_revision()
             } else {
-                self.connect_state.shuffle()?;
+                self.connect_state.shuffle(None)?;
                 self.add_autoplay_resolving_when_required();
             }
         } else {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -25,9 +25,7 @@ use crate::{
         user_attributes::UserAttributesMutation,
     },
     state::{
-        context::{
-            ResetContext, {ContextType, UpdateContext},
-        },
+        context::{ContextType, ResetContext},
         metadata::Metadata,
         provider::IsProvider,
         {ConnectState, ConnectStateConfig},
@@ -37,7 +35,6 @@ use futures_util::StreamExt;
 use protobuf::MessageField;
 use std::{
     future::Future,
-    ops::Deref,
     sync::atomic::{AtomicUsize, Ordering},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -889,7 +886,7 @@ impl SpircTask {
                 } else {
                     self.context_resolver.add(ResolveContext::from_context(
                         update_context.context,
-                        super::state::context::UpdateContext::Default,
+                        ContextType::Default,
                         ContextAction::Replace,
                     ))
                 }
@@ -1007,7 +1004,7 @@ impl SpircTask {
         self.context_resolver.add(ResolveContext::from_uri(
             ctx_uri.clone(),
             &fallback,
-            UpdateContext::Default,
+            ContextType::Default,
             ContextAction::Replace,
         ));
 
@@ -1044,7 +1041,7 @@ impl SpircTask {
             self.context_resolver.add(ResolveContext::from_uri(
                 ctx_uri,
                 fallback,
-                UpdateContext::Autoplay,
+                ContextType::Autoplay,
                 ContextAction::Replace,
             ))
         }
@@ -1139,13 +1136,12 @@ impl SpircTask {
         };
 
         let update_context = if cmd.autoplay {
-            UpdateContext::Autoplay
+            ContextType::Autoplay
         } else {
-            UpdateContext::Default
+            ContextType::Default
         };
 
-        self.connect_state
-            .set_active_context(*update_context.deref());
+        self.connect_state.set_active_context(update_context);
 
         let current_context_uri = self.connect_state.context_uri();
         if current_context_uri == &cmd.context_uri && fallback == cmd.context_uri {
@@ -1366,7 +1362,7 @@ impl SpircTask {
         let resolve = ResolveContext::from_uri(
             current_context,
             fallback,
-            UpdateContext::Autoplay,
+            ContextType::Autoplay,
             if has_tracks {
                 ContextAction::Append
             } else {
@@ -1458,7 +1454,7 @@ impl SpircTask {
         self.context_resolver.add(ResolveContext::from_uri(
             uri,
             self.connect_state.current_track(|t| &t.uri),
-            UpdateContext::Default,
+            ContextType::Default,
             ContextAction::Replace,
         ));
 

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -7,12 +7,12 @@ mod restrictions;
 mod tracks;
 mod transfer;
 
-use crate::model::SpircPlayStatus;
 use crate::{
     core::{
         config::DeviceType, date::Date, dealer::protocol::Request, spclient::SpClientResult,
         version, Error, Session,
     },
+    model::SpircPlayStatus,
     protocol::{
         connect::{Capabilities, Device, DeviceInfo, MemberType, PutStateReason, PutStateRequest},
         media::AudioQuality,
@@ -26,7 +26,6 @@ use crate::{
         provider::{IsProvider, Provider},
     },
 };
-
 use log::LevelFilter;
 use protobuf::{EnumOrUnknown, MessageField};
 use std::{
@@ -119,9 +118,6 @@ pub struct ConnectState {
     /// the context from which we play, is used to top up prev and next tracks
     context: Option<StateContext>,
 
-    /// a context to keep track of our shuffled context,
-    /// should be only available when `player.option.shuffling_context` is true
-    shuffle_context: Option<StateContext>,
     /// a context to keep track of the autoplay context
     autoplay_context: Option<StateContext>,
 }

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -117,6 +117,8 @@ pub struct ConnectState {
 
     /// the context from which we play, is used to top up prev and next tracks
     context: Option<StateContext>,
+    /// seed extracted in [ConnectState::handle_initial_transfer] and used in [ConnectState::finish_transfer]
+    transfer_shuffle_seed: Option<String>,
 
     /// a context to keep track of the autoplay context
     autoplay_context: Option<StateContext>,

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -118,7 +118,7 @@ pub struct ConnectState {
     /// the context from which we play, is used to top up prev and next tracks
     context: Option<StateContext>,
     /// seed extracted in [ConnectState::handle_initial_transfer] and used in [ConnectState::finish_transfer]
-    transfer_shuffle_seed: Option<String>,
+    transfer_shuffle_seed: Option<u64>,
 
     /// a context to keep track of the autoplay context
     autoplay_context: Option<StateContext>,

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -366,7 +366,7 @@ impl ConnectState {
             .collect::<Vec<_>>();
 
         StateContext {
-            tracks: ShuffleVec::new(tracks),
+            tracks: tracks.into(),
             skip_track: None,
             restrictions,
             metadata,

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -107,6 +107,7 @@ impl ConnectState {
         }
 
         if let Ok(ctx) = self.get_context_mut(ContextType::Default) {
+            ctx.remove_shuffle_seed();
             ctx.tracks.unshuffle()
         }
 

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -480,7 +480,7 @@ impl ConnectState {
         }
 
         if matches!(provider, Provider::Autoplay) {
-            track.set_autoplay(true)
+            track.set_from_autoplay(true)
         }
 
         Ok(track)

--- a/connect/src/state/handle.rs
+++ b/connect/src/state/handle.rs
@@ -13,7 +13,7 @@ impl ConnectState {
         self.set_shuffle(shuffle);
 
         if shuffle {
-            return self.shuffle();
+            return self.shuffle(None);
         }
 
         self.reset_context(ResetContext::DefaultIndex);

--- a/connect/src/state/handle.rs
+++ b/connect/src/state/handle.rs
@@ -2,6 +2,7 @@ use crate::{
     core::{dealer::protocol::SetQueueCommand, Error},
     state::{
         context::{ContextType, ResetContext},
+        metadata::Metadata,
         ConnectState,
     },
 };
@@ -21,11 +22,16 @@ impl ConnectState {
             return Ok(());
         }
 
-        let ctx = self.get_context(ContextType::Default)?;
-        let current_index =
-            ConnectState::find_index_in_context(ctx, |c| self.current_track(|t| c.uri == t.uri))?;
-
-        self.reset_playback_to_position(Some(current_index))
+        match self.current_track(|t| t.get_context_index()) {
+            Some(current_index) => self.reset_playback_to_position(Some(current_index)),
+            None => {
+                let ctx = self.get_context(ContextType::Default)?;
+                let current_index = ConnectState::find_index_in_context(ctx, |c| {
+                    self.current_track(|t| c.uri == t.uri)
+                })?;
+                self.reset_playback_to_position(Some(current_index))
+            }
+        }
     }
 
     pub fn handle_set_queue(&mut self, set_queue: SetQueueCommand) {

--- a/connect/src/state/metadata.rs
+++ b/connect/src/state/metadata.rs
@@ -6,9 +6,10 @@ const CONTEXT_URI: &str = "context_uri";
 const ENTITY_URI: &str = "entity_uri";
 const IS_QUEUED: &str = "is_queued";
 const IS_AUTOPLAY: &str = "autoplay.is_autoplay";
-
 const HIDDEN: &str = "hidden";
 const ITERATION: &str = "iteration";
+
+const CUSTOM_CONTEXT_INDEX: &str = "context_index";
 
 macro_rules! metadata_entry {
     ( $get:ident, $set:ident ($key:ident: $entry:ident)) => {
@@ -34,6 +35,10 @@ pub trait Metadata {
         matches!(self.metadata().get(entry), Some(entry) if entry.eq("true"))
     }
 
+    fn get_usize(&self, entry: &str) -> Option<usize> {
+        self.metadata().get(entry)?.parse().ok()
+    }
+
     fn get(&self, entry: &str) -> Option<&String> {
         self.metadata().get(entry)
     }
@@ -41,6 +46,8 @@ pub trait Metadata {
     metadata_entry!(is_from_queue use get_bool, set_from_queue (is_queued: IS_QUEUED) -> bool);
     metadata_entry!(is_from_autoplay use get_bool, set_from_autoplay (is_autoplay: IS_AUTOPLAY) -> bool);
     metadata_entry!(is_hidden use get_bool, set_hidden (is_hidden: HIDDEN) -> bool);
+
+    metadata_entry!(get_context_index use get_usize, set_context_index (iteration: CUSTOM_CONTEXT_INDEX) -> Option<usize>);
 
     metadata_entry!(get_context_uri, set_context_uri (context_uri: CONTEXT_URI));
     metadata_entry!(get_entity_uri, set_entity_uri (entity_uri: ENTITY_URI));

--- a/connect/src/state/metadata.rs
+++ b/connect/src/state/metadata.rs
@@ -55,12 +55,11 @@ pub trait Metadata {
     metadata_entry!(is_from_autoplay use get_bool, set_from_autoplay, remove_from_autoplay (is_autoplay: IS_AUTOPLAY) -> bool);
     metadata_entry!(is_hidden use get_bool, set_hidden, remove_hidden (is_hidden: HIDDEN) -> bool);
 
-    metadata_entry!(get_context_index use get_usize, set_context_index, remove_context_index (iteration: CUSTOM_CONTEXT_INDEX) -> Option<usize>);
-
+    metadata_entry!(get_context_index use get_usize, set_context_index, remove_context_index (context_index: CUSTOM_CONTEXT_INDEX) -> Option<usize>);
     metadata_entry!(get_context_uri, set_context_uri, remove_context_uri (context_uri: CONTEXT_URI));
     metadata_entry!(get_entity_uri, set_entity_uri, remove_entity_uri (entity_uri: ENTITY_URI));
     metadata_entry!(get_iteration, set_iteration, remove_iteration (iteration: ITERATION));
-    metadata_entry!(get_shuffle_seed, set_shuffle_seed, remove_shuffle_seed (iteration: CUSTOM_SHUFFLE_SEED));
+    metadata_entry!(get_shuffle_seed, set_shuffle_seed, remove_shuffle_seed (shuffle_seed: CUSTOM_SHUFFLE_SEED));
 }
 
 macro_rules! impl_metadata {

--- a/connect/src/state/metadata.rs
+++ b/connect/src/state/metadata.rs
@@ -1,4 +1,7 @@
-use librespot_protocol::{context_track::ContextTrack, player::ProvidedTrack};
+use crate::{
+    protocol::{context::Context, context_track::ContextTrack, player::ProvidedTrack},
+    state::context::StateContext,
+};
 use std::collections::HashMap;
 use std::fmt::Display;
 
@@ -10,18 +13,23 @@ const HIDDEN: &str = "hidden";
 const ITERATION: &str = "iteration";
 
 const CUSTOM_CONTEXT_INDEX: &str = "context_index";
+const CUSTOM_SHUFFLE_SEED: &str = "shuffle_seed";
 
 macro_rules! metadata_entry {
-    ( $get:ident, $set:ident ($key:ident: $entry:ident)) => {
-        metadata_entry!( $get use get, $set ($key: $entry) -> Option<&String> );
+    ( $get:ident, $set:ident, $clear:ident ($key:ident: $entry:ident)) => {
+        metadata_entry!( $get use get, $set, $clear ($key: $entry) -> Option<&String> );
     };
-    ( $get_key:ident use $get:ident, $set:ident ($key:ident: $entry:ident) -> $ty:ty ) => {
+    ( $get_key:ident use $get:ident, $set:ident, $clear:ident ($key:ident: $entry:ident) -> $ty:ty ) => {
         fn $get_key (&self) -> $ty {
             self.$get($entry)
         }
 
         fn $set (&mut self, $key: impl Display) {
             self.metadata_mut().insert($entry.to_string(), $key.to_string());
+        }
+
+        fn $clear(&mut self) {
+            self.metadata_mut().remove($entry);
         }
     };
 }
@@ -43,33 +51,33 @@ pub trait Metadata {
         self.metadata().get(entry)
     }
 
-    metadata_entry!(is_from_queue use get_bool, set_from_queue (is_queued: IS_QUEUED) -> bool);
-    metadata_entry!(is_from_autoplay use get_bool, set_from_autoplay (is_autoplay: IS_AUTOPLAY) -> bool);
-    metadata_entry!(is_hidden use get_bool, set_hidden (is_hidden: HIDDEN) -> bool);
+    metadata_entry!(is_from_queue use get_bool, set_from_queue, remove_from_queue (is_queued: IS_QUEUED) -> bool);
+    metadata_entry!(is_from_autoplay use get_bool, set_from_autoplay, remove_from_autoplay (is_autoplay: IS_AUTOPLAY) -> bool);
+    metadata_entry!(is_hidden use get_bool, set_hidden, remove_hidden (is_hidden: HIDDEN) -> bool);
 
-    metadata_entry!(get_context_index use get_usize, set_context_index (iteration: CUSTOM_CONTEXT_INDEX) -> Option<usize>);
+    metadata_entry!(get_context_index use get_usize, set_context_index, remove_context_index (iteration: CUSTOM_CONTEXT_INDEX) -> Option<usize>);
 
-    metadata_entry!(get_context_uri, set_context_uri (context_uri: CONTEXT_URI));
-    metadata_entry!(get_entity_uri, set_entity_uri (entity_uri: ENTITY_URI));
-    metadata_entry!(get_iteration, set_iteration (iteration: ITERATION));
+    metadata_entry!(get_context_uri, set_context_uri, remove_context_uri (context_uri: CONTEXT_URI));
+    metadata_entry!(get_entity_uri, set_entity_uri, remove_entity_uri (entity_uri: ENTITY_URI));
+    metadata_entry!(get_iteration, set_iteration, remove_iteration (iteration: ITERATION));
+    metadata_entry!(get_shuffle_seed, set_shuffle_seed, remove_shuffle_seed (iteration: CUSTOM_SHUFFLE_SEED));
 }
 
-impl Metadata for ContextTrack {
-    fn metadata(&self) -> &HashMap<String, String> {
-        &self.metadata
-    }
+macro_rules! impl_metadata {
+    ($impl_for:ident) => {
+        impl Metadata for $impl_for {
+            fn metadata(&self) -> &HashMap<String, String> {
+                &self.metadata
+            }
 
-    fn metadata_mut(&mut self) -> &mut HashMap<String, String> {
-        &mut self.metadata
-    }
+            fn metadata_mut(&mut self) -> &mut HashMap<String, String> {
+                &mut self.metadata
+            }
+        }
+    };
 }
 
-impl Metadata for ProvidedTrack {
-    fn metadata(&self) -> &HashMap<String, String> {
-        &self.metadata
-    }
-
-    fn metadata_mut(&mut self) -> &mut HashMap<String, String> {
-        &mut self.metadata
-    }
-}
+impl_metadata!(ContextTrack);
+impl_metadata!(ProvidedTrack);
+impl_metadata!(Context);
+impl_metadata!(StateContext);

--- a/connect/src/state/options.rs
+++ b/connect/src/state/options.rs
@@ -63,7 +63,7 @@ impl ConnectState {
 
         // we don't need to include the current track, because it is already being played
         ctx.skip_track = current_track;
-        ctx.tracks.shuffle();
+        ctx.tracks.shuffle_with_rng(rand::thread_rng());
 
         self.set_active_context(ContextType::Default);
         self.fill_up_context = ContextType::Default;

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -124,6 +124,7 @@ impl<'ct> ConnectState {
                     continue;
                 }
                 Some(next) if next.is_unavailable() => continue,
+                Some(next) if self.is_skip_track(&next) => continue,
                 other => break other,
             };
         };
@@ -323,7 +324,7 @@ impl<'ct> ConnectState {
                     }
                 }
                 None => break,
-                Some(ct) if ct.is_unavailable() => {
+                Some(ct) if ct.is_unavailable() || self.is_skip_track(ct) => {
                     new_index += 1;
                     continue;
                 }

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -23,7 +23,7 @@ impl<'ct> ConnectState {
             ..Default::default()
         };
         delimiter.set_hidden(true);
-        delimiter.add_iteration(iteration);
+        delimiter.set_iteration(iteration);
 
         delimiter
     }
@@ -415,7 +415,7 @@ impl<'ct> ConnectState {
 
         track.set_provider(Provider::Queue);
         if !track.is_from_queue() {
-            track.set_queued(true);
+            track.set_from_queue(true);
         }
 
         let next_tracks = self.next_tracks_mut();

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -142,12 +142,10 @@ impl<'ct> ConnectState {
             self.set_active_context(ContextType::Autoplay);
             None
         } else {
-            let ctx = self.get_context(ContextType::Default)?;
-            let new_index = Self::find_index_in_context(ctx, |c| c.uri == new_track.uri);
-            match new_index {
-                Ok(new_index) => Some(new_index as u32),
-                Err(why) => {
-                    error!("didn't find the track in the current context: {why}");
+            match new_track.get_context_index() {
+                Some(new_index) => Some(new_index as u32),
+                None => {
+                    error!("the given context track had no set context_index");
                     None
                 }
             }

--- a/connect/src/state/transfer.rs
+++ b/connect/src/state/transfer.rs
@@ -26,6 +26,7 @@ impl ConnectState {
             track,
             transfer.current_session.context.uri.as_deref(),
             None,
+            None,
             transfer
                 .queue
                 .is_playing_queue
@@ -133,6 +134,7 @@ impl ConnectState {
             if let Ok(queued_track) = self.context_to_provided_track(
                 track,
                 Some(self.context_uri()),
+                None,
                 None,
                 Some(Provider::Queue),
             ) {


### PR DESCRIPTION
Follow up on https://github.com/librespot-org/librespot/pull/1356#issuecomment-2427617758

- removes duplication of context tracks when shuffling
- shuffle by a given seed, by that we can restore the shuffle state after a spontaneously disconnect

With the updated protobuf definitions, there is technically a given seed from the side of spotify when transfering playback. The given seed seems to be a hex value which we can convert into a u64 (which we currently use as seed value). But the shuffled queue isn't even similar to what spotify shuffles (which makes sense as they use a more preference base algorithm with less randomness). So when transferring we reshuffle unless we have a previous shuffle seed in the context metadata.