### PR TITLE
feat: Basic local file support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [core] Add method `transfer` to `SpClient`
 - [core] Add `SpotifyUri` type to represent more types of URI than `SpotifyId` can
 - [discovery] Add support for [device aliases](https://developer.spotify.com/documentation/commercial-hardware/implementation/guides/zeroconf#device-aliases)
+- [main] `--local-file-dir` / `-l` option added to binary to specify local file directories to pull from
+- [metadata] `Local` variant added to `UniqueFields` enum (breaking)
+- [playback] Local files can now be played with the following caveats:
+  - They must be sampled at 44,100 Hz
+  - They cannot be played from a Connect device using the dedicated 'Local Files' playlist; they must be added to another playlist first
+- [playback] `local_file_directories` field added to `PlayerConfig` struct (breaking)
+  
 
 ### Changed
 
@@ -81,13 +88,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Add `pause` parameter to `Spirc::disconnect` method (breaking)
 - [connect] Add `volume_steps` to `ConnectConfig` (breaking)
 - [connect] Add and enforce rustdoc
-- [connect] Add `audio/local` to the `supported_types` field of the device capabilities.
 - [playback] Add `track` field to `PlayerEvent::RepeatChanged` (breaking)
 - [playback] Add `PlayerEvent::PositionChanged` event to notify about the current playback position
 - [core] Add `request_with_options` and `request_with_protobuf_and_options` to `SpClient`
 - [core] Add `try_get_urls` to `CdnUrl`
 - [oauth] Add `OAuthClient` and `OAuthClientBuilder` structs to achieve a more customizable login process
-
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,11 +81,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Add `pause` parameter to `Spirc::disconnect` method (breaking)
 - [connect] Add `volume_steps` to `ConnectConfig` (breaking)
 - [connect] Add and enforce rustdoc
+- [connect] Add `audio/local` to the `supported_types` field of the device capabilities.
 - [playback] Add `track` field to `PlayerEvent::RepeatChanged` (breaking)
 - [playback] Add `PlayerEvent::PositionChanged` event to notify about the current playback position
 - [core] Add `request_with_options` and `request_with_protobuf_and_options` to `SpClient`
 - [core] Add `try_get_urls` to `CdnUrl`
 - [oauth] Add `OAuthClient` and `OAuthClientBuilder` structs to achieve a more customizable login process
+
 
 ### Fixed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1978,6 +1978,7 @@ version = "0.7.1"
 dependencies = [
  "alsa 0.10.0",
  "cpal",
+ "form_urlencoded",
  "futures-util",
  "gstreamer",
  "gstreamer-app",

--- a/audio/src/fetch/mod.rs
+++ b/audio/src/fetch/mod.rs
@@ -300,6 +300,14 @@ impl StreamLoaderController {
         // terminate stream loading and don't load any more data for this file.
         self.send_stream_loader_command(StreamLoaderCommand::Close);
     }
+
+    pub fn from_local_file(file_size: u64) -> Self {
+        Self {
+            channel_tx: None,
+            stream_shared: None,
+            file_size: file_size as usize,
+        }
+    }
 }
 
 pub struct AudioFileStreaming {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -544,7 +544,13 @@ impl SpircTask {
                 // finish after we received our last item of a type
                 next_context = async {
                     self.context_resolver.get_next_context(|| {
+                        // Sending local file URIs to this endpoint results in a Bad Request status.
+                        // It's likely appropriate to filter them out anyway; Spotify's backend
+                        // has no knowledge about these tracks and so can't do anything with them.
                         self.connect_state.recent_track_uris()
+                            .into_iter()
+                            .filter(|t| !t.starts_with("spotify:local"))
+                            .collect::<Vec<_>>()
                     }).await
                 }, if allow_context_resolving && self.context_resolver.has_next() => {
                     let update_state = self.handle_next_context(next_context);

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -161,7 +161,11 @@ impl ConnectState {
                 supports_gzip_pushes: true,
                 // todo: enable after logout handling is implemented, see spirc logout_request
                 supports_logout: false,
-                supported_types: vec!["audio/episode".into(), "audio/track".into()],
+                supported_types: vec![
+                    "audio/episode".into(),
+                    "audio/track".into(),
+                    "audio/local".into(),
+                ],
                 supports_playlist_v2: true,
                 supports_transfer_command: true,
                 supports_command_request: true,

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -446,7 +446,7 @@ impl ConnectState {
         provider: Option<Provider>,
     ) -> Result<ProvidedTrack, Error> {
         let id = match (ctx_track.uri.as_ref(), ctx_track.gid.as_ref()) {
-            (Some(uri), _) if uri.contains(['?', '%']) => {
+            (Some(uri), _) if uri.contains(['?']) => {
                 Err(StateError::InvalidTrackUri(Some(uri.clone())))?
             }
             (Some(uri), _) if !uri.is_empty() => SpotifyUri::from_uri(uri)?,

--- a/core/src/spotify_uri.rs
+++ b/core/src/spotify_uri.rs
@@ -1,5 +1,5 @@
 use crate::{Error, SpotifyId};
-use std::{borrow::Cow, fmt};
+use std::{borrow::Cow, fmt, str::FromStr, time::Duration};
 use thiserror::Error;
 
 use librespot_protocol as protocol;
@@ -65,7 +65,10 @@ pub enum SpotifyUri {
 impl SpotifyUri {
     /// Returns whether this `SpotifyUri` is for a playable audio item, if known.
     pub fn is_playable(&self) -> bool {
-        matches!(self, SpotifyUri::Episode { .. } | SpotifyUri::Track { .. })
+        matches!(
+            self,
+            SpotifyUri::Episode { .. } | SpotifyUri::Track { .. } | SpotifyUri::Local { .. }
+        )
     }
 
     /// Gets the item type of this URI as a static string
@@ -147,6 +150,7 @@ impl SpotifyUri {
         };
 
         let name = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+
         match item_type {
             SPOTIFY_ITEM_TYPE_ALBUM => Ok(Self::Album {
                 id: SpotifyId::from_base62(name)?,
@@ -167,12 +171,22 @@ impl SpotifyUri {
             SPOTIFY_ITEM_TYPE_TRACK => Ok(Self::Track {
                 id: SpotifyId::from_base62(name)?,
             }),
-            SPOTIFY_ITEM_TYPE_LOCAL => Ok(Self::Local {
-                artist: "unimplemented".to_owned(),
-                album_title: "unimplemented".to_owned(),
-                track_title: "unimplemented".to_owned(),
-                duration: Default::default(),
-            }),
+            SPOTIFY_ITEM_TYPE_LOCAL => {
+                let artist = name;
+                let album_title = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+                let track_title = parts.next().ok_or(SpotifyUriError::InvalidFormat)?;
+                let duration_secs = parts
+                    .next()
+                    .and_then(|f| u64::from_str(f).ok())
+                    .ok_or(SpotifyUriError::InvalidFormat)?;
+
+                Ok(Self::Local {
+                    artist: artist.to_owned(),
+                    album_title: album_title.to_owned(),
+                    track_title: track_title.to_owned(),
+                    duration: Duration::from_secs(duration_secs),
+                })
+            }
             _ => Ok(Self::Unknown {
                 kind: item_type.to_owned().into(),
                 id: name.to_owned(),
@@ -533,15 +547,33 @@ mod tests {
 
     #[test]
     fn from_local_uri() {
-        let actual = SpotifyUri::from_uri("spotify:local:xyz:123").unwrap();
+        let actual = SpotifyUri::from_uri(
+            "spotify:local:David+Wise:Donkey+Kong+Country%3A+Tropical+Freeze:Snomads+Island:127",
+        )
+        .unwrap();
 
         assert_eq!(
             actual,
             SpotifyUri::Local {
-                artist: "unimplemented".to_owned(),
-                album_title: "unimplemented".to_owned(),
-                track_title: "unimplemented".to_owned(),
-                duration: Default::default(),
+                artist: "David+Wise".to_owned(),
+                album_title: "Donkey+Kong+Country%3A+Tropical+Freeze".to_owned(),
+                track_title: "Snomads+Island".to_owned(),
+                duration: Duration::from_secs(127),
+            }
+        );
+    }
+
+    #[test]
+    fn from_local_uri_missing_fields() {
+        let actual = SpotifyUri::from_uri("spotify:local:::Snomads+Island:127").unwrap();
+
+        assert_eq!(
+            actual,
+            SpotifyUri::Local {
+                artist: "".to_owned(),
+                album_title: "".to_owned(),
+                track_title: "Snomads+Island".to_owned(),
+                duration: Duration::from_secs(127),
             }
         );
     }

--- a/metadata/src/audio/file.rs
+++ b/metadata/src/audio/file.rs
@@ -103,6 +103,18 @@ impl AudioFiles {
     pub fn is_flac(format: AudioFileFormat) -> bool {
         matches!(format, AudioFileFormat::FLAC_FLAC)
     }
+
+    pub fn mime_type(format: AudioFileFormat) -> Option<&'static str> {
+        if Self::is_ogg_vorbis(format) {
+            Some("audio/ogg")
+        } else if Self::is_mp3(format) {
+            Some("audio/mpeg")
+        } else if Self::is_flac(format) {
+            Some("audio/flac")
+        } else {
+            None
+        }
+    }
 }
 
 impl From<&[AudioFileMessage]> for AudioFiles {

--- a/metadata/src/audio/item.rs
+++ b/metadata/src/audio/item.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, path::PathBuf};
 
 use crate::{
     Metadata,
@@ -49,6 +49,16 @@ pub enum UniqueFields {
         popularity: u8,
         number: u32,
         disc_number: u32,
+    },
+    Local {
+        // artists / album_artists can't be a Vec here, they are retrieved from metadata as a String,
+        // and we cannot make any assumptions about them being e.g. comma-separated
+        artists: Option<String>,
+        album: Option<String>,
+        album_artists: Option<String>,
+        number: Option<u32>,
+        disc_number: Option<u32>,
+        path: PathBuf,
     },
     Episode {
         description: String,

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -94,3 +94,6 @@ ogg = { version = "0.9", optional = true }
 # Dithering
 rand = { version = "0.9", default-features = false, features = ["small_rng"] }
 rand_distr = "0.5"
+
+# Local file handling
+form_urlencoded = "1.2.2"

--- a/playback/src/config.rs
+++ b/playback/src/config.rs
@@ -1,4 +1,4 @@
-use std::{mem, str::FromStr, time::Duration};
+use std::{mem, path::PathBuf, str::FromStr, time::Duration};
 
 pub use crate::dither::{DithererBuilder, TriangularDitherer, mk_ditherer};
 use crate::{convert::i24, player::duration_to_coefficient};
@@ -116,6 +116,8 @@ pub struct PlayerConfig {
     pub normalisation_release_cf: f64,
     pub normalisation_knee_db: f64,
 
+    pub local_file_directories: Vec<PathBuf>,
+
     // pass function pointers so they can be lazily instantiated *after* spawning a thread
     // (thereby circumventing Send bounds that they might not satisfy)
     pub ditherer: Option<DithererBuilder>,
@@ -140,6 +142,7 @@ impl Default for PlayerConfig {
             passthrough: false,
             ditherer: Some(mk_ditherer::<TriangularDitherer>),
             position_update_interval: None,
+            local_file_directories: Vec::new(),
         }
     }
 }

--- a/playback/src/decoder/symphonia_decoder.rs
+++ b/playback/src/decoder/symphonia_decoder.rs
@@ -146,7 +146,7 @@ impl SymphoniaDecoder {
                         }
                     }
                     Some(StandardTagKey::DiscNumber) => {
-                        metadata.disc_number = match "q".parse::<u32>() {
+                        metadata.disc_number = match value.parse::<u32>() {
                             Ok(value) => Some(value),
                             Err(e) => {
                                 warn!(

--- a/playback/src/decoder/symphonia_decoder.rs
+++ b/playback/src/decoder/symphonia_decoder.rs
@@ -1,36 +1,38 @@
 use std::{io, time::Duration};
 
-use symphonia::{
-    core::{
-        audio::SampleBuffer,
-        codecs::{Decoder, DecoderOptions},
-        errors::Error,
-        formats::{FormatOptions, FormatReader, SeekMode, SeekTo},
-        io::{MediaSource, MediaSourceStream, MediaSourceStreamOptions},
-        meta::{StandardTagKey, Value},
-    },
-    default::{
-        codecs::{FlacDecoder, MpaDecoder, VorbisDecoder},
-        formats::{FlacReader, MpaReader, OggReader},
-    },
+use symphonia::core::{
+    audio::SampleBuffer,
+    codecs::{Decoder, DecoderOptions},
+    errors::Error,
+    formats::{FormatOptions, SeekMode, SeekTo},
+    io::{MediaSource, MediaSourceStream, MediaSourceStreamOptions},
+    meta::{MetadataOptions, StandardTagKey, Value},
+    probe::{Hint, ProbeResult},
 };
 
 use super::{AudioDecoder, AudioPacket, AudioPacketPosition, DecoderError, DecoderResult};
 
-use crate::{
-    NUM_CHANNELS, PAGES_PER_MS, SAMPLE_RATE,
-    metadata::audio::{AudioFileFormat, AudioFiles},
-    player::NormalisationData,
-};
+use crate::{NUM_CHANNELS, PAGES_PER_MS, SAMPLE_RATE, player::NormalisationData, symphonia_util};
 
 pub struct SymphoniaDecoder {
-    format: Box<dyn FormatReader>,
+    probe_result: ProbeResult,
     decoder: Box<dyn Decoder>,
     sample_buffer: Option<SampleBuffer<f64>>,
 }
 
+#[derive(Default)]
+pub(crate) struct LocalFileMetadata {
+    pub name: Option<String>,
+    pub language: Option<String>,
+    pub album: Option<String>,
+    pub artists: Option<String>,
+    pub album_artists: Option<String>,
+    pub number: Option<u32>,
+    pub disc_number: Option<u32>,
+}
+
 impl SymphoniaDecoder {
-    pub fn new<R>(input: R, file_format: AudioFileFormat) -> DecoderResult<Self>
+    pub fn new<R>(input: R, hint: Hint) -> DecoderResult<Self>
     where
         R: MediaSource + 'static,
     {
@@ -43,39 +45,29 @@ impl SymphoniaDecoder {
             enable_gapless: true,
             ..Default::default()
         };
+        let metadata_opts: MetadataOptions = Default::default();
 
-        let format: Box<dyn FormatReader> = if AudioFiles::is_ogg_vorbis(file_format) {
-            Box::new(OggReader::try_new(mss, &format_opts)?)
-        } else if AudioFiles::is_mp3(file_format) {
-            Box::new(MpaReader::try_new(mss, &format_opts)?)
-        } else if AudioFiles::is_flac(file_format) {
-            Box::new(FlacReader::try_new(mss, &format_opts)?)
-        } else {
-            return Err(DecoderError::SymphoniaDecoder(format!(
-                "Unsupported format: {file_format:?}"
-            )));
-        };
+        let probe_result =
+            symphonia::default::get_probe().format(&hint, mss, &format_opts, &metadata_opts)?;
+
+        let format = &probe_result.format;
 
         let track = format.default_track().ok_or_else(|| {
             DecoderError::SymphoniaDecoder("Could not retrieve default track".into())
         })?;
 
         let decoder_opts: DecoderOptions = Default::default();
-        let decoder: Box<dyn Decoder> = if AudioFiles::is_ogg_vorbis(file_format) {
-            Box::new(VorbisDecoder::try_new(&track.codec_params, &decoder_opts)?)
-        } else if AudioFiles::is_mp3(file_format) {
-            Box::new(MpaDecoder::try_new(&track.codec_params, &decoder_opts)?)
-        } else if AudioFiles::is_flac(file_format) {
-            Box::new(FlacDecoder::try_new(&track.codec_params, &decoder_opts)?)
-        } else {
-            return Err(DecoderError::SymphoniaDecoder(format!(
-                "Unsupported decoder: {file_format:?}"
-            )));
-        };
+
+        let decoder = symphonia::default::get_codecs().make(&track.codec_params, &decoder_opts)?;
 
         let rate = decoder.codec_params().sample_rate.ok_or_else(|| {
             DecoderError::SymphoniaDecoder("Could not retrieve sample rate".into())
         })?;
+
+        // TODO: The official client supports local files with sample rates other than 44,100 kHz.
+        // To play these accurately, we need to either resample the input audio, or introduce a way
+        // to change the player's current sample rate (likely by closing and re-opening the sink
+        // with new parameters).
         if rate != SAMPLE_RATE {
             return Err(DecoderError::SymphoniaDecoder(format!(
                 "Unsupported sample rate: {rate}"
@@ -92,9 +84,8 @@ impl SymphoniaDecoder {
         }
 
         Ok(Self {
-            format,
+            probe_result,
             decoder,
-
             // We set the sample buffer when decoding the first full packet,
             // whose duration is also the ideal sample buffer size.
             sample_buffer: None,
@@ -102,16 +93,7 @@ impl SymphoniaDecoder {
     }
 
     pub fn normalisation_data(&mut self) -> Option<NormalisationData> {
-        let mut metadata = self.format.metadata();
-
-        // Advance to the latest metadata revision.
-        // None means we hit the latest.
-        loop {
-            if metadata.pop().is_none() {
-                break;
-            }
-        }
-
+        let metadata = symphonia_util::get_latest_metadata(&mut self.probe_result)?;
         let tags = metadata.current()?.tags();
 
         if tags.is_empty() {
@@ -133,6 +115,65 @@ impl SymphoniaDecoder {
 
             Some(data)
         }
+    }
+
+    pub(crate) fn local_file_metadata(&mut self) -> Option<LocalFileMetadata> {
+        let metadata = symphonia_util::get_latest_metadata(&mut self.probe_result)?;
+        let tags = metadata.current()?.tags();
+        let mut metadata = LocalFileMetadata::default();
+
+        for tag in tags {
+            if let Value::String(value) = &tag.value {
+                match tag.std_key {
+                    // We could possibly use mem::take here to avoid cloning, but that risks leaving
+                    // the audio item metadata in a bad state.
+                    Some(StandardTagKey::TrackTitle) => metadata.name = Some(value.clone()),
+                    Some(StandardTagKey::Language) => metadata.language = Some(value.clone()),
+                    Some(StandardTagKey::Artist) => metadata.artists = Some(value.clone()),
+                    Some(StandardTagKey::AlbumArtist) => {
+                        metadata.album_artists = Some(value.clone())
+                    }
+                    Some(StandardTagKey::Album) => metadata.album = Some(value.clone()),
+                    Some(StandardTagKey::TrackNumber) => {
+                        metadata.number = match value.parse::<u32>() {
+                            Ok(value) => Some(value),
+                            Err(e) => {
+                                warn!(
+                                    "Failed to parse local file's track number tag '{value}': {e}"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    Some(StandardTagKey::DiscNumber) => {
+                        metadata.disc_number = match "q".parse::<u32>() {
+                            Ok(value) => Some(value),
+                            Err(e) => {
+                                warn!(
+                                    "Failed to parse local file's disc number tag '{value}': {e}"
+                                );
+                                None
+                            }
+                        }
+                    }
+                    _ => (),
+                }
+            } else if let Value::UnsignedInt(value) = &tag.value {
+                match tag.std_key {
+                    Some(StandardTagKey::TrackNumber) => metadata.number = Some(*value as u32),
+                    Some(StandardTagKey::DiscNumber) => metadata.disc_number = Some(*value as u32),
+                    _ => (),
+                }
+            } else if let Value::SignedInt(value) = &tag.value {
+                match tag.std_key {
+                    Some(StandardTagKey::TrackNumber) => metadata.number = Some(*value as u32),
+                    Some(StandardTagKey::DiscNumber) => metadata.disc_number = Some(*value as u32),
+                    _ => (),
+                }
+            }
+        }
+
+        Some(metadata)
     }
 
     #[inline]
@@ -161,7 +202,7 @@ impl AudioDecoder for SymphoniaDecoder {
         }
 
         // `track_id: None` implies the default track ID (of the container, not of Spotify).
-        let seeked_to_ts = self.format.seek(
+        let seeked_to_ts = self.probe_result.format.seek(
             SeekMode::Accurate,
             SeekTo::Time {
                 time: target.into(),
@@ -180,7 +221,7 @@ impl AudioDecoder for SymphoniaDecoder {
         let mut skipped = false;
 
         loop {
-            let packet = match self.format.next_packet() {
+            let packet = match self.probe_result.format.next_packet() {
                 Ok(packet) => packet,
                 Err(Error::IoError(err)) => {
                     if err.kind() == io::ErrorKind::UnexpectedEof {

--- a/playback/src/lib.rs
+++ b/playback/src/lib.rs
@@ -10,8 +10,10 @@ pub mod config;
 pub mod convert;
 pub mod decoder;
 pub mod dither;
+mod local_file;
 pub mod mixer;
 pub mod player;
+mod symphonia_util;
 
 pub const SAMPLE_RATE: u32 = 44100;
 pub const NUM_CHANNELS: u8 = 2;

--- a/playback/src/local_file.rs
+++ b/playback/src/local_file.rs
@@ -1,0 +1,167 @@
+use crate::symphonia_util;
+use librespot_core::{Error, SpotifyUri};
+use std::{
+    collections::HashMap,
+    fs,
+    fs::File,
+    io,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use symphonia::core::{
+    formats::FormatOptions,
+    io::MediaSourceStream,
+    meta::{MetadataOptions, StandardTagKey, Tag},
+    probe::{Hint, ProbeResult},
+};
+
+// "Spotify supports .mp3, .mp4, and .m4p files. It doesn’t support .mp4 files that contain video,
+// or the iTunes lossless format (M4A)."
+// https://community.spotify.com/t5/FAQs/Local-Files/ta-p/5186118
+//
+// There are some indications online that FLAC is supported, so check for this as well.
+const SUPPORTED_FILE_EXTENSIONS: &[&str; 4] = &["mp3", "mp4", "m4p", "flac"];
+
+#[derive(Default)]
+pub struct LocalFileLookup(HashMap<SpotifyUri, PathBuf>);
+
+impl LocalFileLookup {
+    pub fn get(&self, uri: &SpotifyUri) -> Option<&Path> {
+        self.0.get(uri).map(|p| p.as_path())
+    }
+}
+
+pub fn create_local_file_lookup(directories: &[PathBuf]) -> LocalFileLookup {
+    let mut lookup = LocalFileLookup(HashMap::new());
+
+    for path in directories {
+        if !path.is_dir() {
+            warn!(
+                "Ignoring local file source {}: not a directory",
+                path.display()
+            );
+            continue;
+        }
+
+        if let Err(e) = visit_dir(path, &mut lookup) {
+            warn!(
+                "Failed to load entries from local file source {}: {}",
+                path.display(),
+                e
+            );
+        }
+    }
+
+    lookup
+}
+
+fn visit_dir(dir: &Path, accumulator: &mut LocalFileLookup) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let path = entry?.path();
+        if path.is_dir() {
+            visit_dir(&path, accumulator)?;
+        } else {
+            let Some(file_extension) = path.extension().and_then(|e| e.to_str()) else {
+                continue;
+            };
+
+            let lowercase_extension = file_extension.to_lowercase();
+
+            if SUPPORTED_FILE_EXTENSIONS.contains(&lowercase_extension.as_str()) {
+                let uri = match get_uri_from_file(path.as_path(), file_extension) {
+                    Ok(uri) => uri,
+                    Err(e) => {
+                        warn!(
+                            "Failed to determine URI of local file {}: {}",
+                            path.display(),
+                            e
+                        );
+                        continue;
+                    }
+                };
+
+                accumulator.0.insert(uri, path);
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn get_uri_from_file(audio_path: &Path, file_extension: &str) -> Result<SpotifyUri, Error> {
+    let src = File::open(audio_path)?;
+    let mss = MediaSourceStream::new(Box::new(src), Default::default());
+
+    let mut hint = Hint::new();
+    hint.with_extension(file_extension);
+
+    let meta_opts: MetadataOptions = Default::default();
+    let fmt_opts: FormatOptions = Default::default();
+
+    let mut probed = symphonia::default::get_probe()
+        .format(&hint, mss, &fmt_opts, &meta_opts)
+        .map_err(|_| Error::internal("Failed to probe file"))?;
+
+    let mut artist: Option<String> = None;
+    let mut album_title: Option<String> = None;
+    let mut track_title: Option<String> = None;
+
+    fn get_tags(probed: &mut ProbeResult) -> Option<Vec<Tag>> {
+        let metadata = symphonia_util::get_latest_metadata(probed)?;
+        let metadata_rev = metadata.current()?;
+        Some(metadata_rev.tags().to_vec())
+    }
+
+    for tag in get_tags(&mut probed).ok_or(Error::internal("Failed to probe audio tags"))? {
+        if let Some(std_key) = tag.std_key {
+            match std_key {
+                StandardTagKey::Album => {
+                    album_title.replace(tag.value.to_string());
+                }
+                StandardTagKey::Artist => {
+                    artist.replace(tag.value.to_string());
+                }
+                StandardTagKey::TrackTitle => {
+                    track_title.replace(tag.value.to_string());
+                }
+                _ => {
+                    continue;
+                }
+            }
+        }
+    }
+
+    let first_track = probed
+        .format
+        .default_track()
+        .ok_or(Error::internal("Failed to find an audio track"))?;
+
+    let time_base = first_track
+        .codec_params
+        .time_base
+        .ok_or(Error::internal("Failed to calculate track duration"))?;
+
+    let num_frames = first_track
+        .codec_params
+        .n_frames
+        .ok_or(Error::internal("Failed to calculate track duration"))?;
+
+    let time = time_base.calc_time(num_frames);
+
+    fn format_uri_part(input: Option<String>) -> String {
+        input
+            .map(|s| {
+                let bytes = s.into_bytes();
+                let encoded = form_urlencoded::byte_serialize(bytes.as_slice());
+                encoded.collect::<String>()
+            })
+            .unwrap_or("".to_owned())
+    }
+
+    Ok(SpotifyUri::Local {
+        artist: format_uri_part(artist),
+        album_title: format_uri_part(album_title),
+        track_title: format_uri_part(track_title),
+        duration: Duration::from_secs(time.seconds),
+    })
+}

--- a/playback/src/symphonia_util.rs
+++ b/playback/src/symphonia_util.rs
@@ -1,0 +1,18 @@
+use symphonia::core::meta::Metadata;
+use symphonia::core::probe::ProbeResult;
+
+pub fn get_latest_metadata(probe_result: &mut ProbeResult) -> Option<Metadata<'_>> {
+    let mut metadata = probe_result.format.metadata();
+
+    // If we can't get metadata from the container, fall back to other tags found by probing.
+    // Note that this is only relevant for local files.
+    if metadata.current().is_none() {
+        if let Some(inner_probe_metadata) = probe_result.metadata.get() {
+            metadata = inner_probe_metadata;
+        }
+    }
+
+    _ = metadata.skip_to_latest();
+
+    Some(metadata)
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -283,6 +283,7 @@ async fn get_setup() -> Setup {
     const ZEROCONF_PORT: &str = "zeroconf-port";
     const ZEROCONF_INTERFACE: &str = "zeroconf-interface";
     const ZEROCONF_BACKEND: &str = "zeroconf-backend";
+    const LOCAL_FILE_DIR: &str = "local-file-dir";
 
     // Mostly arbitrary.
     const AP_PORT_SHORT: &str = "a";
@@ -335,6 +336,7 @@ async fn get_setup() -> Setup {
     const NORMALISATION_THRESHOLD_SHORT: &str = "Z";
     const ZEROCONF_PORT_SHORT: &str = "z";
     const ZEROCONF_BACKEND_SHORT: &str = ""; // no short flag
+    const LOCAL_FILE_DIR_SHORT: &str = "l";
 
     // Options that have different descriptions
     // depending on what backends were enabled at build time.
@@ -660,6 +662,11 @@ async fn get_setup() -> Setup {
         ZEROCONF_BACKEND,
         "Zeroconf (MDNS/DNS-SD) backend to use. Valid values are 'avahi', 'dns-sd' and 'libmdns', if librespot is compiled with the corresponding feature flags.",
         "BACKEND"
+    ).optmulti(
+        LOCAL_FILE_DIR_SHORT,
+        LOCAL_FILE_DIR,
+        "Directory to search for local file playback. Can be specified multiple times to add multiple search directories",
+        "DIRECTORY"
     );
 
     #[cfg(feature = "passthrough-decoder")]
@@ -1380,6 +1387,12 @@ async fn get_setup() -> Setup {
         })
     });
 
+    let local_file_directories = matches
+        .opt_strs(LOCAL_FILE_DIR)
+        .into_iter()
+        .map(PathBuf::from)
+        .collect::<Vec<_>>();
+
     let connect_config = {
         let connect_default_config = ConnectConfig::default();
 
@@ -1819,6 +1832,7 @@ async fn get_setup() -> Setup {
             normalisation_knee_db,
             ditherer,
             position_update_interval: None,
+            local_file_directories,
         }
     };
 

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -87,6 +87,41 @@ impl EventHandler {
                                                 env_vars
                                                     .insert("DISC_NUMBER", disc_number.to_string());
                                             }
+                                            UniqueFields::Local {
+                                                artists,
+                                                album,
+                                                album_artists,
+                                                number,
+                                                disc_number,
+                                                path,
+                                            } => {
+                                                env_vars.insert("ITEM_TYPE", "Track".to_string());
+                                                env_vars
+                                                    .insert("ARTISTS", artists.unwrap_or_default());
+                                                env_vars.insert(
+                                                    "ALBUM_ARTISTS",
+                                                    album_artists.unwrap_or_default(),
+                                                );
+                                                env_vars.insert("ALBUM", album.unwrap_or_default());
+                                                env_vars.insert(
+                                                    "NUMBER",
+                                                    number
+                                                        .map(|n: u32| n.to_string())
+                                                        .unwrap_or_default(),
+                                                );
+                                                env_vars.insert(
+                                                    "DISC_NUMBER",
+                                                    disc_number
+                                                        .map(|n: u32| n.to_string())
+                                                        .unwrap_or_default(),
+                                                );
+                                                env_vars.insert(
+                                                    "LOCAL_FILE_PATH",
+                                                    path.into_os_string()
+                                                        .into_string()
+                                                        .unwrap_or_default(),
+                                                );
+                                            }
                                             UniqueFields::Episode {
                                                 description,
                                                 publish_time,


### PR DESCRIPTION
Discussed in #1525. Adds a basic level of support for playing back local files from a connect device. The `librespot` binary must be launched with `--local-file-dir` / `-l` flags specifying search paths for local files. If a request is received to play a local file, and a file match is made based on the file's artist, album, track title, and duration, then `librespot` will now be able to play it.

This support has the following caveats:

- Unlike the official client, we cannot play local files if they have a sample rate != 44,100 Hz. This is the sample rate used by the player - without adjusting it, playback of local files with differing sample rates will sound either slowed or sped up. Adjusting the sample rate of the player on the fly is a non-trivial task which may be implemented later.
- The dedicated 'Local Files' playlist cannot be used to play a local file. This is a special playlist with a URI of `spotify:local-files` which currently causes an error in the context handling code, as `librespot` attempts to fetch it from the API and appears to get a 404. I tried to make this work, but it feels like an abstraction for context would be beneficial so we could generate context from the filesystem (currently I think we use the proto models which are obviously tightly coupled to the Spotify API). Also, I do not understand enough about the context handling code to do a good job :sweat_smile: 