### PR TITLE
Replacing atomic_shim with portable-atomic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -170,15 +170,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atomic-shim"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67cd4b51d303cf3501c301e8125df442128d3c6d7c69f71b27833d253de47e77"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2142,7 +2133,6 @@ name = "librespot-playback"
 version = "0.6.0-dev"
 dependencies = [
  "alsa",
- "atomic-shim",
  "cpal",
  "futures-util",
  "glib",
@@ -2158,6 +2148,7 @@ dependencies = [
  "log",
  "ogg",
  "parking_lot",
+ "portable-atomic",
  "portaudio-rs",
  "rand",
  "rand_distr",

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -21,7 +21,7 @@ path = "../metadata"
 version = "0.6.0-dev"
 
 [dependencies]
-atomic-shim = "0.2.0"
+portable-atomic = "1"
 futures-util = "0.3"
 log = "0.4"
 parking_lot = { version = "0.12", features = ["deadlock_detection"] }

--- a/playback/src/mixer/softmixer.rs
+++ b/playback/src/mixer/softmixer.rs
@@ -1,4 +1,4 @@
-use atomic_shim::AtomicU64;
+use portable_atomic::AtomicU64;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
 


### PR DESCRIPTION
Replacing atomic_shim with portable-atomic, since atomic_shim worsk well for MIPS and MIPSEL, but has problems with some ARM flavours.