### PR TITLE
Chore: fix clippy warnings for stable (1.87) and nightly (1.89)

### DIFF
--- a/core/src/mercury/types.rs
+++ b/core/src/mercury/types.rs
@@ -57,7 +57,7 @@ impl std::fmt::Display for MercuryMethod {
             MercuryMethod::Unsub => "UNSUB",
             MercuryMethod::Send => "SEND",
         };
-        write!(f, "{}", s)
+        write!(f, "{s}")
     }
 }
 

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -96,12 +96,10 @@ pub fn find(name: Option<&str>) -> Result<DnsSdServiceBuilder, Error> {
         match BACKENDS.iter().find(|(id, _)| name == id) {
             Some((_id, Some(launch_svc))) => Ok(*launch_svc),
             Some((_id, None)) => Err(Error::unavailable(format!(
-                "librespot built without '{}' support",
-                name
+                "librespot built without '{name}' support"
             ))),
             None => Err(Error::not_found(format!(
-                "unknown zeroconf backend '{}'",
-                name
+                "unknown zeroconf backend '{name}'"
             ))),
         }
     } else {
@@ -286,14 +284,14 @@ async fn avahi_task(
                             //
                             // EntryGroup has been withdrawn at this point already!
                             log::error!("zeroconf collision for name '{}'", &name);
-                            return Err(zbus::Error::Failure(format!("zeroconf collision for name: {}", name)).into());
+                            return Err(zbus::Error::Failure(format!("zeroconf collision for name: {name}")).into());
                         }
                         EntryGroupState::Failure => {
                             // TODO: Back off/treat as fatal?
                             // EntryGroup has been withdrawn at this point already!
                             // There seems to be no code in Avahi that actually sets this state.
                             log::error!("zeroconf failure: {}", error);
-                            return Err(zbus::Error::Failure(format!("zeroconf failure: {}", error)).into());
+                            return Err(zbus::Error::Failure(format!("zeroconf failure: {error}")).into());
                         }
                     }
                 }

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -237,7 +237,7 @@ impl OAuthClient {
         if self.should_open_url {
             open::that_in_background(auth_url.as_str());
         }
-        println!("Browse to: {}", auth_url);
+        println!("Browse to: {auth_url}");
 
         pkce_verifier
     }
@@ -456,7 +456,7 @@ pub fn get_access_token(
         .set_pkce_challenge(pkce_challenge)
         .url();
 
-    println!("Browse to: {}", auth_url);
+    println!("Browse to: {auth_url}");
 
     let code = match get_socket_address(redirect_uri) {
         Some(addr) => get_authcode_listener(addr, String::from("Go back to your terminal :)")),

--- a/playback/src/mixer/mappings.rs
+++ b/playback/src/mixer/mappings.rs
@@ -158,6 +158,6 @@ impl CubicMapping {
     fn min_norm(db_range: f64) -> f64 {
         // Note that this 60.0 is unrelated to DEFAULT_DB_RANGE.
         // Instead, it's the cubic voltage to dB ratio.
-        f64::powf(10.0, -1.0 * db_range / 60.0)
+        f64::powf(10.0, -db_range / 60.0)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1227,8 +1227,7 @@ fn get_setup() -> Setup {
         Some("librespot compiled without zeroconf backend".to_owned())
     } else if opt_present(DISABLE_DISCOVERY) {
         Some(format!(
-            "the `--{}` / `-{}` flag set",
-            DISABLE_DISCOVERY, DISABLE_DISCOVERY_SHORT,
+            "the `--{DISABLE_DISCOVERY}` / `-{DISABLE_DISCOVERY_SHORT}` flag set",
         ))
     } else {
         None


### PR DESCRIPTION
Fixes the current `clippy` warnings and upcoming `clippy` warnings ( up until 1.79, aka current nightly). The fixes where applied automatically by `clippy` with the following commands.

```sh
cargo clippy --workspace --all-features --allow-dirty --fix
```

```sh
cargo +nightly clippy --workspace --all-features --allow-dirty --fix
```