### PR TITLE
Fix: Fixup how the headers are set in `spclient` to prevent deleting headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [core] Fixed a problem where in `spclient` where a http 411 error was thrown because the header were set wrong 
+
 ### Security
 
 ## [0.7.0] - 2025-08-24

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -489,9 +489,12 @@ impl SpClient {
             let token = self.session().login5().auth_token().await?;
 
             let headers_mut = request.headers_mut();
-            if let Some(ref hdrs) = headers {
-                *headers_mut = hdrs.clone();
+            if let Some(ref headers) = headers {
+                for (name, value) in headers {
+                    headers_mut.insert(name, value.clone());
+                }
             }
+
             headers_mut.insert(
                 AUTHORIZATION,
                 HeaderValue::from_str(&format!("{} {}", token.token_type, token.access_token,))?,


### PR DESCRIPTION
Instead of setting the header later I overwrite the headers in a loop. `insert` seems to replace the existing keys, so the headers given from the outside are still prioritized, and headers set in the builder are not removed.

Fixes #1551 