### PR TITLE
Fix: playback of uris by api request

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -977,7 +977,10 @@ impl SpircTask {
                 return self.notify().await;
             }
             Play(mut play) => {
-                let first_page = play.context.pages.pop();
+                if !self.connect_state.is_active() {
+                    self.handle_activate()
+                }
+
                 let context = match play.context.uri {
                     Some(s) => PlayContext::Uri(s),
                     None if !play.context.pages.is_empty() => PlayContext::Tracks(
@@ -1008,7 +1011,7 @@ impl SpircTask {
                             context_options,
                         },
                     },
-                    first_page,
+                    play.context.pages.pop(),
                 )
                 .await?;
 


### PR DESCRIPTION
- pop page after it was used, otherwise we might run into an error that doesn't exist
- become active when play is requested, otherwise we are playing but it isn't visible to connect devices

fixes #1508