### PR TITLE
Perf: reduce sink usage to improve idle CPU usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Moved all public items to the highest level (breaking)
 - [connect] Replaced Mercury usage in `Spirc` with Dealer
 - [metadata] Replaced `AudioFileFormat` with own enum. (breaking)
+- [player] Changed `sink_builder` parameter from `FnOnce()` to `Fn()` of `Player::new` (breaking)
 
 ### Added
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1949,9 +1949,10 @@ async fn main() {
     let soft_volume = mixer.get_soft_volume();
     let format = setup.format;
     let backend = setup.backend;
-    let device = setup.device.clone();
+    let device = setup.device;
+
     let player = Player::new(player_config, session.clone(), soft_volume, move || {
-        (backend)(device, format)
+        backend(device.clone(), format)
     });
 
     if let Some(player_event_program) = setup.player_event_program.clone() {


### PR DESCRIPTION
This PR tries to address the high idle cpu usage discussed in #1500.

By closing the sink when not in use and opening it when streaming, the idle CPU usage should decrease. 

> Additionally this should also resolve a bug where disconnection a device on windows results in loosing the output sink and having to restart librespot as result. Tho I didn't verify that yet.
>
> Sadly that issue isn't resolved by that, so might be rather related to the mixer instead of the sink