### PR TITLE
Exposes the PlayerTrackLoader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Replaced `ConnectConfig` with `ConnectStateConfig` (breaking)
 - [connect] Replaced `playing_track_index` field of `SpircLoadCommand` with `playing_track` (breaking)
 - [connect] Replaced Mercury usage in `Spirc` with Dealer
+- [player] Expose `PlayerTrackLoader` as a public interface.
 
 ### Added
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -632,11 +632,11 @@ impl Drop for Player {
     }
 }
 
-struct PlayerLoadedTrackData {
-    decoder: Decoder,
+pub struct PlayerLoadedTrackData {
+    pub decoder: Decoder,
+    pub audio_item: AudioItem,
     normalisation_data: NormalisationData,
     stream_loader_controller: StreamLoaderController,
-    audio_item: AudioItem,
     bytes_per_second: usize,
     duration_ms: u32,
     stream_position_ms: u32,
@@ -655,7 +655,7 @@ enum PlayerPreload {
     },
 }
 
-type Decoder = Box<dyn AudioDecoder + Send>;
+pub type Decoder = Box<dyn AudioDecoder + Send>;
 
 enum PlayerState {
     Stopped,
@@ -876,9 +876,9 @@ impl PlayerState {
     }
 }
 
-struct PlayerTrackLoader {
-    session: Session,
-    config: PlayerConfig,
+pub struct PlayerTrackLoader {
+    pub session: Session,
+    pub config: PlayerConfig,
 }
 
 impl PlayerTrackLoader {
@@ -927,7 +927,7 @@ impl PlayerTrackLoader {
         Some(data_rate.ceil() as usize)
     }
 
-    async fn load_track(
+    pub async fn load_track(
         &self,
         spotify_id: SpotifyId,
         position_ms: u32,


### PR DESCRIPTION
Hi, 

The motivation behind this is that I want to stream Audio tracks from Spotify, but I don't want the entire Player infrastructure behind it. I've already got a queueing system, and the two of them did _not_ like each other.

By exposing this I can easily handle one Track's lifetime, instead of an entire Sink's

Let me know if there's a better way to change this so we can still get at individual tracks

Thanks!