### PR TITLE
Fix compiler error when `objc2` is in dependency tree

### DIFF
--- a/connect/src/shuffle_vec.rs
+++ b/connect/src/shuffle_vec.rs
@@ -55,7 +55,7 @@ impl<T> ShuffleVec<T> {
             self.unshuffle()
         }
 
-        let indices = {
+        let indices: Vec<_> = {
             (1..self.vec.len())
                 .rev()
                 .map(|i| rng.gen_range(0..i + 1))


### PR DESCRIPTION
@simlay is working on upgrading `cpal` to depend on `objc2` in https://github.com/RustAudio/coreaudio-rs/issues/132, but because of an unrelated `impl IntoIterator` in `objc2`, compiling `librespot` fails with the following error:

```
simlay@m1-mbp-si:~/projects/rust-audio/librespot (dev)$ cargo build
   Compiling librespot-connect v0.6.0-dev (/Users/simlay/projects/rust-audio/librespot/connect)
uerror[E0275]: overflow evaluating the requirement `&_: IntoIterator`
  --> connect/src/shuffle_vec.rs:65:56
   |
65 |         for (i, &rnd_ind) in (1..self.vec.len()).rev().zip(&indices) {
   |                                                        ^^^
   |
   = help: consider increasing the recursion limit by adding a `#![recursion_limit = "256"]` attribute to your crate (`librespot_connect`)
   = note: required for `&objc2::rc::retained::Retained<_>` to implement `IntoIterator`
   = note: 126 redundant requirements hidden
   = note: required for `&Retained<Retained<Retained<Retained<Retained<...>>>>>` to implement `IntoIterator`
   = note: the full name for the type has been written to '/Users/simlay/projects/rust-audio/librespot/target/debug/deps/librespot_connect-d7de9da5a372e7ea.long-type-1250449993922365444.txt'
   = note: consider using `--verbose` to print the full type name to the console

For more information about this error, try `rustc --explain E0275`.
error: could not compile `librespot-connect` (lib) due to 1 previous error
```

This is a type inference bug in `rustc` that will be fixed with the new trait solver, see https://github.com/rust-lang/rust/issues/136856, but in the meantime we can fix this in `librespot`.