### PR TITLE
refactor: Introduce SpotifyUri struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Removed
 
+- [core] Removed `SpotifyItemType` enum; the new `SpotifyUri` is an enum over all item types and so which variant it is 
+  describes its item type (breaking)
+
 ### Fixed
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [playback] Changed type of `SpotifyId` fields in `PlayerEvent` members to `SpotifyUri` (breaking)
 - [metadata] Changed arguments for `Metadata` trait from `&SpotifyId` to `&SpotifyUri` (breaking)
-- [player] `load()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri`
-- [player] `preload()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri`
+- [player] `load()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
+- [player] `preload()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,17 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [player] `load()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
 - [player] `preload()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
 
-### Deprecated
-
-
 ### Removed
 
 - [core] Removed `SpotifyItemType` enum; the new `SpotifyUri` is an enum over all item types and so which variant it is 
   describes its item type (breaking)
-
-### Fixed
-
-### Security
 
 ## [v0.7.1] - 2025-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,34 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) since v0.2.0.
 
+## [Unreleased]
+
+### Added
+
+- [playback] Add `load_uri()` function to load a `SpotifyUri`
+- [playback] Add `preload_uri()` function to load a `SpotifyUri`
+- [core] Add `SpotifyUri` type to represent more types of URI than `SpotifyId` can
+
+### Changed
+
+- [connect] Changed `track_id` parameter in `SpircTask::handle_unavailable` from `SpotifyId` to `&SpotifyUri` (breaking)
+- [connect] Changed return type of `ConnectState::preview_next_track` from `Option<SpotifyId>` to
+  `Option<SpotifyUri>` (breaking)
+- [connect] Changed type of `id` parameter `ConnectState::mark_unavailable` from `SpotifyId` to `&SpotifyUri` (breaking)
+- [playback] Changed type of `SpotifyId` fields in `PlayerEvent` members to `SpotifyUri` (breaking)
+- [metadata] Changed arguments for `Metadata` trait from `&SpotifyId` to `&SpotifyUri` (breaking)
+
+### Deprecated
+
+- [player] `load()` function marked for deprecation
+- [player] `preload()` function marked for deprecation
+
+### Removed
+
+### Fixed
+
+### Security
+
 ## [v0.7.1] - 2025-08-31
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,23 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- [playback] Add `load_uri()` function to load a `SpotifyUri`
-- [playback] Add `preload_uri()` function to load a `SpotifyUri`
 - [core] Add `SpotifyUri` type to represent more types of URI than `SpotifyId` can
 
 ### Changed
 
-- [connect] Changed `track_id` parameter in `SpircTask::handle_unavailable` from `SpotifyId` to `&SpotifyUri` (breaking)
-- [connect] Changed return type of `ConnectState::preview_next_track` from `Option<SpotifyId>` to
-  `Option<SpotifyUri>` (breaking)
-- [connect] Changed type of `id` parameter `ConnectState::mark_unavailable` from `SpotifyId` to `&SpotifyUri` (breaking)
 - [playback] Changed type of `SpotifyId` fields in `PlayerEvent` members to `SpotifyUri` (breaking)
 - [metadata] Changed arguments for `Metadata` trait from `&SpotifyId` to `&SpotifyUri` (breaking)
+- [player] `load()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri`
+- [player] `preload()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri`
 
 ### Deprecated
 
-- [player] `load()` function marked for deprecation
-- [player] `preload()` function marked for deprecation
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,13 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [playback] Changed type of `SpotifyId` fields in `PlayerEvent` members to `SpotifyUri` (breaking)
 - [metadata] Changed arguments for `Metadata` trait from `&SpotifyId` to `&SpotifyUri` (breaking)
