### PR TITLE
Adjust: Allow repeat in combination with shuffle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 target
 .cargo
 spotify_appkey.key
+.idea/
 .vagrant/
 .project
 .history

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [connect] Shuffling was adjusted, so that shuffle and repeat can be used combined
+
 ### Deprecated
 
 ### Removed
 
 ### Fixed
 
+- [connect] Repeat context will not go into autoplay anymore and triggering autoplay while shuffling shouldn't reshuffle anymore 
 - [connect] Only deletes the connect state on dealer shutdown instead on disconnecting
-- [core] Fixed a problem where in `spclient` where a http 411 error was thrown because the header were set wrong 
+- [core] Fixed a problem where in `spclient` where an http 411 error was thrown because the header were set wrong
 - [main] Use the config instead of the type default for values that are not provided by the user
 
 

--- a/connect/src/context_resolver.rs
+++ b/connect/src/context_resolver.rs
@@ -319,7 +319,7 @@ impl ContextResolver {
         let res = if let Some(transfer_state) = transfer_state.take() {
             state.finish_transfer(transfer_state)
         } else if state.shuffling_context() && next.update == ContextType::Default {
-            state.shuffle(None)
+            state.shuffle_new()
         } else if matches!(active_ctx, Ok(ctx) if ctx.index.track == 0) {
             // has context, and context is not touched
             // when the index is not zero, the next index was already evaluated elsewhere

--- a/connect/src/context_resolver.rs
+++ b/connect/src/context_resolver.rs
@@ -318,7 +318,7 @@ impl ContextResolver {
         let active_ctx = state.get_context(state.active_context);
         let res = if let Some(transfer_state) = transfer_state.take() {
             state.finish_transfer(transfer_state)
-        } else if state.shuffling_context() {
+        } else if state.shuffling_context() && next.update == ContextType::Default {
             state.shuffle(None)
         } else if matches!(active_ctx, Ok(ctx) if ctx.index.track == 0) {
             // has context, and context is not touched

--- a/connect/src/shuffle_vec.rs
+++ b/connect/src/shuffle_vec.rs
@@ -76,8 +76,10 @@ impl<T> ShuffleVec<T> {
         };
 
         for i in 1..self.vec.len() {
-            let n = indices[self.vec.len() - i - 1];
-            self.vec.swap(n, i);
+            match indices.get(self.vec.len() - i - 1) {
+                None => return,
+                Some(n) => self.vec.swap(*n, i),
+            }
         }
     }
 }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1287,7 +1287,7 @@ impl SpircTask {
             if self.context_resolver.has_next() {
                 self.connect_state.update_queue_revision()
             } else {
-                self.connect_state.shuffle(None)?;
+                self.connect_state.shuffle_new()?;
                 self.add_autoplay_resolving_when_required();
             }
         } else {

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -395,7 +395,7 @@ impl ConnectState {
         self.update_context_index(self.active_context, new_index + 1)?;
         self.fill_up_context = self.active_context;
 
-        if !self.current_track(|t| t.is_queue()) {
+        if !self.current_track(|t| t.is_queue() || self.is_skip_track(t, None)) {
             self.set_current_track(new_index)?;
         }
 

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -23,6 +23,7 @@ use crate::{
     },
     state::{
         context::{ContextType, ResetContext, StateContext},
+        options::ShuffleState,
         provider::{IsProvider, Provider},
     },
 };
@@ -123,7 +124,7 @@ pub(super) struct ConnectState {
     /// the context from which we play, is used to top up prev and next tracks
     context: Option<StateContext>,
     /// seed extracted in [ConnectState::handle_initial_transfer] and used in [ConnectState::finish_transfer]
-    transfer_shuffle_seed: Option<u64>,
+    transfer_shuffle: Option<ShuffleState>,
 
     /// a context to keep track of the autoplay context
     autoplay_context: Option<StateContext>,

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -55,7 +55,7 @@ pub(super) enum StateError {
     #[error("the provided context has no tracks")]
     ContextHasNoTracks,
     #[error("playback of local files is not supported")]
-    UnsupportedLocalPlayBack,
+    UnsupportedLocalPlayback,
     #[error("track uri <{0:?}> contains invalid characters")]
     InvalidTrackUri(Option<String>),
 }
@@ -69,7 +69,7 @@ impl From<StateError> for Error {
             | CanNotFindTrackInContext(_, _)
             | ContextHasNoTracks
             | InvalidTrackUri(_) => Error::failed_precondition(err),
-            CurrentlyDisallowed { .. } | UnsupportedLocalPlayBack => Error::unavailable(err),
+            CurrentlyDisallowed { .. } | UnsupportedLocalPlayback => Error::unavailable(err),
         }
     }
 }

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -194,7 +194,7 @@ impl ConnectState {
             error!("context didn't have any tracks: {context:#?}");
             Err(StateError::ContextHasNoTracks)?;
         } else if matches!(context.uri, Some(ref uri) if uri.starts_with(LOCAL_FILES_IDENTIFIER)) {
-            Err(StateError::UnsupportedLocalPlayBack)?;
+            Err(StateError::UnsupportedLocalPlayback)?;
         }
 
         let mut next_contexts = Vec::new();

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -24,7 +24,6 @@ const SEARCH_IDENTIFIER: &str = "spotify:search";
 #[derive(Debug)]
 pub struct StateContext {
     pub tracks: ShuffleVec<ProvidedTrack>,
-    pub skip_track: Option<ProvidedTrack>,
     pub metadata: HashMap<String, String>,
     pub restrictions: Option<Restrictions>,
     /// is used to keep track which tracks are already loaded into the next_tracks
@@ -108,6 +107,7 @@ impl ConnectState {
 
         if let Ok(ctx) = self.get_context_mut(ContextType::Default) {
             ctx.remove_shuffle_seed();
+            ctx.remove_initial_track();
             ctx.tracks.unshuffle()
         }
 
@@ -377,18 +377,23 @@ impl ConnectState {
 
         StateContext {
             tracks: tracks.into(),
-            skip_track: None,
             restrictions,
             metadata,
             index: ContextIndex::new(),
         }
     }
 
-    pub fn is_skip_track(&self, track: &ProvidedTrack) -> bool {
-        self.get_context(self.active_context)
-            .ok()
-            .and_then(|t| t.skip_track.as_ref().map(|t| t.uri == track.uri))
-            .unwrap_or(false)
+    pub fn is_skip_track(&self, track: &ProvidedTrack, iteration: Option<u32>) -> bool {
+        let ctx = match self.get_context(self.active_context).ok() {
+            None => return false,
+            Some(ctx) => ctx,
+        };
+
+        if ctx.get_initial_track().is_none_or(|uri| uri != &track.uri) {
+            return false;
+        }
+
+        iteration.is_none_or(|i| i == 0)
     }
 
     pub fn merge_context(&mut self, new_page: Option<ContextPage>) -> Option<()> {

--- a/connect/src/state/handle.rs
+++ b/connect/src/state/handle.rs
@@ -13,7 +13,7 @@ impl ConnectState {
         self.set_shuffle(shuffle);
 
         if shuffle {
-            return self.shuffle(None);
+            return self.shuffle_new();
         }
 
         self.reset_context(ResetContext::DefaultIndex);

--- a/connect/src/state/handle.rs
+++ b/connect/src/state/handle.rs
@@ -45,16 +45,13 @@ impl ConnectState {
 
         if repeat {
             if let ContextType::Autoplay = self.fill_up_context {
-                self.autoplay_context = None;
                 self.fill_up_context = ContextType::Default;
             }
-            self.fill_up_next_tracks()
-        } else {
-            let ctx = self.get_context(ContextType::Default)?;
-            let current_track = ConnectState::find_index_in_context(ctx, |t| {
-                self.current_track(|t| &t.uri) == &t.uri
-            })?;
-            self.reset_playback_to_position(Some(current_track))
         }
+
+        let ctx = self.get_context(ContextType::Default)?;
+        let current_track =
+            ConnectState::find_index_in_context(ctx, |t| self.current_track(|t| &t.uri) == &t.uri)?;
+        self.reset_playback_to_position(Some(current_track))
     }
 }

--- a/connect/src/state/handle.rs
+++ b/connect/src/state/handle.rs
@@ -44,17 +44,17 @@ impl ConnectState {
         self.set_repeat_context(repeat);
 
         if repeat {
-            self.set_shuffle(false);
-            self.reset_context(ResetContext::DefaultIndex);
-
+            if let ContextType::Autoplay = self.fill_up_context {
+                self.autoplay_context = None;
+                self.fill_up_context = ContextType::Default;
+            }
+            self.fill_up_next_tracks()
+        } else {
             let ctx = self.get_context(ContextType::Default)?;
             let current_track = ConnectState::find_index_in_context(ctx, |t| {
                 self.current_track(|t| &t.uri) == &t.uri
             })?;
             self.reset_playback_to_position(Some(current_track))
-        } else {
-            self.update_restrictions();
-            Ok(())
         }
     }
 }

--- a/connect/src/state/metadata.rs
+++ b/connect/src/state/metadata.rs
@@ -14,6 +14,7 @@ const ITERATION: &str = "iteration";
 
 const CUSTOM_CONTEXT_INDEX: &str = "context_index";
 const CUSTOM_SHUFFLE_SEED: &str = "shuffle_seed";
+const CUSTOM_INITIAL_TRACK: &str = "initial_track";
 
 macro_rules! metadata_entry {
     ( $get:ident, $set:ident, $clear:ident ($key:ident: $entry:ident)) => {
@@ -63,6 +64,7 @@ pub(super) trait Metadata {
     metadata_entry!(get_entity_uri, set_entity_uri, remove_entity_uri (entity_uri: ENTITY_URI));
     metadata_entry!(get_iteration, set_iteration, remove_iteration (iteration: ITERATION));
     metadata_entry!(get_shuffle_seed, set_shuffle_seed, remove_shuffle_seed (shuffle_seed: CUSTOM_SHUFFLE_SEED));
+    metadata_entry!(get_initial_track, set_initial_track, remove_initial_track (initial_track: CUSTOM_INITIAL_TRACK));
 }
 
 macro_rules! impl_metadata {

--- a/connect/src/state/options.rs
+++ b/connect/src/state/options.rs
@@ -65,8 +65,9 @@ impl ConnectState {
         self.reset_context(ResetContext::DefaultIndex);
         let ctx = self.get_context_mut(ContextType::Default)?;
 
-        // we don't need to include the current track, because it is already being played
-        ctx.skip_track = current_track;
+        if let Some(current_track) = current_track {
+            ctx.set_initial_track(current_track.uri);
+        }
 
         let seed =
             seed.unwrap_or_else(|| rand::rng().random_range(100_000_000_000..1_000_000_000_000));

--- a/connect/src/state/restrictions.rs
+++ b/connect/src/state/restrictions.rs
@@ -14,7 +14,6 @@ impl ConnectState {
     pub fn update_restrictions(&mut self) {
         const NO_PREV: &str = "no previous tracks";
         const AUTOPLAY: &str = "autoplay";
-        const ENDLESS_CONTEXT: &str = "endless_context";
 
         let prev_tracks_is_empty = self.prev_tracks().is_empty();
 
@@ -51,8 +50,6 @@ impl ConnectState {
                 restrictions.disallow_toggling_shuffle_reasons = vec![AUTOPLAY.to_string()];
                 restrictions.disallow_toggling_repeat_context_reasons = vec![AUTOPLAY.to_string()];
                 restrictions.disallow_toggling_repeat_track_reasons = vec![AUTOPLAY.to_string()];
-            } else if player.options.repeating_context {
-                restrictions.disallow_toggling_shuffle_reasons = vec![ENDLESS_CONTEXT.to_string()]
             } else {
                 restrictions.disallow_toggling_shuffle_reasons.clear();
                 restrictions

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -296,7 +296,8 @@ impl<'ct> ConnectState {
                     delimiter
                 }
                 None if !matches!(self.fill_up_context, ContextType::Autoplay)
-                    && self.autoplay_context.is_some() =>
+                    && self.autoplay_context.is_some()
+                    && !self.repeat_context() =>
                 {
                     self.update_context_index(self.fill_up_context, new_index)?;
 

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -124,7 +124,7 @@ impl<'ct> ConnectState {
                     continue;
                 }
                 Some(next) if next.is_unavailable() => continue,
-                Some(next) if self.is_skip_track(&next) => continue,
+                Some(next) if self.is_skip_track(&next, None) => continue,
                 other => break other,
             };
         };
@@ -322,7 +322,11 @@ impl<'ct> ConnectState {
                     }
                 }
                 None => break,
-                Some(ct) if ct.is_unavailable() || self.is_skip_track(ct) => {
+                Some(ct) if ct.is_unavailable() || self.is_skip_track(ct, Some(iteration)) => {
+                    debug!(
+                        "skipped track {} during fillup as it's unavailable or should be skipped",
+                        ct.uri
+                    );
                     new_index += 1;
                     continue;
                 }

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -124,7 +124,6 @@ impl<'ct> ConnectState {
                     continue;
                 }
                 Some(next) if next.is_unavailable() => continue,
-                Some(next) if self.is_skip_track(&next, None) => continue,
                 other => break other,
             };
         };

--- a/connect/src/state/transfer.rs
+++ b/connect/src/state/transfer.rs
@@ -173,8 +173,10 @@ impl ConnectState {
             self.set_current_track(current_index.unwrap_or_default())?;
             self.set_shuffle(true);
 
-            let shuffle = self.transfer_shuffle.take();
-            self.shuffle(shuffle)?;
+            match self.transfer_shuffle.take() {
+                None => self.shuffle_new(),
+                Some(state) => self.shuffle_restore(state),
+            }?
         } else {
             self.reset_playback_to_position(current_index)?;
         }


### PR DESCRIPTION
This should allow to combine repeat and shuffle without any odd behaviors. Shuffling itself was quite a bit inconsistent before, so I had to adjust the shuffling a bit so that's a bit more predictable to work with.

@aome510 could you give this a try and see if there is anything weird in the combination or how the queue behaves? Thanks in advance :)

Fixes #1550 