### PR TITLE
Mark unrelated parsing error as warning

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -411,11 +411,15 @@ impl SpircTask {
                     }
                 }
             };
-            ( $next:expr, match |$ok:ident| $use_ok:expr ) => {
+            ( $next:expr, $log:ident!($msg:expr), match |$ok:ident| $use_ok:expr ) => {
                 unwrap!($next, |$ok| match $ok {
                     Ok($ok) => $use_ok,
-                    Err(why) => error!("could not parse {}: {}", stringify!($ok), why),
+                    Err(why) => $log!("{} could not parse {}: {}", $msg, stringify!($ok), why),
                 })
+            };
+
+            ( $next:expr, match |$ok:ident| $use_ok:expr ) => {
+                unwrap! { $next, error!(""), match |$ok| $use_ok }
             };
         }
 
@@ -486,6 +490,7 @@ impl SpircTask {
                 },
                 session_update = self.session_update.next() => unwrap! {
                     session_update,
+                    warn!("Known parsing error for WIFI_BROADCAST_CHANGED."),
                     match |session_update| self.handle_session_update(session_update)
                 },
                 cmd = async { commands?.recv().await }, if commands.is_some() => if let Some(cmd) = cmd {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -419,7 +419,7 @@ impl SpircTask {
             };
 
             ( $next:expr, match |$ok:ident| $use_ok:expr ) => {
-                unwrap! { $next, error!(""), match |$ok| $use_ok }
+                unwrap! { $next, error!("Unexpected:"), match |$ok| $use_ok }
             };
         }
 

--- a/core/src/dealer/mod.rs
+++ b/core/src/dealer/mod.rs
@@ -357,7 +357,7 @@ impl DealerShared {
             }
         }
 
-        warn!("No subscriber for msg.uri: {}", msg.uri);
+        debug!("No subscriber for msg.uri: {}", msg.uri);
     }
 
     fn dispatch_request(

--- a/core/src/deserialize_with.rs
+++ b/core/src/deserialize_with.rs
@@ -35,11 +35,7 @@ where
     D: Deserializer<'de>,
 {
     let v: Value = Deserialize::deserialize(de)?;
-    parse_value_to_msg(&v).map_err(|why| {
-        warn!("deserialize_json_proto: {v}");
-        error!("deserialize_json_proto: {why}");
-        Error::custom(why)
-    })
+    parse_value_to_msg(&v).map_err(Error::custom)
 }
 
 pub fn option_json_proto<'de, T, D>(de: D) -> Result<Option<T>, D::Error>


### PR DESCRIPTION
The parsing error was multiple times falsely refereed to as possible cause, even tho it is completely unrelated to the main issue in most cases. 

The issue will always happens when playing from an official player and then transferring the playback to `librespot`. The log message looked like the following:
```
[2025-04-20T09:14:08Z ERROR librespot_connect::spirc] could not parse session_update: Invalid state { Unknown enum variant name: WIFI_BROADCAST_CHANGED at 1:11 }
```

This change reduces the log level for the parsing failure for `session_update` to `warn`, while adding an additional message to highlight why it is only a warning.