### PR TITLE
Expose `autoplay` option to `SpircLoadCommand`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [connect] Add `seek_to` field to `SpircLoadCommand` (breaking)
 - [connect] Add `repeat_track` field to `SpircLoadCommand` (breaking)
+- [connect] Add `autoplay` field to `SpircLoadCommand` (breaking)
 - [connect] Add `pause` parameter to `Spirc::disconnect` method (breaking)
 - [playback] Add `track` field to `PlayerEvent::RepeatChanged` (breaking)
 - [core] Add `request_with_options` and `request_with_protobuf_and_options` to `SpClient`

--- a/connect/src/model.rs
+++ b/connect/src/model.rs
@@ -9,10 +9,15 @@ pub struct SpircLoadCommand {
     pub shuffle: bool,
     pub repeat: bool,
     pub repeat_track: bool,
+    /// Decides if the context or the autoplay of the context is played
+    ///
+    /// ## Remarks:
+    /// If `true` is provided, the option values (`shuffle`, `repeat` and `repeat_track`) are ignored
+    pub autoplay: bool,
     /// Decides the starting position in the given context
     ///
     /// ## Remarks:
-    /// If none is provided and shuffle true, a random track is played, otherwise the first
+    /// If `None` is provided and `shuffle` is `true`, a random track is played, otherwise the first
     pub playing_track: Option<PlayingTrack>,
 }
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1193,9 +1193,11 @@ impl SpircTask {
             cmd.shuffle, cmd.repeat, cmd.repeat_track
         );
 
-        self.connect_state.set_shuffle(cmd.shuffle);
-        self.connect_state.set_repeat_context(cmd.repeat);
-        self.connect_state.set_repeat_track(cmd.repeat_track);
+        self.connect_state.set_shuffle(!cmd.autoplay && cmd.shuffle);
+        self.connect_state
+            .set_repeat_context(!cmd.autoplay && cmd.repeat);
+        self.connect_state
+            .set_repeat_track(!cmd.autoplay && cmd.repeat_track);
 
         if cmd.shuffle {
             if let Some(index) = index {

--- a/examples/play_connect.rs
+++ b/examples/play_connect.rs
@@ -83,6 +83,7 @@ async fn main() {
                 shuffle: false,
                 repeat: false,
                 repeat_track: false,
+                autoplay: false,
                 // the index specifies which track in the context starts playing, in this case the first in the album
                 playing_track: PlayingTrack::Index(0).into(),
             })


### PR DESCRIPTION
It only makes sense to directly expose the `autoplay` option to start playing a radio/station. This doesn't start the "radio"-playlist currently found in the spotify UI and rather just switches into the endless autoplay mode.

Previously mentioned here: https://github.com/hrkfdn/ncspot/issues/193