### PR TITLE
Fix cross compilation for armv6hf (Raspberry Pi 1)

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -8,10 +8,10 @@
 # The compiled binaries will be located in /tmp/librespot-build
 #
 # If only one architecture is desired, cargo can be invoked directly with the appropriate options :
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features alsa-backend
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features alsa-backend
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features alsa-backend
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features alsa-backend
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features "alsa-backend with-libmdns"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns"
 
 FROM debian:bookworm
 

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -30,6 +30,7 @@ RUN dpkg --add-architecture arm64 && \
 	crossbuild-essential-armel \
 	crossbuild-essential-armhf \
 	curl \
+	git \
 	libasound2-dev \
 	libasound2-dev:arm64 \
 	libasound2-dev:armel \

--- a/contrib/cross-compile-armv6hf/Dockerfile
+++ b/contrib/cross-compile-armv6hf/Dockerfile
@@ -11,7 +11,7 @@ FROM --platform=linux/amd64 ubuntu:18.04
 
 # Install common packages.
 RUN apt-get update
-RUN apt-get install -y -qq git curl build-essential libasound2-dev libpulse-dev
+RUN apt-get install -y -qq git curl build-essential cmake clang libclang-dev libasound2-dev libpulse-dev
 
 # Install armhf packages.
 RUN echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ bionic main" | tee -a /etc/apt/sources.list

--- a/contrib/cross-compile-armv6hf/Dockerfile
+++ b/contrib/cross-compile-armv6hf/Dockerfile
@@ -11,20 +11,18 @@ FROM --platform=linux/amd64 ubuntu:18.04
 
 # Install common packages.
 RUN apt-get update
-RUN apt-get install -y -qq git curl build-essential libasound2-dev libssl-dev libpulse-dev libdbus-1-dev
+RUN apt-get install -y -qq git curl build-essential libasound2-dev libpulse-dev
 
 # Install armhf packages.
 RUN echo "deb [arch=armhf] http://ports.ubuntu.com/ubuntu-ports/ bionic main" | tee -a /etc/apt/sources.list
 RUN apt-get update
-RUN apt-get download libasound2:armhf libasound2-dev:armhf libssl-dev:armhf libssl1.1:armhf
+RUN apt-get download libasound2:armhf libasound2-dev:armhf
 RUN mkdir /sysroot && \
     dpkg -x libasound2_*.deb /sysroot/ && \
-    dpkg -x libssl-dev*.deb /sysroot/ && \
-    dpkg -x libssl1.1*.deb /sysroot/ && \
     dpkg -x libasound2-dev*.deb /sysroot/
 
 # Install rust.
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
+RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.81 -y
 ENV PATH="/root/.cargo/bin/:${PATH}"
 RUN rustup target add arm-unknown-linux-gnueabihf
 RUN mkdir /.cargo && \
@@ -35,14 +33,11 @@ RUN mkdir /pi && \
     git -C /pi clone --depth=1 https://github.com/raspberrypi/tools.git
 
 # Build env variables.
-ENV CARGO_TARGET_DIR /build
-ENV CARGO_HOME /build/cache
+ENV CARGO_TARGET_DIR=/build
+ENV CARGO_HOME=/build/cache
 ENV PATH="/pi/tools/arm-bcm2708/arm-linux-gnueabihf/bin:${PATH}"
 ENV PKG_CONFIG_ALLOW_CROSS=1
 ENV PKG_CONFIG_PATH_arm-unknown-linux-gnueabihf=/usr/lib/arm-linux-gnueabihf/pkgconfig/
-ENV C_INCLUDE_PATH=/sysroot/usr/include
-ENV OPENSSL_LIB_DIR=/sysroot/usr/lib/arm-linux-gnueabihf
-ENV OPENSSL_INCLUDE_DIR=/sysroot/usr/include/arm-linux-gnueabihf
 
 ADD . /src
 WORKDIR /src

