### PR TITLE
Fix: Fires the `SessionConnected` and `SessionDisconnected` again

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -898,8 +898,8 @@ impl SpircTask {
                 && cluster.active_device_id != self.session.device_id();
             if became_inactive {
                 info!("device became inactive");
-                self.connect_state.became_inactive(&self.session).await?;
-                self.handle_stop()
+                self.handle_disconnect().await?;
+                self.handle_stop();
             } else if self.connect_state.is_active() {
                 // fixme: workaround fix, because of missing information why it behaves like it does
                 //  background: when another device sends a connect-state update, some player's position de-syncs
@@ -1102,10 +1102,10 @@ impl SpircTask {
             ContextAction::Replace,
         ));
 
+        self.handle_activate();
+
         let timestamp = self.now_ms();
         let state = &mut self.connect_state;
-
-        state.set_active(true);
         state.handle_initial_transfer(&mut transfer);
 
         // adjust active context, so resolve knows for which context it should set up the state

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -29,7 +29,7 @@ use futures_util::future::IntoStream;
 use http::{Uri, header::HeaderValue};
 use hyper::{
     HeaderMap, Method, Request,
-    header::{ACCEPT, AUTHORIZATION, CONTENT_TYPE, HeaderName, RANGE},
+    header::{ACCEPT, AUTHORIZATION, CONTENT_LENGTH, CONTENT_TYPE, HeaderName, RANGE},
 };
 use hyper_util::client::legacy::ResponseFuture;
 use protobuf::{Enum, Message, MessageFull};
@@ -482,6 +482,7 @@ impl SpClient {
             let mut request = Request::builder()
                 .method(method)
                 .uri(url)
+                .header(CONTENT_LENGTH, body.len())
                 .body(Bytes::copy_from_slice(body))?;
 
             // Reconnection logic: keep getting (cached) tokens because they might have expired.


### PR DESCRIPTION
- fixes the missing event triggers for `SessionConnected` and `SessionDisconnected`
- additionally fixes a problem with `put_connect_state_inactive` where it returned a 411
  - adding the `Content-Length` header fixed the issue

> I didn't add a changelog entry, as this is a result of the refactoring from the dealer

Fixes #1547 