### PR TITLE
Update softmixer.rs to use AtomicU64 from atomic_shim, so that librespot works with MIPS and MIPSEL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,6 +170,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atomic-shim"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67cd4b51d303cf3501c301e8125df442128d3c6d7c69f71b27833d253de47e77"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2133,6 +2142,7 @@ name = "librespot-playback"
 version = "0.6.0-dev"
 dependencies = [
  "alsa",
+ "atomic-shim",
  "cpal",
  "futures-util",
  "glib",

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -21,6 +21,7 @@ path = "../metadata"
 version = "0.6.0-dev"
 
 [dependencies]
+atomic-shim = "0.2.0"
 futures-util = "0.3"
 log = "0.4"
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }

--- a/playback/src/mixer/softmixer.rs
+++ b/playback/src/mixer/softmixer.rs
@@ -1,4 +1,5 @@
-use std::sync::atomic::{AtomicU64, Ordering};
+use atomic_shim::AtomicU64;
+use std::sync::atomic::Ordering;
 use std::sync::Arc;
 
 use super::VolumeGetter;


### PR DESCRIPTION
MIPS and MIPSEL [and PowerPC (?)] don't support AtomicU64, since they are 32 bit. However, there is a crate that provides shims for these platforms. When it detects it is running on unsupported platforms, it fallbacks to the shim implementation, using crossbeam Mutex. For supported platforms, there should be no change.

See initial discussion in https://github.com/librespot-org/librespot/issues/1460