### PR TITLE
fix: add fallback logic for CDN urls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [core] MSRV is now 1.81 (breaking)
 - [core] AP connect and handshake have a combined 5 second timeout.
+- [core] `stream_from_cdn` now accepts the URL as a `&str` instead of `CdnUrl` (breaking)
 - [connect] Replaced `has_volume_ctrl` with `disable_volume` in `ConnectConfig` (breaking)
 - [connect] Changed `initial_volume` from `Option<u16>` to `u16` in `ConnectConfig` (breaking)
 - [connect] Replaced `SpircLoadCommand` with `LoadRequest`, `LoadRequestOptions` and `LoadContextOptions` (breaking)
@@ -30,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [playback] Add `track` field to `PlayerEvent::RepeatChanged` (breaking)
 - [playback] Add `PlayerEvent::PositionChanged` event to notify about the current playback position
 - [core] Add `request_with_options` and `request_with_protobuf_and_options` to `SpClient`
+- [core] Add `try_get_urls` to `CdnUrl`
 - [oauth] Add `OAuthClient` and `OAuthClientBuilder` structs to achieve a more customizable login process
 
 ### Fixed
@@ -48,10 +50,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Handle transfer of playback with empty "uri" field
 - [connect] Correctly apply playing/paused state when transferring playback
 - [player] Saturate invalid seek positions to track duration
+- [audio] Fall back to other URLs in case of a failure when downloading from CDN
 
 ### Deprecated
 
 - [oauth] `get_access_token()` function marked for deprecation
+- [core] `try_get_url()` function marked for deprecation
 
 ### Removed
 

