### PR TITLE
Handle/Ignore unknown audio formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Replaced `SpircLoadCommand` with `LoadRequest`, `LoadRequestOptions` and `LoadContextOptions` (breaking)
 - [connect] Moved all public items to the highest level (breaking)
 - [connect] Replaced Mercury usage in `Spirc` with Dealer
+- [metadata] Replaced `AudioFileFormat` with own enum. (breaking)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Fix "play" command not handled if missing "offset" property
 - [discovery] Fix libmdns zerconf setup errors not propagating to the main task.
 - [metadata] `Show::trailer_uri` is now optional since it isn't always present (breaking)
+- [metadata] Fix incorrect parsing of audio format
 - [connect] Handle transfer of playback with empty "uri" field
 - [connect] Correctly apply playing/paused state when transferring playback
 

--- a/metadata/src/audio/file.rs
+++ b/metadata/src/audio/file.rs
@@ -6,11 +6,73 @@ use std::{
 
 use librespot_core::FileId;
 
+use crate::util::impl_deref_wrapped;
 use librespot_protocol as protocol;
-pub use protocol::metadata::audio_file::Format as AudioFileFormat;
 use protocol::metadata::AudioFile as AudioFileMessage;
 
-use crate::util::impl_deref_wrapped;
+use librespot_protocol::metadata::audio_file::Format;
+use protobuf::Enum;
+
+#[allow(non_camel_case_types)]
+#[derive(Debug, Copy, Clone, Eq, PartialEq, Hash)]
+pub enum AudioFileFormat {
+    OGG_VORBIS_96,   // 0
+    OGG_VORBIS_160,  // 1
+    OGG_VORBIS_320,  // 2
+    MP3_256,         // 3
+    MP3_320,         // 4
+    MP3_160,         // 5
+    MP3_96,          // 6
+    MP3_160_ENC,     // 7
+    AAC_24,          // 8
+    AAC_48,          // 9
+    FLAC_FLAC,       // 16
+    XHE_AAC_24,      // 18
+    XHE_AAC_16,      // 19
+    XHE_AAC_12,      // 20
+    FLAC_FLAC_24BIT, // 22
+    // not defined in protobuf, but sometimes send
+    AAC_160, // 10
+    AAC_320, // 11
+    MP4_128, // 12
+    OTHER5,  // 13
+}
+
+impl TryFrom<i32> for AudioFileFormat {
+    type Error = i32;
+
+    fn try_from(value: i32) -> Result<Self, Self::Error> {
+        Ok(match value {
+            10 => AudioFileFormat::AAC_160,
+            11 => AudioFileFormat::AAC_320,
+            12 => AudioFileFormat::MP4_128,
+            13 => AudioFileFormat::OTHER5,
+            _ => Format::from_i32(value).ok_or(value)?.into(),
+        })
+    }
+}
+
+impl From<Format> for AudioFileFormat {
+    fn from(value: Format) -> Self {
+        match value {
+            Format::OGG_VORBIS_96 => AudioFileFormat::OGG_VORBIS_96,
+            Format::OGG_VORBIS_160 => AudioFileFormat::OGG_VORBIS_160,
+            Format::OGG_VORBIS_320 => AudioFileFormat::OGG_VORBIS_320,
+            Format::MP3_256 => AudioFileFormat::MP3_256,
+            Format::MP3_320 => AudioFileFormat::MP3_320,
+            Format::MP3_160 => AudioFileFormat::MP3_160,
+            Format::MP3_96 => AudioFileFormat::MP3_96,
+            Format::MP3_160_ENC => AudioFileFormat::MP3_160_ENC,
+            Format::AAC_24 => AudioFileFormat::AAC_24,
+            Format::AAC_48 => AudioFileFormat::AAC_48,
+            Format::FLAC_FLAC => AudioFileFormat::FLAC_FLAC,
+            Format::XHE_AAC_24 => AudioFileFormat::XHE_AAC_24,
+            Format::XHE_AAC_16 => AudioFileFormat::XHE_AAC_16,
+            Format::XHE_AAC_12 => AudioFileFormat::XHE_AAC_12,
+            Format::FLAC_FLAC_24BIT => AudioFileFormat::FLAC_FLAC_24BIT,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Default)]
 pub struct AudioFiles(pub HashMap<AudioFileFormat, FileId>);
@@ -51,7 +113,7 @@ impl From<&[AudioFileMessage]> for AudioFiles {
                 let file_id = FileId::from(file.file_id());
                 if let Some(format) = file.format {
                     match format.enum_value() {
-                        Ok(f) => return Some((f, file_id)),
+                        Ok(f) => return Some((f.into(), file_id)),
                         Err(unknown) => {
                             trace!("Ignoring file <{}> with unknown format {unknown}", file_id);
                         }

--- a/metadata/src/audio/file.rs
+++ b/metadata/src/audio/file.rs
@@ -49,12 +49,17 @@ impl From<&[AudioFileMessage]> for AudioFiles {
             .iter()
             .filter_map(|file| {
                 let file_id = FileId::from(file.file_id());
-                if file.has_format() {
-                    Some((file.format(), file_id))
+                if let Some(format) = file.format {
+                    match format.enum_value() {
+                        Ok(f) => return Some((f, file_id)),
+                        Err(unknown) => {
+                            trace!("Ignoring file <{}> with unknown format {unknown}", file_id);
+                        }
+                    }
                 } else {
                     trace!("Ignoring file <{}> with unspecified format", file_id);
-                    None
                 }
+                None
             })
             .collect();
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -917,6 +917,10 @@ impl PlayerTrackLoader {
             AudioFileFormat::MP3_160_ENC => 20.,
             AudioFileFormat::AAC_24 => 3.,
             AudioFileFormat::AAC_48 => 6.,
+            AudioFileFormat::AAC_160 => 20.,
+            AudioFileFormat::AAC_320 => 40.,
+            AudioFileFormat::MP4_128 => 16.,
+            AudioFileFormat::OTHER5 => 40.,
             AudioFileFormat::FLAC_FLAC => 112., // assume 900 kbit/s on average
             AudioFileFormat::XHE_AAC_12 => 1.5,
             AudioFileFormat::XHE_AAC_16 => 2.,


### PR DESCRIPTION
Fixes the incorrect parsing when a audio format is unknown. See explanation here https://github.com/librespot-org/librespot/pull/1434#issuecomment-2596950985.

Fixes #1433