### PR TITLE
feat: add inital flac decoding support via the symphonia crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3546,11 +3546,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "815c942ae7ee74737bb00f965fa5b5a2ac2ce7b6c01c0cc169bbeaf7abd5f5a9"
 dependencies = [
  "lazy_static",
+ "symphonia-bundle-flac",
  "symphonia-bundle-mp3",
  "symphonia-codec-vorbis",
  "symphonia-core",
  "symphonia-format-ogg",
  "symphonia-metadata",
+]
+
+[[package]]
+name = "symphonia-bundle-flac"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72e34f34298a7308d4397a6c7fbf5b84c5d491231ce3dd379707ba673ab3bd97"
+dependencies = [
+ "log",
+ "symphonia-core",
+ "symphonia-metadata",
+ "symphonia-utils-xiph",
 ]
 
 [[package]]

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -91,6 +91,7 @@ symphonia = { version = "0.5", default-features = false, features = [
     "mp3",
     "ogg",
     "vorbis",
+    "flac"
 ] }
 
 # Legacy Ogg container decoder for the passthrough decoder

--- a/playback/src/decoder/symphonia_decoder.rs
+++ b/playback/src/decoder/symphonia_decoder.rs
@@ -10,8 +10,8 @@ use symphonia::{
         meta::{StandardTagKey, Value},
     },
     default::{
-        codecs::{MpaDecoder, VorbisDecoder},
-        formats::{MpaReader, OggReader},
+        codecs::{FlacDecoder, MpaDecoder, VorbisDecoder},
+        formats::{FlacReader, MpaReader, OggReader},
     },
 };
 
@@ -48,6 +48,8 @@ impl SymphoniaDecoder {
             Box::new(OggReader::try_new(mss, &format_opts)?)
         } else if AudioFiles::is_mp3(file_format) {
             Box::new(MpaReader::try_new(mss, &format_opts)?)
+        } else if AudioFiles::is_flac(file_format) {
+            Box::new(FlacReader::try_new(mss, &format_opts)?)
         } else {
             return Err(DecoderError::SymphoniaDecoder(format!(
                 "Unsupported format: {file_format:?}"
@@ -63,6 +65,8 @@ impl SymphoniaDecoder {
             Box::new(VorbisDecoder::try_new(&track.codec_params, &decoder_opts)?)
         } else if AudioFiles::is_mp3(file_format) {
             Box::new(MpaDecoder::try_new(&track.codec_params, &decoder_opts)?)
+        } else if AudioFiles::is_flac(file_format) {
+            Box::new(FlacDecoder::try_new(&track.codec_params, &decoder_opts)?)
         } else {
             return Err(DecoderError::SymphoniaDecoder(format!(
                 "Unsupported decoder: {file_format:?}"


### PR DESCRIPTION
I have added the initial code path to support decoding FLAC bitstreams using the existing tooling around the symphonia crate. This needs further testing, as I don't yet have access to FLAC capabilities from the official client. Also, I have some questions regarding the required implementation: should I add a `passthrough_decoder.rs` code path too?
Let me know if you need any changes to be made.