### PR TITLE
Fix: Delete the connect state only on spirc shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [connect] Only deletes the connect state on dealer shutdown instead on disconnecting
+
 ### Security
 
 ## [0.7.0] - 2025-08-24

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -552,6 +552,11 @@ impl SpircTask {
             }
         }
 
+        // this should clear the active session id, leaving an empty state
+        if let Err(why) = self.session.spclient().delete_connect_state_request().await {
+            error!("error during connect state deletion: {why}")
+        };
+
         self.session.dealer().close().await;
     }
 
@@ -1162,12 +1167,6 @@ impl SpircTask {
         self.notify().await?;
 
         self.connect_state.became_inactive(&self.session).await?;
-
-        // this should clear the active session id, leaving an empty state
-        self.session
-            .spclient()
-            .delete_connect_state_request()
-            .await?;
 
         self.player
             .emit_session_disconnected_event(self.session.connection_id(), self.session.username());


### PR DESCRIPTION
In #1551 @samcook encountered an unexpected behavior during reconnecting.

The issue happens because the reconnect is initiated via zeroconf instead of using the connect interface, aka in the disconnect handling was a major issue where the state itself was deleted. This should only happen when shutting down the dealer so that the dealer can still receive requests and updates.