### PR TITLE
Expose possible mixer opening errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Moved all public items to the highest level (breaking)
 - [connect] Replaced Mercury usage in `Spirc` with Dealer
 - [metadata] Replaced `AudioFileFormat` with own enum. (breaking)
+- [playback] Changed trait `Mixer::open` to return `Result<Self, Error>` instead of `Self` (breaking)
+- [playback] Changed type alias `MixerFn` to return `Result<Arc<dyn Mixer>, Error>` instead of `Arc<dyn Mixer>` (breaking)
 
 ### Added
 

--- a/connect/README.md
+++ b/connect/README.md
@@ -55,7 +55,7 @@ async fn create_basic_spirc() -> Result<(), Error> {
         session,
         credentials,
         player,
-        mixer(MixerConfig::default())
+        mixer(MixerConfig::default())?
     ).await?;
 
     Ok(())

--- a/examples/play_connect.rs
+++ b/examples/play_connect.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<(), Error> {
         })?;
 
     let session = Session::new(session_config, Some(cache));
-    let mixer = mixer_builder(mixer_config);
+    let mixer = mixer_builder(mixer_config)?;
 
     let player = Player::new(
         player_config,

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -1,6 +1,6 @@
-use std::sync::Arc;
-
 use crate::config::VolumeCtrl;
+use librespot_core::Error;
+use std::sync::Arc;
 
 pub mod mappings;
 use self::mappings::MappedCtrl;
@@ -8,12 +8,12 @@ use self::mappings::MappedCtrl;
 pub struct NoOpVolume;
 
 pub trait Mixer: Send + Sync {
-    fn open(config: MixerConfig) -> Self
+    fn open(config: MixerConfig) -> Result<Self, Error>
     where
         Self: Sized;
 
-    fn set_volume(&self, volume: u16);
     fn volume(&self) -> u16;
+    fn set_volume(&self, volume: u16);
 
     fn get_soft_volume(&self) -> Box<dyn VolumeGetter + Send> {
         Box::new(NoOpVolume)
@@ -57,10 +57,10 @@ impl Default for MixerConfig {
     }
 }
 
-pub type MixerFn = fn(MixerConfig) -> Arc<dyn Mixer>;
+pub type MixerFn = fn(MixerConfig) -> Result<Arc<dyn Mixer>, Error>;
 
-fn mk_sink<M: Mixer + 'static>(config: MixerConfig) -> Arc<dyn Mixer> {
-    Arc::new(M::open(config))
+fn mk_sink<M: Mixer + 'static>(config: MixerConfig) -> Result<Arc<dyn Mixer>, Error> {
+    Ok(Arc::new(M::open(config)?))
 }
 
 pub const MIXERS: &[(&str, MixerFn)] = &[

--- a/playback/src/mixer/softmixer.rs
+++ b/playback/src/mixer/softmixer.rs
@@ -1,10 +1,10 @@
-use portable_atomic::AtomicU64;
-use std::sync::atomic::Ordering;
-use std::sync::Arc;
-
 use super::VolumeGetter;
 use super::{MappedCtrl, VolumeCtrl};
 use super::{Mixer, MixerConfig};
+use librespot_core::Error;
+use portable_atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::sync::Arc;
 
 #[derive(Clone)]
 pub struct SoftMixer {
@@ -15,14 +15,14 @@ pub struct SoftMixer {
 }
 
 impl Mixer for SoftMixer {
-    fn open(config: MixerConfig) -> Self {
+    fn open(config: MixerConfig) -> Result<Self, Error> {
         let volume_ctrl = config.volume_ctrl;
         info!("Mixing with softvol and volume control: {:?}", volume_ctrl);
 
-        Self {
+        Ok(Self {
             volume: Arc::new(AtomicU64::new(f64::to_bits(0.5))),
             volume_ctrl,
-        }
+        })
     }
 
     fn volume(&self) -> u16 {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,3 @@
-use std::{
-    env,
-    fs::create_dir_all,
-    ops::RangeInclusive,
-    path::{Path, PathBuf},
-    pin::Pin,
-    process::exit,
-    str::FromStr,
-    time::{Duration, Instant},
-};
-
 use data_encoding::HEXLOWER;
 use futures_util::StreamExt;
 #[cfg(feature = "alsa-backend")]
@@ -33,6 +22,16 @@ use librespot::{
 use librespot_oauth::OAuthClientBuilder;
 use log::{debug, error, info, trace, warn};
 use sha1::{Digest, Sha1};
+use std::{
+    env,
+    fs::create_dir_all,
+    ops::RangeInclusive,
+    path::{Path, PathBuf},
+    pin::Pin,
+    process::exit,
+    str::FromStr,
+    time::{Duration, Instant},
+};
 use sysinfo::{ProcessesToUpdate, System};
 use thiserror::Error;
 use url::Url;
@@ -1921,7 +1920,13 @@ async fn main() {
     }
 
     let mixer_config = setup.mixer_config.clone();
-    let mixer = (setup.mixer)(mixer_config);
+    let mixer = match (setup.mixer)(mixer_config) {
+        Ok(mixer) => mixer,
+        Err(why) => {
+            error!("{why}");
+            exit(1)
+        }
+    };
     let player_config = setup.player_config.clone();
 
     let soft_volume = mixer.get_soft_volume();


### PR DESCRIPTION
This should address the possible panic found in #1478 by exposing the errors that might occur while opening a device. 

The binary will now exit when it encounters an issue while opening the mixer.

Fixes #1478