--- a/contrib/cross-compile-armv6hf/docker-build.sh
+++ b/contrib/cross-compile-armv6hf/docker-build.sh
@@ -1,13 +1,17 @@
 #!/usr/bin/env bash
 set -eux
 
-PI1_TOOLS_DIR="/pi/tools/arm-bcm2708/arm-linux-gnueabihf"
+cargo install --force --locked bindgen-cli
+
+PI1_TOOLS_DIR=/pi/tools/arm-bcm2708/arm-linux-gnueabihf
+PI1_TOOLS_SYSROOT_DIR=$PI1_TOOLS_DIR/arm-linux-gnueabihf/sysroot
 
 PI1_LIB_DIRS=(
-  "$PI1_TOOLS_DIR/arm-linux-gnueabihf/sysroot/lib"
-  "$PI1_TOOLS_DIR/arm-linux-gnueabihf/sysroot/usr/lib"
+  "$PI1_TOOLS_SYSROOT_DIR/lib"
+  "$PI1_TOOLS_SYSROOT_DIR/usr/lib"
   "/sysroot/usr/lib/arm-linux-gnueabihf"
 )
 export RUSTFLAGS="-C linker=$PI1_TOOLS_DIR/bin/arm-linux-gnueabihf-gcc ${PI1_LIB_DIRS[*]/#/-L}"
+export BINDGEN_EXTRA_CLANG_ARGS=--sysroot=$PI1_TOOLS_SYSROOT_DIR
 
 cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns"

--- a/contrib/cross-compile-armv6hf/docker-build.sh
+++ b/contrib/cross-compile-armv6hf/docker-build.sh
@@ -11,4 +11,4 @@ PI1_LIB_DIRS=(
 )
 export RUSTFLAGS="-C linker=$PI1_TOOLS_DIR/bin/arm-linux-gnueabihf-gcc ${PI1_LIB_DIRS[*]/#/-L}"
 
-cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend"
+cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns"

--- a/contrib/cross-compile-armv6hf/docker-build.sh
+++ b/contrib/cross-compile-armv6hf/docker-build.sh
@@ -7,7 +7,6 @@ PI1_LIB_DIRS=(
   "$PI1_TOOLS_DIR/arm-linux-gnueabihf/sysroot/lib"
   "$PI1_TOOLS_DIR/arm-linux-gnueabihf/sysroot/usr/lib"
   "/sysroot/usr/lib/arm-linux-gnueabihf"
-  "/sysroot/lib/arm-linux-gnueabihf"
 )
 export RUSTFLAGS="-C linker=$PI1_TOOLS_DIR/bin/arm-linux-gnueabihf-gcc ${PI1_LIB_DIRS[*]/#/-L}"
 

--- a/contrib/docker-build.sh
+++ b/contrib/docker-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-cargo build --release --no-default-features --features alsa-backend
-cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features alsa-backend
-cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features alsa-backend
-cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features alsa-backend
+cargo build --release --no-default-features --features "alsa-backend with-libmdns"
+cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns"
+cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns"
+cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns"

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,12 +67,12 @@ protobuf-json-mapping = "3.5"
 # but currently, hyper-proxy2 and tokio-tungstenite do not support it.
 [target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
 hyper-proxy2 = { version = "0.1", default-features = false, features = ["rustls"] }
-hyper-rustls = { version = "0.27.2", default-features = false, features = ["http1", "logging", "tls12", "native-tokio", "http2"] }
+hyper-rustls = { version = "0.27.2", default-features = false, features = ["aws-lc-rs", "http1", "logging", "tls12", "native-tokio", "http2"] }
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["rustls-tls-native-roots"] }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))'.dependencies]
 hyper-proxy2 = { version = "0.1", default-features = false, features = ["rustls-webpki"] }
-hyper-rustls = { version = "0.27.2", default-features = false, features = ["http1", "logging", "tls12", "webpki-tokio", "http2"] }
+hyper-rustls = { version = "0.27.2", default-features = false, features = ["aws-lc-rs", "http1", "logging", "tls12", "webpki-tokio", "http2"] }
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["rustls-tls-webpki-roots"] }
 
 [build-dependencies]
