### PR TITLE
Handle drag and drop of current track

### DIFF
--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -249,6 +249,14 @@ impl<'ct> ConnectState {
                 self.queue_count += 1;
             });
 
+        // when you drag 'n drop the current track in the queue view into the "Next from: ..."
+        // section, it is only send as an empty item with just the provider and metadata, so we have
+        // to provide set the uri from the current track manually
+        tracks
+            .iter_mut()
+            .filter(|t| t.uri.is_empty())
+            .for_each(|t| t.uri = self.current_track(|ct| ct.uri.clone()));
+
         self.player_mut().next_tracks = tracks;
     }
 


### PR DESCRIPTION
When drag and dropping the currently played track into the "Next from: ..." or Queued item section, it is only send as an empty item with an uri. So it seems we need to add the uri of the current track to these provided tracks.