### PR TITLE
chore: update libmdns to 0.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1413,7 +1413,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.0",
+ "socket2",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -1560,12 +1560,12 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.12.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb2a33e9c38988ecbda730c85b0fd9ddcdf83c0305ac7fd21c8bb9f57f2f0cc8"
+checksum = "bf39cc0423ee66021dc5eccface85580e4a001e0c5288bae8bea7ecb69225e90"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1779,9 +1779,9 @@ checksum = "f9fbbcab51052fe104eb5e5d351cf728d30a5be1fe14d9be8a3b097481fb97de"
 
 [[package]]
 name = "libmdns"
-version = "0.9.1"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48854699e11b111433431b69cee2365fcab0b29b06993f48c257dfbaf6395862"
+checksum = "a00dbe871d2cf9df13f68d152b949fca8cafc854b60ffd259fc6df6e8663d8d7"
 dependencies = [
  "byteorder",
  "futures-util",
@@ -1789,9 +1789,9 @@ dependencies = [
  "if-addrs",
  "log",
  "multimap",
- "rand 0.8.5",
- "socket2 0.5.10",
- "thiserror 1.0.69",
+ "rand 0.9.2",
+ "socket2",
+ "thiserror 2.0.16",
  "tokio",
 ]
 
@@ -2163,9 +2163,6 @@ name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "native-tls"
@@ -2855,7 +2852,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls 0.23.31",
- "socket2 0.6.0",
+ "socket2",
  "thiserror 2.0.16",
  "tokio",
  "tracing",
@@ -2892,7 +2889,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.0",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3485,16 +3482,6 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
@@ -3857,7 +3844,7 @@ dependencies = [
  "pin-project-lite",
  "signal-hook-registry",
  "slab",
- "socket2 0.6.0",
+ "socket2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.59.0",

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -41,7 +41,7 @@ hyper-util = { version = "0.1", features = [
     "server-graceful",
     "service",
 ] }
-libmdns = { version = "0.9", optional = true }
+libmdns = { version = "0.10", optional = true }
 log = "0.4"
 rand = "0.9"
 serde = { version = "1", default-features = false, features = [

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -406,12 +406,7 @@ fn launch_libmdns(
             }
             .map_err(|e| DiscoveryError::DnsSdError(Box::new(e)))?;
 
-            let svc = responder.register(
-                DNS_SD_SERVICE_NAME.to_owned(),
-                name.into_owned(),
-                port,
-                &TXT_RECORD,
-            );
+            let svc = responder.register(&DNS_SD_SERVICE_NAME, &name, port, &TXT_RECORD);
 
             let _ = shutdown_rx.blocking_recv();
 


### PR DESCRIPTION
This is not required to fix #1569 as the broken version has been yanked.