--- a/audio/src/fetch/mod.rs
+++ b/audio/src/fetch/mod.rs
@@ -435,9 +435,10 @@ impl AudioFileStreaming {
             // larger than the audio file we're going to stream later on. This is OK; requesting
             // `Content-Range` > `Content-Length` will return the complete file with status code
             // 206 Partial Content.
-            let mut streamer = session
-                .spclient()
-                .stream_from_cdn(url, 0, minimum_download_size)?;
+            let mut streamer =
+                session
+                    .spclient()
+                    .stream_from_cdn(*url, 0, minimum_download_size)?;
 
             // Get the first chunk with the headers to get the file size.
             // The remainder of that chunk with possibly also a response body is then

--- a/audio/src/fetch/mod.rs
+++ b/audio/src/fetch/mod.rs
@@ -306,7 +306,7 @@ struct AudioFileDownloadStatus {
 }
 
 struct AudioFileShared {
-    cdn_url: CdnUrl,
+    cdn_url: String,
     file_size: usize,
     bytes_per_second: usize,
     cond: Condvar,
@@ -426,25 +426,41 @@ impl AudioFileStreaming {
     ) -> Result<AudioFileStreaming, Error> {
         let cdn_url = CdnUrl::new(file_id).resolve_audio(&session).await?;
 
-        if let Ok(url) = cdn_url.try_get_url() {
-            trace!("Streaming from {}", url);
-        }
-
         let minimum_download_size = AudioFetchParams::get().minimum_download_size;
 
-        // When the audio file is really small, this `download_size` may turn out to be
-        // larger than the audio file we're going to stream later on. This is OK; requesting
-        // `Content-Range` > `Content-Length` will return the complete file with status code
-        // 206 Partial Content.
-        let mut streamer =
-            session
-                .spclient()
-                .stream_from_cdn(&cdn_url, 0, minimum_download_size)?;
+        let mut response_streamer_url = None;
 
-        // Get the first chunk with the headers to get the file size.
-        // The remainder of that chunk with possibly also a response body is then
-        // further processed in `audio_file_fetch`.
-        let response = streamer.next().await.ok_or(AudioFileError::NoData)??;
+        for url in cdn_url.try_get_urls()? {
+            // When the audio file is really small, this `download_size` may turn out to be
+            // larger than the audio file we're going to stream later on. This is OK; requesting
+            // `Content-Range` > `Content-Length` will return the complete file with status code
+            // 206 Partial Content.
+            let mut streamer = session
+                .spclient()
+                .stream_from_cdn(url, 0, minimum_download_size)?;
+
+            // Get the first chunk with the headers to get the file size.
+            // The remainder of that chunk with possibly also a response body is then
+            // further processed in `audio_file_fetch`.
+            let resp: Result<Response<Incoming>, Error> = streamer
+                .next()
+                .await
+                .map_or(Err(AudioFileError::NoData.into()), |x| Ok(x?));
+
+            match resp {
+                Ok(r) => {
+                    response_streamer_url = Some((r, streamer, url));
+                    break;
+                }
+                Err(e) => warn!("Fetching {url} failed with error {e:?}, trying next"),
+            }
+        }
+
+        let Some((response, streamer, url)) = response_streamer_url else {
+            return Err(Error::unavailable("all URLs failed, none left to try"));
+        };
+
+        trace!("Streaming from {}", url);
 
         let code = response.status();
         if code != StatusCode::PARTIAL_CONTENT {
@@ -473,7 +489,7 @@ impl AudioFileStreaming {
         };
 
         let shared = Arc::new(AudioFileShared {
-            cdn_url,
+            cdn_url: url.to_string(),
             file_size,
             bytes_per_second,
             cond: Condvar::new(),

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -6,7 +6,6 @@ use std::{
 use crate::config::{os_version, OS};
 use crate::{
     apresolve::SocketAddress,
-    cdn_url::CdnUrl,
     config::SessionConfig,
     error::ErrorKind,
     protocol::{
@@ -732,14 +731,13 @@ impl SpClient {
 
     pub fn stream_from_cdn(
         &self,
-        cdn_url: &CdnUrl,
+        cdn_url: &str,
         offset: usize,
         length: usize,
     ) -> Result<IntoStream<ResponseFuture>, Error> {
-        let url = cdn_url.try_get_url()?;
         let req = Request::builder()
             .method(&Method::GET)
-            .uri(url)
+            .uri(cdn_url)
             .header(
                 RANGE,
                 HeaderValue::from_str(&format!("bytes={}-{}", offset, offset + length - 1))?,

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -26,7 +26,7 @@ use crate::{
 use bytes::Bytes;
 use data_encoding::HEXUPPER_PERMISSIVE;
 use futures_util::future::IntoStream;
-use http::header::HeaderValue;
+use http::{header::HeaderValue, Uri};
 use hyper::{
     header::{HeaderName, ACCEPT, AUTHORIZATION, CONTENT_TYPE, RANGE},
     HeaderMap, Method, Request,
@@ -729,12 +729,16 @@ impl SpClient {
         self.request(&Method::GET, &endpoint, None, None).await
     }
 
-    pub fn stream_from_cdn(
+    pub fn stream_from_cdn<U>(
         &self,
-        cdn_url: &str,
+        cdn_url: U,
         offset: usize,
         length: usize,
-    ) -> Result<IntoStream<ResponseFuture>, Error> {
+    ) -> Result<IntoStream<ResponseFuture>, Error>
+    where
+        U: TryInto<Uri>,
+        <U as TryInto<Uri>>::Error: Into<http::Error>,
+    {
         let req = Request::builder()
             .method(&Method::GET)
             .uri(cdn_url)


### PR DESCRIPTION
- The solution here is to make `CdnUrl` return all non-expired URLs instead of just the first one. Then, in `AudioFileStreaming` all URLs are tried and the first working URL is selected for later use.
  - This means that the fallback logic is not implemented for following requests in `AudioFileFetch::download_range`, but that is also a synchronous function so implementing that would probably require an overhaul of the codebase anyway, unless I'm missing something.
    - This would only become an issue if the URL that worked for the first request stopped working for the following requests.
- I tried minimizing API breakage, but it seems impossible to implement the fallback logic inside `stream_from_cdn`, as it is not async (it doesn't actually send the request), so I made it accept the singular URL instead of `CdnUrl`. It is the responsibility of the caller to implement URL fallback logic by inspecting the result of the streamer.
- The main issue in this first version of the PR is that it's not impossible to use an arbitrary URL with `stream_from_cdn` anymore, but there are a few ways this could be fixed.
  - maybe adding a new type for the singular URLs, like `SingleCdnUrl`?
  - or adding a method to `CdnUrl` that would select the working URL and discard the rest?

<details><summary>Example log</summary>

```
[...]
[2025-08-03T16:49:40Z INFO  librespot_core::spclient] Resolved "gew4-spclient.spotify.com:443" as spclient access point
[2025-08-03T16:49:40Z INFO  librespot_connect::spirc] active device is <405ad53c8038c055e1b13c844c31f50d8bb4b136> with session <3b615ec204e9964c776ce57aa0896dac>
[2025-08-03T16:49:40Z WARN  librespot_connect::state::context] couldn't load context info because: context is not available. type: Default
[2025-08-03T16:49:40Z INFO  librespot_playback::player] Loading <No Fun> with Spotify URI <spotify:track:5ImCVtO1gvcD1ttdG5SrQT>
[2025-08-03T16:49:41Z WARN  librespot_audio::fetch] Fetching https://audio-akp.spotifycdn.com/audio/[...] failed with error Error { kind: Unavailable, error: hyper_util::client::legacy::Error(Connect, Custom { kind: Other, error: ConnectError("dns error", Os { code: 11001, kind: Uncategorized, message: "No such host is known." }) }) }, trying next
[2025-08-03T16:49:41Z INFO  librespot_playback::player] <No Fun> (411147 ms) loaded
```
</details>

Closes: #1521