@@ -81,8 +81,3 @@ vergen-gitcl = { version = "1.0.0", default-features = false, features = ["build
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "parking_lot"] }
-
-[features]
-with-aws-lc-rs = ["hyper-rustls/aws-lc-rs"]
-with-ring = ["hyper-rustls/ring"]
-default = ["with-ring"]

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -67,12 +67,12 @@ protobuf-json-mapping = "3.5"
 # but currently, hyper-proxy2 and tokio-tungstenite do not support it.
 [target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
 hyper-proxy2 = { version = "0.1", default-features = false, features = ["rustls"] }
-hyper-rustls = { version = "0.27.2", default-features = false, features = ["aws-lc-rs", "http1", "logging", "tls12", "native-tokio", "http2"] }
+hyper-rustls = { version = "0.27.2", default-features = false, features = ["http1", "logging", "tls12", "native-tokio", "http2"] }
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["rustls-tls-native-roots"] }
 
 [target.'cfg(not(any(target_os = "windows", target_os = "macos", target_os = "linux")))'.dependencies]
 hyper-proxy2 = { version = "0.1", default-features = false, features = ["rustls-webpki"] }
-hyper-rustls = { version = "0.27.2", default-features = false, features = ["aws-lc-rs", "http1", "logging", "tls12", "webpki-tokio", "http2"] }
+hyper-rustls = { version = "0.27.2", default-features = false, features = ["http1", "logging", "tls12", "webpki-tokio", "http2"] }
 tokio-tungstenite = { version = "0.24", default-features = false, features = ["rustls-tls-webpki-roots"] }
 
 [build-dependencies]
@@ -81,3 +81,8 @@ vergen-gitcl = { version = "1.0.0", default-features = false, features = ["build
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "parking_lot"] }
+
+[features]
+with-aws-lc-rs = ["hyper-rustls/aws-lc-rs"]
+with-ring = ["hyper-rustls/ring"]
+default = ["with-ring"]


### PR DESCRIPTION
The Docker image intended to cross-compile librespot for armv6hf (i.e. Raspberry Pi 1) did not work for some time.

Changes proposed here attempt to fix this:

- ~~Commit https://github.com/librespot-org/librespot/commit/faeaf506d64ab988d6cc950b58dbe22c0eed9386 changes the default tls library from **aws-lc-rs** to **ring** as suggested by @kingosticks in #1382 (commit: https://github.com/kingosticks/librespot/commit/24bbc6314c991c64d1846162f739f223c44e5779). I tried to compile **aws-lc-rs** for armv6hf, but did not succeed. :disappointed: I understand that this change might be controversial - I am open to discuss this.~~ Reverted in https://github.com/librespot-org/librespot/pull/1457/commits/6bb009af83ac737c60c99efbf5d8598f6debd3d8
- Commit https://github.com/librespot-org/librespot/commit/0f497cc690e4fefef83686864155d6d68ab2977f adds **with-libmdns** to the list of features - to compensate for the changes made in #1347.
- Commit https://github.com/librespot-org/librespot/commit/3026d030b552e5fa4cb2c7d8f4981a7d2f069fc7 is just a small clean-up of the Docker image and the script used to build librespot.
- Commit https://github.com/librespot-org/librespot/pull/1457/commits/765f1f2246ba0cd7f8776e983a4dfffd539e4395 fixes build of the **aws-lc-rs** library.
- Commit https://github.com/librespot-org/librespot/pull/1457/commits/ab1102a0aa36d44dbca253de7819b0db844bf0f7 fixes a minor issue in binaries generated via Docker for other platforms (VERGEN_IDEMPOTENT_OUTPUT instead of actual git commit hash)

With these changes in place I have been able to cross-compile librespot for armv6hf and verify that it runs as expected on a Raspberry Pi 1.

I have also verified builds using Docker for aarch64 and x86_64.