### PR TITLE
Fix cross compilation (add required TLS backend selection)

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -8,10 +8,10 @@
 # The compiled binaries will be located in /tmp/librespot-build
 #
 # If only one architecture is desired, cargo can be invoked directly with the appropriate options :
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features "alsa-backend with-libmdns"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
 
 FROM debian:bookworm
 

--- a/contrib/cross-compile-armv6hf/docker-build.sh
+++ b/contrib/cross-compile-armv6hf/docker-build.sh
@@ -14,4 +14,4 @@ PI1_LIB_DIRS=(
 export RUSTFLAGS="-C linker=$PI1_TOOLS_DIR/bin/arm-linux-gnueabihf-gcc ${PI1_LIB_DIRS[*]/#/-L}"
 export BINDGEN_EXTRA_CLANG_ARGS=--sysroot=$PI1_TOOLS_SYSROOT_DIR
 
-cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns"
+cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"

--- a/contrib/docker-build.sh
+++ b/contrib/docker-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-cargo build --release --no-default-features --features "alsa-backend with-libmdns"
-cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns"
-cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns"
-cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns"
+cargo build --release --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
+cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
+cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
+cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"


### PR DESCRIPTION
After recent changes the TLS back-end must be explicitly selected when `--no-default-features` flag is used.

The provided cross-compilation scripts were not updated accordingly and the cross build failed as described in #1573.

In this PR I propose to cross build with `rustls-tls-native-roots`.

With these changes in place, I have been able to build all available targets. I have verified that the following targets run successfully: `x86_64` (PC), `aarch64` (RPi 3), `armhf` (RPi 3) and `armv6hf` (RPi 1). The `armel` target built OK, but I have not been able to verify it.

The selection of features used in these scripts (audio, mDNS , TLS) depends on the use case, but I think it is better to have at least a single set that is known to work.