-- [player] `load()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
-- [player] `preload()` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
+- [player] `load` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
+- [player] `preload` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
+- [spclient] `get_radio_for_track` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
+
 
 ### Removed
 
 - [core] Removed `SpotifyItemType` enum; the new `SpotifyUri` is an enum over all item types and so which variant it is 
   describes its item type (breaking)
+- [core] Removed `NamedSpotifyId` struct; it was made obsolete by `SpotifyUri` (breaking)
+- [core] The following methods have been removed from `SpotifyId` and moved to `SpotifyUri` (breaking):
+  - `is_playable`
+  - `from_uri`
+  - `to_uri`
 
 ## [v0.7.1] - 2025-08-31
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -2,7 +2,7 @@ use crate::{
     LoadContextOptions, LoadRequestOptions, PlayContext,
     context_resolver::{ContextAction, ContextResolver, ResolveContext},
     core::{
-        Error, Session, SpotifyId,
+        Error, Session, SpotifyUri,
         authentication::Credentials,
         dealer::{
             manager::{BoxedStream, BoxedStreamResult, Reply, RequestReply},
@@ -778,7 +778,7 @@ impl SpircTask {
                 return Ok(());
             }
             PlayerEvent::Unavailable { track_id, .. } => {
-                self.handle_unavailable(track_id)?;
+                self.handle_unavailable(&track_id)?;
                 if self.connect_state.current_track(|t| &t.uri) == &track_id.to_uri()? {
                     self.handle_next(None)?
                 }
@@ -1494,12 +1494,12 @@ impl SpircTask {
         }
 
         if let Some(track_id) = self.connect_state.preview_next_track() {
-            self.player.preload(track_id);
+            self.player.preload_uri(track_id);
         }
     }
 
     // Mark unavailable tracks so we can skip them later
-    fn handle_unavailable(&mut self, track_id: SpotifyId) -> Result<(), Error> {
+    fn handle_unavailable(&mut self, track_id: &SpotifyUri) -> Result<(), Error> {
         self.connect_state.mark_unavailable(track_id)?;
         self.handle_preload_next_track();
 
@@ -1704,8 +1704,8 @@ impl SpircTask {
         }
 
         let current_uri = self.connect_state.current_track(|t| &t.uri);
-        let id = SpotifyId::from_uri(current_uri)?;
-        self.player.load(id, start_playing, position_ms);
+        let id = SpotifyUri::from_uri(current_uri)?;
+        self.player.load_uri(id, start_playing, position_ms);
 
         self.connect_state
             .update_position(position_ms, self.now_ms());

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1494,7 +1494,7 @@ impl SpircTask {
         }
 
         if let Some(track_id) = self.connect_state.preview_next_track() {
-            self.player.preload_uri(track_id);
+            self.player.preload(track_id);
         }
     }
 
@@ -1705,7 +1705,7 @@ impl SpircTask {
 
         let current_uri = self.connect_state.current_track(|t| &t.uri);
         let id = SpotifyUri::from_uri(current_uri)?;
-        self.player.load_uri(id, start_playing, position_ms);
+        self.player.load(id, start_playing, position_ms);
 
         self.connect_state
             .update_position(position_ms, self.now_ms());

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Error, SpotifyUri},
+    core::{Error, SpotifyId, SpotifyUri},
     protocol::{
         context::Context,
         context_page::ContextPage,
@@ -14,7 +14,6 @@ use crate::{
         provider::{IsProvider, Provider},
     },
 };
-use librespot_core::SpotifyId;
 use protobuf::MessageField;
 use std::collections::HashMap;
 use uuid::Uuid;

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -14,7 +14,7 @@ use crate::{
         provider::{IsProvider, Provider},
     },
 };
-use librespot_core::spotify_id::SpotifyItemType;
+use librespot_core::SpotifyId;
 use protobuf::MessageField;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -451,7 +451,9 @@ impl ConnectState {
                 Err(StateError::InvalidTrackUri(Some(uri.clone())))?
             }
             (Some(uri), _) if !uri.is_empty() => SpotifyUri::from_uri(uri)?,
-            (_, Some(gid)) if !gid.is_empty() => SpotifyUri::from_raw(gid, SpotifyItemType::Track)?,
+            (_, Some(gid)) if !gid.is_empty() => SpotifyUri::Track {
+                id: SpotifyId::from_raw(gid)?,
+            },
             _ => Err(StateError::InvalidTrackUri(None))?,
         };
 

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Error, SpotifyId},
+    core::{Error, SpotifyUri},
     protocol::{
         context::Context,
         context_page::ContextPage,
@@ -14,6 +14,7 @@ use crate::{
         provider::{IsProvider, Provider},
     },
 };
+use librespot_core::spotify_id::SpotifyItemType;
 use protobuf::MessageField;
 use std::collections::HashMap;
 use uuid::Uuid;
@@ -449,8 +450,8 @@ impl ConnectState {
             (Some(uri), _) if uri.contains(['?', '%']) => {
                 Err(StateError::InvalidTrackUri(Some(uri.clone())))?
             }
-            (Some(uri), _) if !uri.is_empty() => SpotifyId::from_uri(uri)?,
-            (_, Some(gid)) if !gid.is_empty() => SpotifyId::from_raw(gid)?,
+            (Some(uri), _) if !uri.is_empty() => SpotifyUri::from_uri(uri)?,
+            (_, Some(gid)) if !gid.is_empty() => SpotifyUri::from_raw(gid, SpotifyItemType::Track)?,
             _ => Err(StateError::InvalidTrackUri(None))?,
         };
 

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -1,5 +1,5 @@
 use crate::{
-    core::{Error, SpotifyId},
+    core::{Error, SpotifyUri},
     protocol::player::ProvidedTrack,
     state::{
         ConnectState, SPOTIFY_MAX_NEXT_TRACKS_SIZE, SPOTIFY_MAX_PREV_TRACKS_SIZE, StateError,
@@ -352,14 +352,14 @@ impl<'ct> ConnectState {
         Ok(())
     }
 
-    pub fn preview_next_track(&mut self) -> Option<SpotifyId> {
+    pub fn preview_next_track(&mut self) -> Option<SpotifyUri> {
         let next = if self.repeat_track() {
             self.current_track(|t| &t.uri)
         } else {
             &self.next_tracks().first()?.uri
         };
 
-        SpotifyId::from_uri(next).ok()
+        SpotifyUri::from_uri(next).ok()
     }
 
     pub fn has_next_tracks(&self, min: Option<usize>) -> bool {
@@ -381,7 +381,7 @@ impl<'ct> ConnectState {
         prev
     }
 
-    pub fn mark_unavailable(&mut self, id: SpotifyId) -> Result<(), Error> {
+    pub fn mark_unavailable(&mut self, id: &SpotifyUri) -> Result<(), Error> {
         let uri = id.to_uri()?;
 
         debug!("marking {uri} as unavailable");

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -32,6 +32,7 @@ mod socket;
 #[allow(dead_code)]
 pub mod spclient;
 pub mod spotify_id;
+pub mod spotify_uri;
 pub mod token;
 #[doc(hidden)]
 pub mod util;
@@ -42,3 +43,4 @@ pub use error::Error;
 pub use file_id::FileId;
 pub use session::Session;
 pub use spotify_id::SpotifyId;
+pub use spotify_uri::SpotifyUri;

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::config::{OS, os_version};
 use crate::{
-    Error, FileId, SpotifyId,
+    Error, FileId, SpotifyId, SpotifyUri,
     apresolve::SocketAddress,
     config::SessionConfig,
     error::ErrorKind,
@@ -676,10 +676,10 @@ impl SpClient {
             .await
     }
 
-    pub async fn get_radio_for_track(&self, track_id: &SpotifyId) -> SpClientResult {
+    pub async fn get_radio_for_track(&self, track_uri: &SpotifyUri) -> SpClientResult {
         let endpoint = format!(
             "/inspiredby-mix/v2/seed_to_playlist/{}?response-format=json",
-            track_id.to_uri()?
+            track_uri.to_uri()?
         );
 
         self.request_as_json(&Method::GET, &endpoint, None, None)

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -1,70 +1,26 @@
-use std::{fmt, ops::Deref};
+use std::fmt;
 
 use thiserror::Error;
 
 use crate::Error;
 
-use librespot_protocol as protocol;
-
 // re-export FileId for historic reasons, when it was part of this mod
 pub use crate::FileId;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum SpotifyItemType {
-    Album,
-    Artist,
-    Episode,
-    Playlist,
-    Show,
-    Track,
-    Local,
-    Unknown,
-}
-
-impl From<&str> for SpotifyItemType {
-    fn from(v: &str) -> Self {
-        match v {
-            "album" => Self::Album,
-            "artist" => Self::Artist,
-            "episode" => Self::Episode,
-            "playlist" => Self::Playlist,
-            "show" => Self::Show,
-            "track" => Self::Track,
-            "local" => Self::Local,
-            _ => Self::Unknown,
-        }
-    }
-}
-
-impl From<SpotifyItemType> for &str {
-    fn from(item_type: SpotifyItemType) -> &'static str {
-        match item_type {
-            SpotifyItemType::Album => "album",
-            SpotifyItemType::Artist => "artist",
-            SpotifyItemType::Episode => "episode",
-            SpotifyItemType::Playlist => "playlist",
-            SpotifyItemType::Show => "show",
-            SpotifyItemType::Track => "track",
-            SpotifyItemType::Local => "local",
-            _ => "unknown",
-        }
-    }
-}
+// re-export SpotifyItemType for similar reasons
+pub use crate::spotify_uri::SpotifyItemType;
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SpotifyId {
     pub id: u128,
-    pub item_type: SpotifyItemType,
 }
 
 #[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
 pub enum SpotifyIdError {
     #[error("ID cannot be parsed")]
     InvalidId,
-    #[error("not a valid Spotify URI")]
+    #[error("not a valid Spotify ID")]
     InvalidFormat,
-    #[error("URI does not belong to Spotify")]
-    InvalidRoot,
 }
 
 impl From<SpotifyIdError> for Error {
@@ -74,7 +30,6 @@ impl From<SpotifyIdError> for Error {
 }
 
 pub type SpotifyIdResult = Result<SpotifyId, Error>;
-pub type NamedSpotifyIdResult = Result<NamedSpotifyId, Error>;
 
 const BASE62_DIGITS: &[u8; 62] = b"0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 const BASE16_DIGITS: &[u8; 16] = b"0123456789abcdef";
@@ -83,14 +38,6 @@ impl SpotifyId {
     const SIZE: usize = 16;
     const SIZE_BASE16: usize = 32;
     const SIZE_BASE62: usize = 22;
-
-    /// Returns whether this `SpotifyId` is for a playable audio item, if known.
-    pub fn is_playable(&self) -> bool {
-        matches!(
-            self.item_type,
-            SpotifyItemType::Episode | SpotifyItemType::Track
-        )
-    }
 
     /// Parses a base16 (hex) encoded [Spotify ID] into a `SpotifyId`.
     ///
@@ -114,10 +61,7 @@ impl SpotifyId {
             dst += p;
         }
 
-        Ok(Self {
-            id: dst,
-            item_type: SpotifyItemType::Unknown,
-        })
+        Ok(Self { id: dst })
     }
 
     /// Parses a base62 encoded [Spotify ID] into a `u128`.
@@ -126,7 +70,7 @@ impl SpotifyId {
     ///
     /// [Spotify ID]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
     pub fn from_base62(src: &str) -> SpotifyIdResult {
-        if src.len() != 22 {
+        if src.len() != Self::SIZE_BASE62 {
             return Err(SpotifyIdError::InvalidId.into());
         }
         let mut dst: u128 = 0;
@@ -143,10 +87,7 @@ impl SpotifyId {
             dst = dst.checked_add(p).ok_or(SpotifyIdError::InvalidId)?;
         }
 
-        Ok(Self {
-            id: dst,
-            item_type: SpotifyItemType::Unknown,
-        })
+        Ok(Self { id: dst })
     }
 
     /// Creates a `u128` from a copy of `SpotifyId::SIZE` (16) bytes in big-endian order.
@@ -156,63 +97,9 @@ impl SpotifyId {
         match src.try_into() {
             Ok(dst) => Ok(Self {
                 id: u128::from_be_bytes(dst),
-                item_type: SpotifyItemType::Unknown,
             }),
             Err(_) => Err(SpotifyIdError::InvalidId.into()),
         }
-    }
-
-    /// Parses a [Spotify URI] into a `SpotifyId`.
-    ///
-    /// `uri` is expected to be in the canonical form `spotify:{type}:{id}`, where `{type}`
-    /// can be arbitrary while `{id}` is a 22-character long, base62 encoded Spotify ID.
-    ///
-    /// Note that this should not be used for playlists, which have the form of
-    /// `spotify:playlist:{id}`.
-    ///
-    /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
-    pub fn from_uri(src: &str) -> SpotifyIdResult {
-        // Basic: `spotify:{type}:{id}`
-        // Named: `spotify:user:{user}:{type}:{id}`
-        // Local: `spotify:local:{artist}:{album_title}:{track_title}:{duration_in_seconds}`
-        let mut parts = src.split(':');
-
-        let scheme = parts.next().ok_or(SpotifyIdError::InvalidFormat)?;
-
-        let item_type = {
-            let next = parts.next().ok_or(SpotifyIdError::InvalidFormat)?;
-            if next == "user" {
-                let _username = parts.next().ok_or(SpotifyIdError::InvalidFormat)?;
-                parts.next().ok_or(SpotifyIdError::InvalidFormat)?
-            } else {
-                next
-            }
-        };
-
-        let id = parts.next().ok_or(SpotifyIdError::InvalidFormat)?;
-
-        if scheme != "spotify" {
-            return Err(SpotifyIdError::InvalidRoot.into());
-        }
-
-        let item_type = item_type.into();
-
-        // Local files have a variable-length ID: https://developer.spotify.com/documentation/general/guides/local-files-spotify-playlists/
-        // TODO: find a way to add this local file ID to SpotifyId.
-        // One possible solution would be to copy the contents of `id` to a new String field in SpotifyId,
-        // but then we would need to remove the derived Copy trait, which would be a breaking change.
-        if item_type == SpotifyItemType::Local {
-            return Ok(Self { item_type, id: 0 });
-        }
-
-        if id.len() != Self::SIZE_BASE62 {
-            return Err(SpotifyIdError::InvalidId.into());
-        }
-
-        Ok(Self {
-            item_type,
-            ..Self::from_base62(id)?
-        })
     }
 
     /// Returns the `SpotifyId` as a base16 (hex) encoded, `SpotifyId::SIZE_BASE16` (32)
@@ -274,124 +161,19 @@ impl SpotifyId {
     pub fn to_raw(&self) -> [u8; Self::SIZE] {
         self.id.to_be_bytes()
     }
-
-    /// Returns the `SpotifyId` as a [Spotify URI] in the canonical form `spotify:{type}:{id}`,
-    /// where `{type}` is an arbitrary string and `{id}` is a 22-character long, base62 encoded
-    /// Spotify ID.
-    ///
-    /// If the `SpotifyId` has an associated type unrecognized by the library, `{type}` will
-    /// be encoded as `unknown`.
-    ///
-    /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
-    #[allow(clippy::wrong_self_convention)]
-    pub fn to_uri(&self) -> Result<String, Error> {
-        // 8 chars for the "spotify:" prefix + 1 colon + 22 chars base62 encoded ID  = 31
-        // + unknown size item_type.
-        let item_type: &str = self.item_type.into();
-        let mut dst = String::with_capacity(31 + item_type.len());
-        dst.push_str("spotify:");
-        dst.push_str(item_type);
-        dst.push(':');
-        let base_62 = self.to_base62()?;
-        dst.push_str(&base_62);
-
-        Ok(dst)
-    }
 }
 
 impl fmt::Debug for SpotifyId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("SpotifyId")
-            .field(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
+            .field(&self.to_base62().unwrap_or_else(|_| "invalid uri".into()))
             .finish()
     }
 }
 
 impl fmt::Display for SpotifyId {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
-    }
-}
-
-#[derive(Clone, PartialEq, Eq, Hash)]
-pub struct NamedSpotifyId {
-    pub inner_id: SpotifyId,
-    pub username: String,
-}
-
-impl NamedSpotifyId {
-    pub fn from_uri(src: &str) -> NamedSpotifyIdResult {
-        let uri_parts: Vec<&str> = src.split(':').collect();
-
-        // At minimum, should be `spotify:user:{username}:{type}:{id}`
-        if uri_parts.len() < 5 {
-            return Err(SpotifyIdError::InvalidFormat.into());
-        }
-
-        if uri_parts[0] != "spotify" {
-            return Err(SpotifyIdError::InvalidRoot.into());
-        }
-
-        if uri_parts[1] != "user" {
-            return Err(SpotifyIdError::InvalidFormat.into());
-        }
-
-        Ok(Self {
-            inner_id: SpotifyId::from_uri(src)?,
-            username: uri_parts[2].to_owned(),
-        })
-    }
-
-    pub fn to_uri(&self) -> Result<String, Error> {
-        let item_type: &str = self.inner_id.item_type.into();
-        let mut dst = String::with_capacity(37 + self.username.len() + item_type.len());
-        dst.push_str("spotify:user:");
-        dst.push_str(&self.username);
-        dst.push(':');
-        dst.push_str(item_type);
-        dst.push(':');
-        let base_62 = self.to_base62()?;
-        dst.push_str(&base_62);
-
-        Ok(dst)
-    }
-
-    pub fn from_spotify_id(id: SpotifyId, username: &str) -> Self {
-        Self {
-            inner_id: id,
-            username: username.to_owned(),
-        }
-    }
-}
-
-impl Deref for NamedSpotifyId {
-    type Target = SpotifyId;
-    fn deref(&self) -> &Self::Target {
-        &self.inner_id
-    }
-}
-
-impl fmt::Debug for NamedSpotifyId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("NamedSpotifyId")
-            .field(
-                &self
-                    .inner_id
-                    .to_uri()
-                    .unwrap_or_else(|_| "invalid id".into()),
-            )
-            .finish()
-    }
-}
-
-impl fmt::Display for NamedSpotifyId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(
-            &self
-                .inner_id
-                .to_uri()
-                .unwrap_or_else(|_| "invalid id".into()),
-        )
+        f.write_str(&self.to_base62().unwrap_or_else(|_| "invalid uri".into()))
     }
 }
 
@@ -423,107 +205,6 @@ impl TryFrom<&Vec<u8>> for SpotifyId {
     }
 }
 
-impl TryFrom<&protocol::metadata::Album> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(album: &protocol::metadata::Album) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Album,
-            ..Self::from_raw(album.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::Artist> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(artist: &protocol::metadata::Artist) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Artist,
-            ..Self::from_raw(artist.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::Episode> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(episode: &protocol::metadata::Episode) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Episode,
-            ..Self::from_raw(episode.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::Track> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(track: &protocol::metadata::Track) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Track,
-            ..Self::from_raw(track.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::Show> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(show: &protocol::metadata::Show) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Show,
-            ..Self::from_raw(show.gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::metadata::ArtistWithRole> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(artist: &protocol::metadata::ArtistWithRole) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Artist,
-            ..Self::from_raw(artist.artist_gid())?
-        })
-    }
-}
-
-impl TryFrom<&protocol::playlist4_external::Item> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(item: &protocol::playlist4_external::Item) -> Result<Self, Self::Error> {
-        Ok(Self {
-            item_type: SpotifyItemType::Track,
-            ..Self::from_uri(item.uri())?
-        })
-    }
-}
-
-// Note that this is the unique revision of an item's metadata on a playlist,
-// not the ID of that item or playlist.
-impl TryFrom<&protocol::playlist4_external::MetaItem> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(item: &protocol::playlist4_external::MetaItem) -> Result<Self, Self::Error> {
-        Self::try_from(item.revision())
-    }
-}
-
-// Note that this is the unique revision of a playlist, not the ID of that playlist.
-impl TryFrom<&protocol::playlist4_external::SelectedListContent> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(
-        playlist: &protocol::playlist4_external::SelectedListContent,
-    ) -> Result<Self, Self::Error> {
-        Self::try_from(playlist.revision())
-    }
-}
-
-// TODO: check meaning and format of this field in the wild. This might be a FileId,
-// which is why we now don't create a separate `Playlist` enum value yet and choose
-// to discard any item type.
-impl TryFrom<&protocol::playlist_annotate3::TranscodedPicture> for SpotifyId {
-    type Error = crate::Error;
-    fn try_from(
-        picture: &protocol::playlist_annotate3::TranscodedPicture,
-    ) -> Result<Self, Self::Error> {
-        Self::from_base62(picture.uri())
-    }
-}
-
 pub fn to_base16(src: &[u8], buf: &mut [u8]) -> Result<String, Error> {
     let mut i = 0;
     for v in src {
@@ -541,8 +222,6 @@ mod tests {
 
     struct ConversionCase {
         id: u128,
-        kind: SpotifyItemType,
-        uri: &'static str,
         base16: &'static str,
         base62: &'static str,
         raw: &'static [u8],
@@ -551,8 +230,6 @@ mod tests {
     static CONV_VALID: [ConversionCase; 5] = [
         ConversionCase {
             id: 238762092608182713602505436543891614649,
-            kind: SpotifyItemType::Track,
-            uri: "spotify:track:5sWHDYs0csV6RS48xBl0tH",
             base16: "b39fe8081e1f4c54be38e8d6f9f12bb9",
             base62: "5sWHDYs0csV6RS48xBl0tH",
             raw: &[
@@ -561,8 +238,6 @@ mod tests {
         },
         ConversionCase {
             id: 204841891221366092811751085145916697048,
-            kind: SpotifyItemType::Track,
-            uri: "spotify:track:4GNcXTGWmnZ3ySrqvol3o4",
             base16: "9a1b1cfbc6f244569ae0356c77bbe9d8",
             base62: "4GNcXTGWmnZ3ySrqvol3o4",
             raw: &[
@@ -571,8 +246,6 @@ mod tests {
         },
         ConversionCase {
             id: 204841891221366092811751085145916697048,
-            kind: SpotifyItemType::Episode,
-            uri: "spotify:episode:4GNcXTGWmnZ3ySrqvol3o4",
             base16: "9a1b1cfbc6f244569ae0356c77bbe9d8",
             base62: "4GNcXTGWmnZ3ySrqvol3o4",
             raw: &[
@@ -581,8 +254,6 @@ mod tests {
         },
         ConversionCase {
             id: 204841891221366092811751085145916697048,
-            kind: SpotifyItemType::Show,
-            uri: "spotify:show:4GNcXTGWmnZ3ySrqvol3o4",
             base16: "9a1b1cfbc6f244569ae0356c77bbe9d8",
             base62: "4GNcXTGWmnZ3ySrqvol3o4",
             raw: &[
@@ -591,8 +262,6 @@ mod tests {
         },
         ConversionCase {
             id: 0,
-            kind: SpotifyItemType::Local,
-            uri: "spotify:local:0000000000000000000000",
             base16: "00000000000000000000000000000000",
             base62: "0000000000000000000000",
             raw: &[0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
@@ -602,9 +271,6 @@ mod tests {
     static CONV_INVALID: [ConversionCase; 5] = [
         ConversionCase {
             id: 0,
-            kind: SpotifyItemType::Unknown,
-            // Invalid ID in the URI.
-            uri: "spotify:arbitrarywhatever:5sWHDYs0Bl0tH",
             base16: "ZZZZZ8081e1f4c54be38e8d6f9f12bb9",
             base62: "!!!!!Ys0csV6RS48xBl0tH",
             raw: &[
@@ -614,9 +280,6 @@ mod tests {
         },
         ConversionCase {
             id: 0,
-            kind: SpotifyItemType::Unknown,
-            // Missing colon between ID and type.
-            uri: "spotify:arbitrarywhatever5sWHDYs0csV6RS48xBl0tH",
             base16: "--------------------",
             base62: "....................",
             raw: &[
@@ -626,9 +289,6 @@ mod tests {
         },
         ConversionCase {
             id: 0,
-            kind: SpotifyItemType::Unknown,
-            // Uri too short
-            uri: "spotify:azb:aRS48xBl0tH",
             // too long, should return error but not panic overflow
             base16: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
             // too long, should return error but not panic overflow
@@ -640,9 +300,6 @@ mod tests {
         },
         ConversionCase {
             id: 0,
-            kind: SpotifyItemType::Unknown,
-            // Uri too short
-            uri: "spotify:azb:aRS48xBl0tH",
             base16: "--------------------",
             // too short to encode a 128 bits int
             base62: "aa",
@@ -653,8 +310,6 @@ mod tests {
         },
         ConversionCase {
             id: 0,
-            kind: SpotifyItemType::Unknown,
-            uri: "cleary invalid uri",
             base16: "--------------------",
             // too high of a value, this would need a 132 bits int
             base62: "ZZZZZZZZZZZZZZZZZZZZZZ",
@@ -679,10 +334,7 @@ mod tests {
     #[test]
     fn to_base62() {
         for c in &CONV_VALID {
-            let id = SpotifyId {
-                id: c.id,
-                item_type: c.kind,
-            };
+            let id = SpotifyId { id: c.id };
 
             assert_eq!(id.to_base62().unwrap(), c.base62);
         }
@@ -702,57 +354,9 @@ mod tests {
     #[test]
     fn to_base16() {
         for c in &CONV_VALID {
-            let id = SpotifyId {
-                id: c.id,
-                item_type: c.kind,
-            };
+            let id = SpotifyId { id: c.id };
 
             assert_eq!(id.to_base16().unwrap(), c.base16);
-        }
-    }
-
-    #[test]
-    fn from_uri() {
-        for c in &CONV_VALID {
-            let actual = SpotifyId::from_uri(c.uri).unwrap();
-
-            assert_eq!(actual.id, c.id);
-            assert_eq!(actual.item_type, c.kind);
-        }
-
-        for c in &CONV_INVALID {
-            assert!(SpotifyId::from_uri(c.uri).is_err());
-        }
-    }
-
-    #[test]
-    fn from_local_uri() {
-        let actual = SpotifyId::from_uri("spotify:local:xyz:123").unwrap();
-
-        assert_eq!(actual.id, 0);
-        assert_eq!(actual.item_type, SpotifyItemType::Local);
-    }
-
-    #[test]
-    fn from_named_uri() {
-        let actual =
-            NamedSpotifyId::from_uri("spotify:user:spotify:playlist:37i9dQZF1DWSw8liJZcPOI")
-                .unwrap();
-
-        assert_eq!(actual.id, 136159921382084734723401526672209703396);
-        assert_eq!(actual.item_type, SpotifyItemType::Playlist);
-        assert_eq!(actual.username, "spotify");
-    }
-
-    #[test]
-    fn to_uri() {
-        for c in &CONV_VALID {
-            let id = SpotifyId {
-                id: c.id,
-                item_type: c.kind,
-            };
-
-            assert_eq!(id.to_uri().unwrap(), c.uri);
         }
     }
 

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -2,7 +2,7 @@ use std::fmt;
 
 use thiserror::Error;
 
-use crate::Error;
+use crate::{Error, SpotifyUri};
 
 // re-export FileId for historic reasons, when it was part of this mod
 pub use crate::FileId;
@@ -199,6 +199,23 @@ impl TryFrom<&Vec<u8>> for SpotifyId {
     type Error = crate::Error;
     fn try_from(src: &Vec<u8>) -> Result<Self, Self::Error> {
         Self::try_from(src.as_slice())
+    }
+}
+
+impl TryFrom<&SpotifyUri> for SpotifyId {
+    type Error = crate::Error;
+    fn try_from(value: &SpotifyUri) -> Result<Self, Self::Error> {
+        match value {
+            SpotifyUri::Album { id }
+            | SpotifyUri::Artist { id }
+            | SpotifyUri::Episode { id }
+            | SpotifyUri::Playlist { id, .. }
+            | SpotifyUri::Show { id }
+            | SpotifyUri::Track { id } => Ok(*id),
+            SpotifyUri::Local { .. } | SpotifyUri::Unknown { .. } => {
+                Err(SpotifyIdError::InvalidFormat.into())
+            }
+        }
     }
 }
 

--- a/core/src/spotify_id.rs
+++ b/core/src/spotify_id.rs
@@ -7,9 +7,6 @@ use crate::Error;
 // re-export FileId for historic reasons, when it was part of this mod
 pub use crate::FileId;
 
-// re-export SpotifyItemType for similar reasons
-pub use crate::spotify_uri::SpotifyItemType;
-
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct SpotifyId {
     pub id: u128,

--- a/core/src/spotify_uri.rs
+++ b/core/src/spotify_uri.rs
@@ -82,9 +82,9 @@ impl SpotifyUri {
         }
     }
 
-    /// Gets the name of this URI. The resource name is the component of the URI that identifies
+    /// Gets the ID of this URI. The resource ID is the component of the URI that identifies
     /// the resource after its type label. If `self` is a named ID, the user will be omitted.
-    pub fn to_name(&self) -> Result<String, Error> {
+    pub fn to_id(&self) -> Result<String, Error> {
         match &self {
             SpotifyUri::Album { id }
             | SpotifyUri::Artist { id }
@@ -115,9 +115,6 @@ impl SpotifyUri {
     ///  - For most item types, a 22-character long, base62 encoded Spotify ID is expected.
     ///  - For local files, an arbitrary length string with the fields
     ///    `{artist}:{album_title}:{track_title}:{duration_in_seconds}` is expected.
-    ///
-    /// Note that this should not be used for playlists, which have the form of
-    /// `spotify:playlist:{id}`.
     ///
     /// Spotify URI: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
     pub fn from_uri(src: &str) -> SpotifyUriResult {
@@ -196,7 +193,7 @@ impl SpotifyUri {
     /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
     pub fn to_uri(&self) -> Result<String, Error> {
         let item_type = self.item_type();
-        let name = self.to_name()?;
+        let name = self.to_id()?;
 
         if let SpotifyUri::Playlist {
             id,
@@ -213,10 +210,10 @@ impl SpotifyUri {
     /// the resource after its type label. If `self` is a named ID, the user will be omitted.
     ///
     /// Deprecated: not all IDs can be represented in Base62, so this function has been renamed to
-    /// [SpotifyUri::to_name], which this implementation forwards to.
+    /// [SpotifyUri::to_id], which this implementation forwards to.
     #[deprecated(since = "0.8.0", note = "use to_name instead")]
     pub fn to_base62(&self) -> Result<String, Error> {
-        self.to_name()
+        self.to_id()
     }
 }
 
@@ -426,7 +423,7 @@ mod tests {
     #[test]
     fn to_name() {
         for c in &CONV_VALID {
-            assert_eq!(c.parsed.to_name().unwrap(), c.base62);
+            assert_eq!(c.parsed.to_id().unwrap(), c.base62);
         }
     }
 

--- a/core/src/spotify_uri.rs
+++ b/core/src/spotify_uri.rs
@@ -420,11 +420,82 @@ mod tests {
         },
     ];
 
+    struct ItemTypeCase {
+        uri: SpotifyUri,
+        expected_type: &'static str,
+    }
+
+    static ITEM_TYPES: [ItemTypeCase; 6] = [
+        ItemTypeCase {
+            uri: SpotifyUri::Album {
+                id: SpotifyId { id: 0 },
+            },
+            expected_type: "album",
+        },
+        ItemTypeCase {
+            uri: SpotifyUri::Artist {
+                id: SpotifyId { id: 0 },
+            },
+            expected_type: "artist",
+        },
+        ItemTypeCase {
+            uri: SpotifyUri::Episode {
+                id: SpotifyId { id: 0 },
+            },
+            expected_type: "episode",
+        },
+        ItemTypeCase {
+            uri: SpotifyUri::Playlist {
+                user: None,
+                id: SpotifyId { id: 0 },
+            },
+            expected_type: "playlist",
+        },
+        ItemTypeCase {
+            uri: SpotifyUri::Show {
+                id: SpotifyId { id: 0 },
+            },
+            expected_type: "show",
+        },
+        ItemTypeCase {
+            uri: SpotifyUri::Track {
+                id: SpotifyId { id: 0 },
+            },
+            expected_type: "track",
+        },
+    ];
+
     #[test]
-    fn to_name() {
+    fn to_id() {
         for c in &CONV_VALID {
             assert_eq!(c.parsed.to_id().unwrap(), c.base62);
         }
+    }
+
+    #[test]
+    fn item_type() {
+        for i in &ITEM_TYPES {
+            assert_eq!(i.uri.item_type(), i.expected_type);
+        }
+
+        // These need to use methods that can't be used in the static context like to_owned() and
+        // into().
+
+        let local_file = SpotifyUri::Local {
+            artist: "".to_owned(),
+            album_title: "".to_owned(),
+            track_title: "".to_owned(),
+            duration: Default::default(),
+        };
+
+        assert_eq!(local_file.item_type(), "local");
+
+        let unknown = SpotifyUri::Unknown {
+            kind: "not used".into(),
+            id: "".to_owned(),
+        };
+
+        assert_eq!(unknown.item_type(), "unknown");
     }
 
     #[test]
@@ -492,5 +563,15 @@ mod tests {
         for c in &CONV_VALID {
             assert_eq!(c.parsed.to_uri().unwrap(), c.uri);
         }
+    }
+
+    #[test]
+    fn to_named_uri() {
+        let string = "spotify:user:spotify:playlist:37i9dQZF1DWSw8liJZcPOI";
+
+        let actual =
+            SpotifyUri::from_uri("spotify:user:spotify:playlist:37i9dQZF1DWSw8liJZcPOI").unwrap();
+
+        assert_eq!(actual.to_uri().unwrap(), string);
     }
 }

--- a/core/src/spotify_uri.rs
+++ b/core/src/spotify_uri.rs
@@ -307,19 +307,6 @@ impl SpotifyUri {
     pub fn to_base62(&self) -> Result<String, Error> {
         self.to_name()
     }
-
-    pub fn to_base16(&self) -> Result<String, Error> {
-        match self {
-            SpotifyUri::Album { id }
-            | SpotifyUri::Artist { id }
-            | SpotifyUri::Episode { id }
-            | SpotifyUri::Playlist { id, .. }
-            | SpotifyUri::Show { id, .. }
-            | SpotifyUri::Track { id, .. }
-            | SpotifyUri::Unknown { id, .. } => Ok(id.to_base16()?),
-            SpotifyUri::Local { .. } => Err(SpotifyUriError::InvalidFormat.into()),
-        }
-    }
 }
 
 impl fmt::Debug for SpotifyUri {
@@ -602,13 +589,6 @@ mod tests {
 
         for c in &CONV_INVALID {
             assert!(SpotifyId::from_base16(c.base16).is_err(),);
-        }
-    }
-
-    #[test]
-    fn to_base16() {
-        for c in &CONV_VALID {
-            assert_eq!(c.parsed.to_base16().unwrap(), c.base16);
         }
     }
 

--- a/core/src/spotify_uri.rs
+++ b/core/src/spotify_uri.rs
@@ -322,12 +322,6 @@ impl SpotifyUri {
     }
 }
 
-impl From<SpotifyId> for SpotifyUri {
-    fn from(id: SpotifyId) -> Self {
-        Self::Unknown { id }
-    }
-}
-
 impl fmt::Debug for SpotifyUri {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_tuple("SpotifyUri")

--- a/core/src/spotify_uri.rs
+++ b/core/src/spotify_uri.rs
@@ -1,0 +1,686 @@
+use crate::{Error, SpotifyId};
+use std::fmt;
+use thiserror::Error;
+
+use librespot_protocol as protocol;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SpotifyItemType {
+    Album,
+    Artist,
+    Episode,
+    Playlist,
+    Show,
+    Track,
+    Local,
+    Unknown,
+}
+
+impl From<&str> for SpotifyItemType {
+    fn from(v: &str) -> Self {
+        match v {
+            "album" => Self::Album,
+
+            "artist" => Self::Artist,
+            "episode" => Self::Episode,
+            "playlist" => Self::Playlist,
+            "show" => Self::Show,
+            "track" => Self::Track,
+            "local" => Self::Local,
+            _ => Self::Unknown,
+        }
+    }
+}
+
+impl From<SpotifyItemType> for &str {
+    fn from(item_type: SpotifyItemType) -> &'static str {
+        match item_type {
+            SpotifyItemType::Album => "album",
+            SpotifyItemType::Artist => "artist",
+            SpotifyItemType::Episode => "episode",
+            SpotifyItemType::Playlist => "playlist",
+            SpotifyItemType::Show => "show",
+            SpotifyItemType::Track => "track",
+            SpotifyItemType::Local => "local",
+            _ => "unknown",
+        }
+    }
+}
+
+#[derive(Debug, Error, Clone, Copy, PartialEq, Eq)]
+pub enum SpotifyUriError {
+    #[error("not a valid Spotify URI")]
+    InvalidFormat,
+    #[error("URI does not belong to Spotify")]
+    InvalidRoot,
+}
+
+impl From<SpotifyUriError> for Error {
+    fn from(err: SpotifyUriError) -> Self {
+        Error::invalid_argument(err)
+    }
+}
+
+pub type SpotifyUriResult = Result<SpotifyUri, Error>;
+
+#[derive(Clone, PartialEq, Eq, Hash)]
+pub enum SpotifyUri {
+    Album {
+        id: SpotifyId,
+    },
+    Artist {
+        id: SpotifyId,
+    },
+    Episode {
+        id: SpotifyId,
+    },
+    Playlist {
+        user: Option<String>,
+        id: SpotifyId,
+    },
+    Show {
+        id: SpotifyId,
+    },
+    Track {
+        id: SpotifyId,
+    },
+    Local {
+        artist: String,
+        album_title: String,
+        track_title: String,
+        duration: std::time::Duration,
+    },
+    Unknown {
+        id: SpotifyId,
+    },
+}
+
+impl SpotifyUri {
+    /// Returns whether this `SpotifyUri` is for a playable audio item, if known.
+    pub fn is_playable(&self) -> bool {
+        matches!(self, SpotifyUri::Episode { .. } | SpotifyUri::Track { .. })
+    }
+
+    /// Gets the item type of this URI as a [SpotifyItemType] value.
+    pub fn item_type(&self) -> SpotifyItemType {
+        match &self {
+            SpotifyUri::Album { .. } => SpotifyItemType::Album,
+            SpotifyUri::Artist { .. } => SpotifyItemType::Artist,
+            SpotifyUri::Episode { .. } => SpotifyItemType::Episode,
+            SpotifyUri::Playlist { .. } => SpotifyItemType::Playlist,
+            SpotifyUri::Show { .. } => SpotifyItemType::Show,
+            SpotifyUri::Track { .. } => SpotifyItemType::Track,
+            SpotifyUri::Local { .. } => SpotifyItemType::Local,
+            SpotifyUri::Unknown { .. } => SpotifyItemType::Unknown,
+        }
+    }
+
+    /// Gets the name of this URI. The resource name is the component of the URI that identifies
+    /// the resource after its type label. If `self` is a named ID, the user will be omitted.
+    pub fn to_name(&self) -> Result<String, Error> {
+        match &self {
+            SpotifyUri::Album { id }
+            | SpotifyUri::Artist { id }
+            | SpotifyUri::Episode { id }
+            | SpotifyUri::Playlist { id, .. }
+            | SpotifyUri::Show { id }
+            | SpotifyUri::Track { id }
+            | SpotifyUri::Unknown { id } => id.to_base62(),
+            SpotifyUri::Local {
+                artist,
+                album_title,
+                track_title,
+                duration,
+            } => {
+                let duration_secs = duration.as_secs();
+                Ok(format!(
+                    "{artist}:{album_title}:{track_title}:{duration_secs}"
+                ))
+            }
+        }
+    }
+
+    /// Parses a [Spotify URI] into a `SpotifyUri`.
+    ///
+    /// `uri` is expected to be in the canonical form `spotify:{type}:{id}`, where `{type}`
+    /// can be arbitrary while `{id}` is in a format that varies based on the `{type}`:
+    ///
+    ///  - For most item types, a 22-character long, base62 encoded Spotify ID is expected.
+    ///  - For local files, an arbitrary length string with the fields
+    ///    `{artist}:{album_title}:{track_title}:{duration_in_seconds}` is expected.
+    ///
+    /// Note that this should not be used for playlists, which have the form of
+    /// `spotify:playlist:{id}`.
+    ///
+    /// Spotify URI: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
+    pub fn from_uri(src: &str) -> SpotifyUriResult {
+        // Basic: `spotify:{type}:{id}`
+        // Named: `spotify:user:{user}:{type}:{id}`
+        // Local: `spotify:local:{artist}:{album_title}:{track_title}:{duration_in_seconds}`
+        let mut parts = src.split(':');
+
+        let scheme = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+        let mut username: Option<String> = None;
+
+        let item_type = {
+            let next = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+            if next == "user" {
+                username.replace(
+                    parts
+                        .next()
+                        .ok_or(SpotifyUriError::InvalidFormat)?
+                        .to_owned(),
+                );
+                parts.next().ok_or(SpotifyUriError::InvalidFormat)?
+            } else {
+                next
+            }
+        };
+
+        let name = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+
+        if scheme != "spotify" {
+            return Err(SpotifyUriError::InvalidRoot.into());
+        }
+
+        let item_type = item_type.into();
+
+        match item_type {
+            SpotifyItemType::Album => Ok(Self::Album {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Artist => Ok(Self::Artist {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Episode => Ok(Self::Episode {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Playlist => Ok(Self::Playlist {
+                id: SpotifyId::from_base62(name)?,
+                user: username,
+            }),
+            SpotifyItemType::Show => Ok(Self::Show {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Track => Ok(Self::Track {
+                id: SpotifyId::from_base62(name)?,
+            }),
+            SpotifyItemType::Local => Ok(Self::Local {
+                artist: "unimplemented".to_owned(),
+                album_title: "unimplemented".to_owned(),
+                track_title: "unimplemented".to_owned(),
+                duration: Default::default(),
+            }),
+            SpotifyItemType::Unknown => Ok(Self::Unknown {
+                id: SpotifyId::from_base62(name)?,
+            }),
+        }
+    }
+
+    /// Parses a base16 (hex) encoded Spotify ID into a `SpotifyUri`.
+    ///
+    /// `src` is expected to be 32 bytes long and encoded using valid characters.
+    ///
+    /// This method cannot be used to create local file IDs; passing in `SpotifyItemType::Local`
+    /// will always yield an error.
+    ///
+    /// Spotify URI: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
+    pub fn from_base16(src: &str, item_type: SpotifyItemType) -> SpotifyUriResult {
+        let id = SpotifyId::from_base16(src)?;
+
+        Self::from_id_and_type(id, item_type)
+    }
+
+    /// Parses a base62 encoded [Spotify ID] into a `u128`.
+    ///
+    /// `src` is expected to be 22 bytes long and encoded using valid characters.
+    ///
+    /// This method cannot be used to create local file IDs; passing in `SpotifyItemType::Local`
+    /// will always yield an error.
+    ///
+    /// Spotify URI: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
+    pub fn from_base62(src: &str, item_type: SpotifyItemType) -> SpotifyUriResult {
+        let id = SpotifyId::from_base62(src)?;
+
+        Self::from_id_and_type(id, item_type)
+    }
+
+    /// Creates a `u128` from a copy of `SpotifyId::SIZE` (16) bytes in big-endian order.
+    ///
+    /// The resulting `SpotifyId` will have a type based on the value of `item_type`.
+    ///
+    /// This method cannot be used to create local file IDs; passing in `SpotifyItemType::Local`
+    /// will always yield an error.
+    ///
+    /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
+    pub fn from_raw(src: &[u8], item_type: SpotifyItemType) -> SpotifyUriResult {
+        let id = SpotifyId::from_raw(src)?;
+
+        Self::from_id_and_type(id, item_type)
+    }
+
+    fn from_id_and_type(id: SpotifyId, item_type: SpotifyItemType) -> SpotifyUriResult {
+        match item_type {
+            SpotifyItemType::Album => Ok(Self::Album { id }),
+            SpotifyItemType::Artist => Ok(Self::Artist { id }),
+            SpotifyItemType::Episode => Ok(Self::Episode { id }),
+            SpotifyItemType::Playlist => Ok(Self::Playlist { id, user: None }),
+            SpotifyItemType::Show => Ok(Self::Show { id }),
+            SpotifyItemType::Track => Ok(Self::Track { id }),
+            SpotifyItemType::Unknown => Ok(Self::Unknown { id }),
+            SpotifyItemType::Local => Err(SpotifyUriError::InvalidFormat.into()),
+        }
+    }
+
+    /// Returns the `SpotifyUri` as a [Spotify URI] in the canonical form `spotify:{type}:{id}`,
+    /// where `{type}` is an arbitrary string and `{id}` is a 22-character long, base62 encoded
+    /// Spotify ID.
+    ///
+    /// If the `SpotifyUri` has an associated type unrecognized by the library, `{type}` will
+    /// be encoded as `unknown`.
+    ///
+    /// If the `SpotifyUri` is named, it will be returned in the form
+    /// `spotify:user:{user}:{type}:{id}`.
+    ///
+    /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
+    pub fn to_uri(&self) -> Result<String, Error> {
+        let item_type: &str = self.item_type().into();
+        let name = self.to_name()?;
+
+        if let SpotifyUri::Playlist {
+            id,
+            user: Some(user),
+        } = self
+        {
+            Ok(format!("spotify:user:{user}:{item_type}:{id}"))
+        } else {
+            Ok(format!("spotify:{item_type}:{name}"))
+        }
+    }
+
+    /// Gets the name of this URI. The resource name is the component of the URI that identifies
+    /// the resource after its type label. If `self` is a named ID, the user will be omitted.
+    ///
+    /// Deprecated: not all IDs can be represented in Base62, so this function has been renamed to
+    /// [SpotifyUri::to_name], which this implementation forwards to.
+    #[deprecated(since = "0.8.0", note = "use to_name instead")]
+    pub fn to_base62(&self) -> Result<String, Error> {
+        self.to_name()
+    }
+
+    pub fn to_base16(&self) -> Result<String, Error> {
+        match self {
+            SpotifyUri::Album { id }
+            | SpotifyUri::Artist { id }
+            | SpotifyUri::Episode { id }
+            | SpotifyUri::Playlist { id, .. }
+            | SpotifyUri::Show { id, .. }
+            | SpotifyUri::Track { id, .. }
+            | SpotifyUri::Unknown { id, .. } => Ok(id.to_base16()?),
+            SpotifyUri::Local { .. } => Err(SpotifyUriError::InvalidFormat.into()),
+        }
+    }
+}
+
+impl From<SpotifyId> for SpotifyUri {
+    fn from(id: SpotifyId) -> Self {
+        Self::Unknown { id }
+    }
+}
+
+impl fmt::Debug for SpotifyUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_tuple("SpotifyUri")
+            .field(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
+            .finish()
+    }
+}
+
+impl TryFrom<&protocol::metadata::Album> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(album: &protocol::metadata::Album) -> Result<Self, Self::Error> {
+        Ok(Self::Album {
+            id: SpotifyId::from_raw(album.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::Artist> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(artist: &protocol::metadata::Artist) -> Result<Self, Self::Error> {
+        Ok(Self::Artist {
+            id: SpotifyId::from_raw(artist.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::Episode> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(episode: &protocol::metadata::Episode) -> Result<Self, Self::Error> {
+        Ok(Self::Episode {
+            id: SpotifyId::from_raw(episode.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::Track> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(track: &protocol::metadata::Track) -> Result<Self, Self::Error> {
+        Ok(Self::Track {
+            id: SpotifyId::from_raw(track.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::Show> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(show: &protocol::metadata::Show) -> Result<Self, Self::Error> {
+        Ok(Self::Show {
+            id: SpotifyId::from_raw(show.gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::metadata::ArtistWithRole> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(artist: &protocol::metadata::ArtistWithRole) -> Result<Self, Self::Error> {
+        Ok(Self::Artist {
+            id: SpotifyId::from_raw(artist.artist_gid())?,
+        })
+    }
+}
+
+impl TryFrom<&protocol::playlist4_external::Item> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(item: &protocol::playlist4_external::Item) -> Result<Self, Self::Error> {
+        Self::from_uri(item.uri())
+    }
+}
+
+// Note that this is the unique revision of an item's metadata on a playlist,
+// not the ID of that item or playlist.
+impl TryFrom<&protocol::playlist4_external::MetaItem> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(item: &protocol::playlist4_external::MetaItem) -> Result<Self, Self::Error> {
+        Ok(Self::Unknown {
+            id: SpotifyId::try_from(item.revision())?,
+        })
+    }
+}
+
+// Note that this is the unique revision of a playlist, not the ID of that playlist.
+impl TryFrom<&protocol::playlist4_external::SelectedListContent> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(
+        playlist: &protocol::playlist4_external::SelectedListContent,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self::Unknown {
+            id: SpotifyId::try_from(playlist.revision())?,
+        })
+    }
+}
+
+// TODO: check meaning and format of this field in the wild. This might be a FileId,
+// which is why we now don't create a separate `Playlist` enum value yet and choose
+// to discard any item type.
+impl TryFrom<&protocol::playlist_annotate3::TranscodedPicture> for SpotifyUri {
+    type Error = crate::Error;
+    fn try_from(
+        picture: &protocol::playlist_annotate3::TranscodedPicture,
+    ) -> Result<Self, Self::Error> {
+        Ok(Self::Unknown {
+            id: SpotifyId::from_base62(picture.uri())?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct ConversionCase {
+        parsed: SpotifyUri,
+        kind: SpotifyItemType,
+        uri: &'static str,
+        base16: &'static str,
+        base62: &'static str,
+        raw: &'static [u8],
+    }
+
+    static CONV_VALID: [ConversionCase; 4] = [
+        ConversionCase {
+            parsed: SpotifyUri::Track {
+                id: SpotifyId {
+                    id: 238762092608182713602505436543891614649,
+                },
+            },
+            kind: SpotifyItemType::Track,
+            uri: "spotify:track:5sWHDYs0csV6RS48xBl0tH",
+            base16: "b39fe8081e1f4c54be38e8d6f9f12bb9",
+            base62: "5sWHDYs0csV6RS48xBl0tH",
+            raw: &[
+                179, 159, 232, 8, 30, 31, 76, 84, 190, 56, 232, 214, 249, 241, 43, 185,
+            ],
+        },
+        ConversionCase {
+            parsed: SpotifyUri::Track {
+                id: SpotifyId {
+                    id: 204841891221366092811751085145916697048,
+                },
+            },
+            kind: SpotifyItemType::Track,
+            uri: "spotify:track:4GNcXTGWmnZ3ySrqvol3o4",
+            base16: "9a1b1cfbc6f244569ae0356c77bbe9d8",
+            base62: "4GNcXTGWmnZ3ySrqvol3o4",
+            raw: &[
+                154, 27, 28, 251, 198, 242, 68, 86, 154, 224, 53, 108, 119, 187, 233, 216,
+            ],
+        },
+        ConversionCase {
+            parsed: SpotifyUri::Episode {
+                id: SpotifyId {
+                    id: 204841891221366092811751085145916697048,
+                },
+            },
+            kind: SpotifyItemType::Episode,
+            uri: "spotify:episode:4GNcXTGWmnZ3ySrqvol3o4",
+            base16: "9a1b1cfbc6f244569ae0356c77bbe9d8",
+            base62: "4GNcXTGWmnZ3ySrqvol3o4",
+            raw: &[
+                154, 27, 28, 251, 198, 242, 68, 86, 154, 224, 53, 108, 119, 187, 233, 216,
+            ],
+        },
+        ConversionCase {
+            parsed: SpotifyUri::Show {
+                id: SpotifyId {
+                    id: 204841891221366092811751085145916697048,
+                },
+            },
+            kind: SpotifyItemType::Show,
+            uri: "spotify:show:4GNcXTGWmnZ3ySrqvol3o4",
+            base16: "9a1b1cfbc6f244569ae0356c77bbe9d8",
+            base62: "4GNcXTGWmnZ3ySrqvol3o4",
+            raw: &[
+                154, 27, 28, 251, 198, 242, 68, 86, 154, 224, 53, 108, 119, 187, 233, 216,
+            ],
+        },
+    ];
+
+    static CONV_INVALID: [ConversionCase; 5] = [
+        ConversionCase {
+            parsed: SpotifyUri::Unknown {
+                id: SpotifyId { id: 0 },
+            },
+            kind: SpotifyItemType::Unknown,
+            // Invalid ID in the URI.
+            uri: "spotify:arbitrarywhatever:5sWHDYs0Bl0tH",
+            base16: "ZZZZZ8081e1f4c54be38e8d6f9f12bb9",
+            base62: "!!!!!Ys0csV6RS48xBl0tH",
+            raw: &[
+                // Invalid length.
+                154, 27, 28, 251, 198, 242, 68, 86, 154, 224, 5, 3, 108, 119, 187, 233, 216, 255,
+            ],
+        },
+        ConversionCase {
+            parsed: SpotifyUri::Unknown {
+                id: SpotifyId { id: 0 },
+            },
+            kind: SpotifyItemType::Unknown,
+            // Missing colon between ID and type.
+            uri: "spotify:arbitrarywhatever5sWHDYs0csV6RS48xBl0tH",
+            base16: "--------------------",
+            base62: "....................",
+            raw: &[
+                // Invalid length.
+                154, 27, 28, 251,
+            ],
+        },
+        ConversionCase {
+            parsed: SpotifyUri::Unknown {
+                id: SpotifyId { id: 0 },
+            },
+            kind: SpotifyItemType::Unknown,
+            // Uri too short
+            uri: "spotify:azb:aRS48xBl0tH",
+            // too long, should return error but not panic overflow
+            base16: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            // too long, should return error but not panic overflow
+            base62: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            raw: &[
+                // Invalid length.
+                154, 27, 28, 251,
+            ],
+        },
+        ConversionCase {
+            parsed: SpotifyUri::Unknown {
+                id: SpotifyId { id: 0 },
+            },
+            kind: SpotifyItemType::Unknown,
+            // Uri too short
+            uri: "spotify:azb:aRS48xBl0tH",
+            base16: "--------------------",
+            // too short to encode a 128 bits int
+            base62: "aa",
+            raw: &[
+                // Invalid length.
+                154, 27, 28, 251,
+            ],
+        },
+        ConversionCase {
+            parsed: SpotifyUri::Unknown {
+                id: SpotifyId { id: 0 },
+            },
+            kind: SpotifyItemType::Unknown,
+            uri: "cleary invalid uri",
+            base16: "--------------------",
+            // too high of a value, this would need a 132 bits int
+            base62: "ZZZZZZZZZZZZZZZZZZZZZZ",
+            raw: &[
+                // Invalid length.
+                154, 27, 28, 251,
+            ],
+        },
+    ];
+
+    #[test]
+    fn from_base62() {
+        for c in &CONV_VALID {
+            assert_eq!(SpotifyUri::from_base62(c.base62, c.kind).unwrap(), c.parsed,);
+        }
+
+        for c in &CONV_INVALID {
+            assert!(SpotifyId::from_base62(c.base62).is_err(),);
+        }
+    }
+
+    #[test]
+    fn to_name() {
+        for c in &CONV_VALID {
+            assert_eq!(c.parsed.to_name().unwrap(), c.base62);
+        }
+    }
+
+    #[test]
+    fn from_base16() {
+        for c in &CONV_VALID {
+            assert_eq!(SpotifyUri::from_base16(c.base16, c.kind).unwrap(), c.parsed);
+        }
+
+        for c in &CONV_INVALID {
+            assert!(SpotifyId::from_base16(c.base16).is_err(),);
+        }
+    }
+
+    #[test]
+    fn to_base16() {
+        for c in &CONV_VALID {
+            assert_eq!(c.parsed.to_base16().unwrap(), c.base16);
+        }
+    }
+
+    #[test]
+    fn from_uri() {
+        for c in &CONV_VALID {
+            let actual = SpotifyUri::from_uri(c.uri).unwrap();
+
+            assert_eq!(actual, c.parsed);
+            assert_eq!(actual.item_type(), c.kind);
+        }
+
+        for c in &CONV_INVALID {
+            assert!(SpotifyUri::from_uri(c.uri).is_err());
+        }
+    }
+
+    #[test]
+    fn from_local_uri() {
+        let actual = SpotifyUri::from_uri("spotify:local:xyz:123").unwrap();
+
+        assert_eq!(
+            actual,
+            SpotifyUri::Local {
+                artist: "unimplemented".to_owned(),
+                album_title: "unimplemented".to_owned(),
+                track_title: "unimplemented".to_owned(),
+                duration: Default::default(),
+            }
+        );
+    }
+
+    #[test]
+    fn from_named_uri() {
+        let actual =
+            SpotifyUri::from_uri("spotify:user:spotify:playlist:37i9dQZF1DWSw8liJZcPOI").unwrap();
+
+        let SpotifyUri::Playlist { ref user, id } = actual else {
+            panic!("wrong id type");
+        };
+
+        assert_eq!(actual.item_type(), SpotifyItemType::Playlist);
+        assert_eq!(*user, Some("spotify".to_owned()));
+        assert_eq!(
+            id,
+            SpotifyId {
+                id: 136159921382084734723401526672209703396
+            },
+        );
+    }
+
+    #[test]
+    fn to_uri() {
+        for c in &CONV_VALID {
+            assert_eq!(c.parsed.to_uri().unwrap(), c.uri);
+        }
+    }
+
+    #[test]
+    fn from_raw() {
+        for c in &CONV_VALID {
+            assert_eq!(SpotifyUri::from_raw(c.raw, c.kind).unwrap(), c.parsed);
+        }
+
+        for c in &CONV_INVALID {
+            assert!(SpotifyUri::from_raw(c.raw, c.kind).is_err());
+        }
+    }
+}

--- a/core/src/spotify_uri.rs
+++ b/core/src/spotify_uri.rs
@@ -124,6 +124,11 @@ impl SpotifyUri {
         let mut parts = src.split(':');
 
         let scheme = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+
+        if scheme != "spotify" {
+            return Err(SpotifyUriError::InvalidRoot.into());
+        }
+
         let mut username: Option<String> = None;
 
         let item_type = {
@@ -142,11 +147,6 @@ impl SpotifyUri {
         };
 
         let name = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
-
-        if scheme != "spotify" {
-            return Err(SpotifyUriError::InvalidRoot.into());
-        }
-
         match item_type {
             SPOTIFY_ITEM_TYPE_ALBUM => Ok(Self::Album {
                 id: SpotifyId::from_base62(name)?,
@@ -222,6 +222,12 @@ impl fmt::Debug for SpotifyUri {
         f.debug_tuple("SpotifyUri")
             .field(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
             .finish()
+    }
+}
+
+impl fmt::Display for SpotifyUri {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
     }
 }
 

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -43,7 +43,7 @@ async fn main() {
         backend(None, audio_format)
     });
 
-    player.load_uri(track, true, 0);
+    player.load(track, true, 0);
 
     println!("Playing...");
 

--- a/examples/play.rs
+++ b/examples/play.rs
@@ -2,10 +2,8 @@ use std::{env, process::exit};
 
 use librespot::{
     core::{
-        authentication::Credentials,
-        config::SessionConfig,
-        session::Session,
-        spotify_id::{SpotifyId, SpotifyItemType},
+        SpotifyUri, authentication::Credentials, config::SessionConfig, session::Session,
+        spotify_id::SpotifyId,
     },
     playback::{
         audio_backend,
@@ -28,8 +26,9 @@ async fn main() {
     }
     let credentials = Credentials::with_access_token(&args[1]);
 
-    let mut track = SpotifyId::from_base62(&args[2]).unwrap();
-    track.item_type = SpotifyItemType::Track;
+    let track = SpotifyUri::Track {
+        id: SpotifyId::from_base62(&args[2]).unwrap(),
+    };
 
     let backend = audio_backend::find(None).unwrap();
 
@@ -44,7 +43,7 @@ async fn main() {
         backend(None, audio_format)
     });
 
-    player.load(track, true, 0);
+    player.load_uri(track, true, 0);
 
     println!("Playing...");
 

--- a/examples/playlist_tracks.rs
+++ b/examples/playlist_tracks.rs
@@ -2,7 +2,8 @@ use std::{env, process::exit};
 
 use librespot::{
     core::{
-        authentication::Credentials, config::SessionConfig, session::Session, spotify_id::SpotifyId,
+        authentication::Credentials, config::SessionConfig, session::Session,
+        spotify_uri::SpotifyUri,
     },
     metadata::{Metadata, Playlist, Track},
 };
@@ -19,7 +20,7 @@ async fn main() {
     }
     let credentials = Credentials::with_access_token(&args[1]);
 
-    let plist_uri = SpotifyId::from_uri(&args[2]).unwrap_or_else(|_| {
+    let plist_uri = SpotifyUri::from_uri(&args[2]).unwrap_or_else(|_| {
         eprintln!(
             "PLAYLIST should be a playlist URI such as: \
                 \"spotify:playlist:37i9dQZF1DXec50AjHrNTq\""

--- a/metadata/src/episode.rs
+++ b/metadata/src/episode.rs
@@ -15,14 +15,14 @@ use crate::{
     video::VideoFiles,
 };
 
-use librespot_core::{Error, Session, SpotifyId, date::Date};
+use librespot_core::{Error, Session, SpotifyUri, date::Date};
 
 use librespot_protocol as protocol;
 pub use protocol::metadata::episode::EpisodeType;
 
 #[derive(Debug, Clone)]
 pub struct Episode {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub name: String,
     pub duration: i32,
     pub audio: AudioFiles,
@@ -49,19 +49,23 @@ pub struct Episode {
 }
 
 #[derive(Debug, Clone, Default)]
-pub struct Episodes(pub Vec<SpotifyId>);
+pub struct Episodes(pub Vec<SpotifyUri>);
 
-impl_deref_wrapped!(Episodes, Vec<SpotifyId>);
+impl_deref_wrapped!(Episodes, Vec<SpotifyUri>);
 
 #[async_trait]
 impl Metadata for Episode {
     type Message = protocol::metadata::Episode;
 
-    async fn request(session: &Session, episode_id: &SpotifyId) -> RequestResult {
+    async fn request(session: &Session, episode_uri: &SpotifyUri) -> RequestResult {
+        let SpotifyUri::Episode { id: episode_id } = episode_uri else {
+            return Err(Error::invalid_argument("episode_uri"));
+        };
+
         session.spclient().get_episode_metadata(episode_id).await
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error> {
         Self::try_from(msg)
     }
 }

--- a/metadata/src/image.rs
+++ b/metadata/src/image.rs
@@ -5,7 +5,7 @@ use std::{
 
 use crate::util::{impl_deref_wrapped, impl_from_repeated, impl_try_from_repeated};
 
-use librespot_core::{FileId, SpotifyId};
+use librespot_core::{FileId, SpotifyUri};
 
 use librespot_protocol as protocol;
 use protocol::metadata::Image as ImageMessage;
@@ -47,7 +47,7 @@ impl_deref_wrapped!(PictureSizes, Vec<PictureSize>);
 #[derive(Debug, Clone)]
 pub struct TranscodedPicture {
     pub target_name: String,
-    pub uri: SpotifyId,
+    pub uri: SpotifyUri,
 }
 
 #[derive(Debug, Clone)]

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -6,7 +6,7 @@ extern crate async_trait;
 
 use protobuf::Message;
 
-use librespot_core::{Error, Session, SpotifyId};
+use librespot_core::{Error, Session, SpotifyUri};
 
 pub mod album;
 pub mod artist;
@@ -44,15 +44,15 @@ pub trait Metadata: Send + Sized + 'static {
     type Message: protobuf::Message + std::fmt::Debug;
 
     // Request a protobuf
-    async fn request(session: &Session, id: &SpotifyId) -> RequestResult;
+    async fn request(session: &Session, id: &SpotifyUri) -> RequestResult;
 
     // Request a metadata struct
-    async fn get(session: &Session, id: &SpotifyId) -> Result<Self, Error> {
+    async fn get(session: &Session, id: &SpotifyUri) -> Result<Self, Error> {
         let response = Self::request(session, id).await?;
         let msg = Self::Message::parse_from_bytes(&response)?;
         trace!("Received metadata: {msg:#?}");
         Self::parse(&msg, id)
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error>;
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error>;
 }

--- a/metadata/src/playlist/annotation.rs
+++ b/metadata/src/playlist/annotation.rs
@@ -8,8 +8,7 @@ use crate::{
     request::{MercuryRequest, RequestResult},
 };
 
-use librespot_core::{Error, Session, SpotifyId};
-
+use librespot_core::{Error, Session, SpotifyId, SpotifyUri};
 use librespot_protocol as protocol;
 pub use protocol::playlist_annotate3::AbuseReportState;
 
@@ -26,12 +25,20 @@ pub struct PlaylistAnnotation {
 impl Metadata for PlaylistAnnotation {
     type Message = protocol::playlist_annotate3::PlaylistAnnotation;
 
-    async fn request(session: &Session, playlist_id: &SpotifyId) -> RequestResult {
+    async fn request(session: &Session, playlist_uri: &SpotifyUri) -> RequestResult {
         let current_user = session.username();
+
+        let SpotifyUri::Playlist {
+            id: playlist_id, ..
+        } = playlist_uri
+        else {
+            return Err(Error::invalid_argument("playlist_uri"));
+        };
+
         Self::request_for_user(session, &current_user, playlist_id).await
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error> {
         Ok(Self {
             description: msg.description().to_owned(),
             picture: msg.picture().to_owned(), // TODO: is this a URL or Spotify URI?
@@ -60,11 +67,18 @@ impl PlaylistAnnotation {
     async fn get_for_user(
         session: &Session,
         username: &str,
-        playlist_id: &SpotifyId,
+        playlist_uri: &SpotifyUri,
     ) -> Result<Self, Error> {
+        let SpotifyUri::Playlist {
+            id: playlist_id, ..
+        } = playlist_uri
+        else {
+            return Err(Error::invalid_argument("playlist_uri"));
+        };
+
         let response = Self::request_for_user(session, username, playlist_id).await?;
         let msg = <Self as Metadata>::Message::parse_from_bytes(&response)?;
-        Self::parse(&msg, playlist_id)
+        Self::parse(&msg, playlist_uri)
     }
 }
 

--- a/metadata/src/playlist/item.rs
+++ b/metadata/src/playlist/item.rs
@@ -10,7 +10,7 @@ use super::{
     permission::Capabilities,
 };
 
-use librespot_core::{SpotifyId, date::Date};
+use librespot_core::{SpotifyUri, date::Date};
 
 use librespot_protocol as protocol;
 use protocol::playlist4_external::Item as PlaylistItemMessage;
@@ -19,7 +19,7 @@ use protocol::playlist4_external::MetaItem as PlaylistMetaItemMessage;
 
 #[derive(Debug, Clone)]
 pub struct PlaylistItem {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub attributes: PlaylistItemAttributes,
 }
 
@@ -38,7 +38,7 @@ pub struct PlaylistItemList {
 
 #[derive(Debug, Clone)]
 pub struct PlaylistMetaItem {
-    pub revision: SpotifyId,
+    pub revision: SpotifyUri,
     pub attributes: PlaylistAttributes,
     pub length: i32,
     pub timestamp: Date,

--- a/metadata/src/playlist/list.rs
+++ b/metadata/src/playlist/list.rs
@@ -14,12 +14,7 @@ use super::{
     permission::Capabilities,
 };
 
-use librespot_core::{
-    Error, Session,
-    date::Date,
-    spotify_id::{NamedSpotifyId, SpotifyId},
-};
-
+use librespot_core::{Error, Session, SpotifyUri, date::Date, spotify_id::SpotifyId};
 use librespot_protocol as protocol;
 use protocol::playlist4_external::GeoblockBlockingType as Geoblock;
 
@@ -30,7 +25,7 @@ impl_deref_wrapped!(Geoblocks, Vec<Geoblock>);
 
 #[derive(Debug, Clone)]
 pub struct Playlist {
-    pub id: NamedSpotifyId,
+    pub id: SpotifyUri,
     pub revision: Vec<u8>,
     pub length: i32,
     pub attributes: PlaylistAttributes,
@@ -72,7 +67,7 @@ pub struct SelectedListContent {
 }
 
 impl Playlist {
-    pub fn tracks(&self) -> impl ExactSizeIterator<Item = &SpotifyId> {
+    pub fn tracks(&self) -> impl ExactSizeIterator<Item = &SpotifyUri> {
         let tracks = self.contents.items.iter().map(|item| &item.id);
 
         let length = tracks.len();
@@ -93,17 +88,35 @@ impl Playlist {
 impl Metadata for Playlist {
     type Message = protocol::playlist4_external::SelectedListContent;
 
-    async fn request(session: &Session, playlist_id: &SpotifyId) -> RequestResult {
+    async fn request(session: &Session, playlist_uri: &SpotifyUri) -> RequestResult {
+        let SpotifyUri::Playlist {
+            id: playlist_id, ..
+        } = playlist_uri
+        else {
+            return Err(Error::invalid_argument("playlist_uri"));
+        };
+
         session.spclient().get_playlist(playlist_id).await
     }
 
-    fn parse(msg: &Self::Message, id: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, uri: &SpotifyUri) -> Result<Self, Error> {
+        let SpotifyUri::Playlist {
+            id: playlist_id, ..
+        } = uri
+        else {
+            return Err(Error::invalid_argument("playlist_uri"));
+        };
+
         // the playlist proto doesn't contain the id so we decorate it
         let playlist = SelectedListContent::try_from(msg)?;
-        let id = NamedSpotifyId::from_spotify_id(*id, &playlist.owner_username);
+
+        let new_uri = SpotifyUri::Playlist {
+            id: *playlist_id,
+            user: Some(playlist.owner_username),
+        };
 
         Ok(Self {
-            id,
+            id: new_uri,
             revision: playlist.revision,
             length: playlist.length,
             attributes: playlist.attributes,

--- a/metadata/src/show.rs
+++ b/metadata/src/show.rs
@@ -5,7 +5,7 @@ use crate::{
     episode::Episodes, image::Images, restriction::Restrictions,
 };
 
-use librespot_core::{Error, Session, SpotifyId};
+use librespot_core::{Error, Session, SpotifyUri};
 
 use librespot_protocol as protocol;
 pub use protocol::metadata::show::ConsumptionOrder as ShowConsumptionOrder;
@@ -13,7 +13,7 @@ pub use protocol::metadata::show::MediaType as ShowMediaType;
 
 #[derive(Debug, Clone)]
 pub struct Show {
-    pub id: SpotifyId,
+    pub id: SpotifyUri,
     pub name: String,
     pub description: String,
     pub publisher: String,
@@ -27,7 +27,7 @@ pub struct Show {
     pub media_type: ShowMediaType,
     pub consumption_order: ShowConsumptionOrder,
     pub availability: Availabilities,
-    pub trailer_uri: Option<SpotifyId>,
+    pub trailer_uri: Option<SpotifyUri>,
     pub has_music_and_talk: bool,
     pub is_audiobook: bool,
 }
@@ -36,11 +36,15 @@ pub struct Show {
 impl Metadata for Show {
     type Message = protocol::metadata::Show;
 
-    async fn request(session: &Session, show_id: &SpotifyId) -> RequestResult {
+    async fn request(session: &Session, show_uri: &SpotifyUri) -> RequestResult {
+        let SpotifyUri::Show { id: show_id } = show_uri else {
+            return Err(Error::invalid_argument("show_uri"));
+        };
+
         session.spclient().get_show_metadata(show_id).await
     }
 
-    fn parse(msg: &Self::Message, _: &SpotifyId) -> Result<Self, Error> {
+    fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error> {
         Self::try_from(msg)
     }
 }
@@ -67,7 +71,7 @@ impl TryFrom<&<Self as Metadata>::Message> for Show {
                 .trailer_uri
                 .as_deref()
                 .filter(|s| !s.is_empty())
-                .map(SpotifyId::from_uri)
+                .map(SpotifyUri::from_uri)
                 .transpose()?,
             has_music_and_talk: show.music_and_talk(),
             is_audiobook: show.is_audiobook(),

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -528,7 +528,7 @@ impl Player {
     #[deprecated(since = "0.8.0", note = "use load_uri instead")]
     pub fn load(&self, track_id: SpotifyId, start_playing: bool, position_ms: u32) {
         self.command(PlayerCommand::Load {
-            track_id: track_id.into(),
+            track_id: SpotifyUri::Track { id: track_id },
             play: start_playing,
             position_ms,
         });
@@ -545,7 +545,7 @@ impl Player {
     #[deprecated(since = "0.8.0", note = "use preload_uri instead")]
     pub fn preload(&self, track_id: SpotifyId) {
         self.command(PlayerCommand::Preload {
-            track_id: track_id.into(),
+            track_id: SpotifyUri::Track { id: track_id },
         });
     }
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -947,7 +947,7 @@ impl PlayerTrackLoader {
                 self.load_remote_track(track_uri, position_ms).await
             }
             _ => {
-                error!("Cannot handle load of track with URI: <{track_uri:?}>",);
+                error!("Cannot handle load of track with URI: <{track_uri}>",);
                 None
             }
         }
@@ -958,7 +958,13 @@ impl PlayerTrackLoader {
         track_uri: SpotifyUri,
         position_ms: u32,
     ) -> Option<PlayerLoadedTrackData> {
-        let track_id: SpotifyId = (&track_uri).try_into().ok()?;
+        let track_id: SpotifyId = match (&track_uri).try_into() {
+            Ok(id) => id,
+            Err(_) => {
+                warn!("<{track_uri}> could not be converted to a base62 ID");
+                return None;
+            }
+        };
 
         let audio_item = match AudioItem::get_file(&self.session, track_uri).await {
             Ok(audio) => match self.find_available_alternative(audio).await {

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -28,7 +28,7 @@ impl EventHandler {
                                 env_vars.insert("PLAY_REQUEST_ID", play_request_id.to_string());
                             }
                             PlayerEvent::TrackChanged { audio_item } => {
-                                match audio_item.track_id.to_base62() {
+                                match audio_item.track_id.to_name() {
                                     Err(e) => {
                                         warn!("PlayerEvent::TrackChanged: Invalid track id: {e}")
                                     }
@@ -104,7 +104,7 @@ impl EventHandler {
                                     }
                                 }
                             }
-                            PlayerEvent::Stopped { track_id, .. } => match track_id.to_base62() {
+                            PlayerEvent::Stopped { track_id, .. } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Stopped: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "stopped".to_string());
@@ -115,7 +115,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_base62() {
+                            } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Playing: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "playing".to_string());
@@ -127,7 +127,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_base62() {
+                            } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Paused: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "paused".to_string());
@@ -135,26 +135,24 @@ impl EventHandler {
                                     env_vars.insert("POSITION_MS", position_ms.to_string());
                                 }
                             },
-                            PlayerEvent::Loading { track_id, .. } => match track_id.to_base62() {
+                            PlayerEvent::Loading { track_id, .. } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Loading: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "loading".to_string());
                                     env_vars.insert("TRACK_ID", id);
                                 }
                             },
-                            PlayerEvent::Preloading { track_id, .. } => {
-                                match track_id.to_base62() {
-                                    Err(e) => {
-                                        warn!("PlayerEvent::Preloading: Invalid track id: {e}")
-                                    }
-                                    Ok(id) => {
-                                        env_vars.insert("PLAYER_EVENT", "preloading".to_string());
-                                        env_vars.insert("TRACK_ID", id);
-                                    }
+                            PlayerEvent::Preloading { track_id, .. } => match track_id.to_name() {
+                                Err(e) => {
+                                    warn!("PlayerEvent::Preloading: Invalid track id: {e}")
                                 }
-                            }
+                                Ok(id) => {
+                                    env_vars.insert("PLAYER_EVENT", "preloading".to_string());
+                                    env_vars.insert("TRACK_ID", id);
+                                }
+                            },
                             PlayerEvent::TimeToPreloadNextTrack { track_id, .. } => {
-                                match track_id.to_base62() {
+                                match track_id.to_name() {
                                     Err(e) => warn!(
                                         "PlayerEvent::TimeToPreloadNextTrack: Invalid track id: {e}"
                                     ),
@@ -164,19 +162,16 @@ impl EventHandler {
                                     }
                                 }
                             }
-                            PlayerEvent::EndOfTrack { track_id, .. } => {
-                                match track_id.to_base62() {
-                                    Err(e) => {
-                                        warn!("PlayerEvent::EndOfTrack: Invalid track id: {e}")
-                                    }
-                                    Ok(id) => {
-                                        env_vars.insert("PLAYER_EVENT", "end_of_track".to_string());
-                                        env_vars.insert("TRACK_ID", id);
-                                    }
+                            PlayerEvent::EndOfTrack { track_id, .. } => match track_id.to_name() {
+                                Err(e) => {
+                                    warn!("PlayerEvent::EndOfTrack: Invalid track id: {e}")
                                 }
-                            }
-                            PlayerEvent::Unavailable { track_id, .. } => match track_id.to_base62()
-                            {
+                                Ok(id) => {
+                                    env_vars.insert("PLAYER_EVENT", "end_of_track".to_string());
+                                    env_vars.insert("TRACK_ID", id);
+                                }
+                            },
+                            PlayerEvent::Unavailable { track_id, .. } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Unavailable: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "unavailable".to_string());
@@ -191,7 +186,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_base62() {
+                            } => match track_id.to_name() {
                                 Err(e) => warn!("PlayerEvent::Seeked: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "seeked".to_string());
@@ -203,7 +198,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_base62() {
+                            } => match track_id.to_name() {
                                 Err(e) => {
                                     warn!("PlayerEvent::PositionCorrection: Invalid track id: {e}")
                                 }

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -28,7 +28,7 @@ impl EventHandler {
                                 env_vars.insert("PLAY_REQUEST_ID", play_request_id.to_string());
                             }
                             PlayerEvent::TrackChanged { audio_item } => {
-                                match audio_item.track_id.to_name() {
+                                match audio_item.track_id.to_id() {
                                     Err(e) => {
                                         warn!("PlayerEvent::TrackChanged: Invalid track id: {e}")
                                     }
@@ -104,7 +104,7 @@ impl EventHandler {
                                     }
                                 }
                             }
-                            PlayerEvent::Stopped { track_id, .. } => match track_id.to_name() {
+                            PlayerEvent::Stopped { track_id, .. } => match track_id.to_id() {
                                 Err(e) => warn!("PlayerEvent::Stopped: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "stopped".to_string());
@@ -115,7 +115,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_name() {
+                            } => match track_id.to_id() {
                                 Err(e) => warn!("PlayerEvent::Playing: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "playing".to_string());
@@ -127,7 +127,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_name() {
+                            } => match track_id.to_id() {
                                 Err(e) => warn!("PlayerEvent::Paused: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "paused".to_string());
@@ -135,14 +135,14 @@ impl EventHandler {
                                     env_vars.insert("POSITION_MS", position_ms.to_string());
                                 }
                             },
-                            PlayerEvent::Loading { track_id, .. } => match track_id.to_name() {
+                            PlayerEvent::Loading { track_id, .. } => match track_id.to_id() {
                                 Err(e) => warn!("PlayerEvent::Loading: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "loading".to_string());
                                     env_vars.insert("TRACK_ID", id);
                                 }
                             },
-                            PlayerEvent::Preloading { track_id, .. } => match track_id.to_name() {
+                            PlayerEvent::Preloading { track_id, .. } => match track_id.to_id() {
                                 Err(e) => {
                                     warn!("PlayerEvent::Preloading: Invalid track id: {e}")
                                 }
@@ -152,7 +152,7 @@ impl EventHandler {
                                 }
                             },
                             PlayerEvent::TimeToPreloadNextTrack { track_id, .. } => {
-                                match track_id.to_name() {
+                                match track_id.to_id() {
                                     Err(e) => warn!(
                                         "PlayerEvent::TimeToPreloadNextTrack: Invalid track id: {e}"
                                     ),
@@ -162,7 +162,7 @@ impl EventHandler {
                                     }
                                 }
                             }
-                            PlayerEvent::EndOfTrack { track_id, .. } => match track_id.to_name() {
+                            PlayerEvent::EndOfTrack { track_id, .. } => match track_id.to_id() {
                                 Err(e) => {
                                     warn!("PlayerEvent::EndOfTrack: Invalid track id: {e}")
                                 }
@@ -171,7 +171,7 @@ impl EventHandler {
                                     env_vars.insert("TRACK_ID", id);
                                 }
                             },
-                            PlayerEvent::Unavailable { track_id, .. } => match track_id.to_name() {
+                            PlayerEvent::Unavailable { track_id, .. } => match track_id.to_id() {
                                 Err(e) => warn!("PlayerEvent::Unavailable: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "unavailable".to_string());
@@ -186,7 +186,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_name() {
+                            } => match track_id.to_id() {
                                 Err(e) => warn!("PlayerEvent::Seeked: Invalid track id: {e}"),
                                 Ok(id) => {
                                     env_vars.insert("PLAYER_EVENT", "seeked".to_string());
@@ -198,7 +198,7 @@ impl EventHandler {
                                 track_id,
                                 position_ms,
                                 ..
-                            } => match track_id.to_name() {
+                            } => match track_id.to_id() {
                                 Err(e) => {
                                     warn!("PlayerEvent::PositionCorrection: Invalid track id: {e}")
                                 }


### PR DESCRIPTION
Contributes to #1266

Introduces a new `SpotifyUri` struct which is layered on top of the existing `SpotifyId`, but has the capability to support URIs that do not confirm to the canonical base62 encoded format. This allows it to describe URIs like `spotify:local`, `spotify:genre` and others that `SpotifyId` cannot represent.

Changed the internal player state to use these URIs as much as possible, such that the player could in the future accept a URI of the type `spotify:local`, as a means of laying the groundwork for local file support.

---

I know #1266 is not a very good issue for my first one on the project, but I would really like to implement local file support and it doesn't seem like that will be possible for the player to handle without hacks unless we change the way we store the track URI. This is because local files URIs are of the form `spotify:local:{artist}:{album_title}:{track_title}:{duration_in_seconds}` which cannot be represented under a `u128` inside `SpotifyId` like the base62 names that all official tracks have.

I have opened this PR to show what the proposed refactor in #1266 would involve, particularly with regard to the breaking changes I have had to make. So there are probably some things that can be polished more and tests added, but I wanted to get some feedback on the overall direction first. If the proposed change is too radical I will not be offended if you decide to close this PR :slightly_smiling_face: 

p.s. I have put all the changelogs etc. as 0.7.0 but it sounds like that is coming soon so just to be clear I have no expectation of this making it into the upcoming release 

