### PR TITLE
Add MPRIS support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [connect] Add method `add_to_queue` to `Spirc` to add tracks, episodes, albums and playlists to the queue
 - [playback] Add `SetQueue` player event, emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect). Gated behind `ConnectConfig::emit_set_queue_events`
+- [dbus/mpris] Add dbus/mpris support to allow controlling player (breaking)
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,6 +152,65 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.2",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.2",
+]
+
+[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -161,6 +220,30 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-signal"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.2",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -222,6 +305,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -434,9 +530,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -861,9 +957,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
@@ -1181,6 +1277,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,9 +1365,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
+checksum = "1744436df46f0bde35af3eda22aeaba453aada65d8f1c171cd8a5f59030bd69f"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1815,8 +1917,11 @@ dependencies = [
  "sha1",
  "sysinfo",
  "thiserror 2.0.17",
+ "time",
  "tokio",
  "url",
+ "zbus 4.4.0",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -1940,7 +2045,7 @@ dependencies = [
  "sha1",
  "thiserror 2.0.17",
  "tokio",
- "zbus",
+ "zbus 5.12.0",
 ]
 
 [[package]]
@@ -2159,6 +2264,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
 ]
 
 [[package]]
@@ -2580,6 +2698,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "piper"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2605,6 +2734,20 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.2",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "portable-atomic"
@@ -2759,9 +2902,9 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.38.3"
+version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42a232e7487fc2ef313d96dde7948e7a3c05101870d8985e4fd8d26aedd27b89"
+checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
 dependencies = [
  "memchr",
  "serde",
@@ -3015,9 +3158,9 @@ dependencies = [
 
 [[package]]
 name = "rsa"
-version = "0.9.8"
+version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78928ac1ed176a5ca1d17e578a1825f3d81ca54cf41053a592584b020cfd691b"
+checksum = "40a0376c50d0358279d9d643e4bf7b7be212f1f4ff1da9070a7b54d22ef75c88"
 dependencies = [
  "const-oid",
  "digest",
@@ -3578,9 +3721,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.109"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f17c7e013e88258aa9543dcbe81aca68a667a9ac37cd69c9fbc07858bfe0e2f"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4790,6 +4933,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
+name = "xdg-home"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4814,6 +4967,39 @@ dependencies = [
 
 [[package]]
 name = "zbus"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
+dependencies = [
+ "async-broadcast",
+ "async-process",
+ "async-recursion",
+ "async-trait",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "nix 0.29.0",
+ "ordered-stream",
+ "rand 0.8.5",
+ "serde",
+ "serde_repr",
+ "sha1",
+ "static_assertions",
+ "tokio",
+ "tracing",
+ "uds_windows",
+ "windows-sys 0.52.0",
+ "xdg-home",
+ "zbus_macros 4.4.0",
+ "zbus_names 3.0.0",
+ "zvariant 4.2.0",
+]
+
+[[package]]
+name = "zbus"
 version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
@@ -4826,7 +5012,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix",
+ "nix 0.30.1",
  "ordered-stream",
  "serde",
  "serde_repr",
@@ -4836,9 +5022,22 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow",
- "zbus_macros",
- "zbus_names",
- "zvariant",
+ "zbus_macros 5.12.0",
+ "zbus_names 4.2.0",
+ "zvariant 5.8.0",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -4851,9 +5050,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
+ "zbus_names 4.2.0",
+ "zvariant 5.8.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zbus_names"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
+dependencies = [
+ "serde",
+ "static_assertions",
+ "zvariant 4.2.0",
 ]
 
 [[package]]
@@ -4865,7 +5075,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "winnow",
- "zvariant",
+ "zvariant 5.8.0",
 ]
 
 [[package]]
@@ -4950,6 +5160,19 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "static_assertions",
+ "zvariant_derive 4.2.0",
+]
+
+[[package]]
+name = "zvariant"
 version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
@@ -4958,8 +5181,21 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow",
- "zvariant_derive",
- "zvariant_utils",
+ "zvariant_derive 5.8.0",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils 2.1.0",
 ]
 
 [[package]]
@@ -4972,7 +5208,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zvariant_utils",
+ "zvariant_utils 3.2.1",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -152,65 +152,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix 1.1.2",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd03604047cee9b6ce9de9f70c6cd540a0520c813cbd49bae61f33ab80ed1dc"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix 1.1.2",
-]
-
-[[package]]
 name = "async-recursion"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -220,30 +161,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "async-signal"
-version = "0.2.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix 1.1.2",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -305,19 +222,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -1277,12 +1181,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1467,9 +1365,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.17"
+version = "0.1.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c6995591a8f1380fcb4ba966a252a4b29188d51d2b89e3a252f5305be65aea8"
+checksum = "52e9a2a24dc5c6821e71a7030e1e14b7b632acac55c40e9d2e082c621261bb56"
 dependencies = [
  "base64",
  "bytes",
@@ -1920,8 +1818,8 @@ dependencies = [
  "time",
  "tokio",
  "url",
- "zbus 4.4.0",
- "zvariant 4.2.0",
+ "zbus",
+ "zvariant",
 ]
 
 [[package]]
@@ -2045,7 +1943,7 @@ dependencies = [
  "sha1",
  "thiserror 2.0.17",
  "tokio",
- "zbus 5.12.0",
+ "zbus",
 ]
 
 [[package]]
@@ -2264,19 +2162,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags 2.10.0",
- "cfg-if",
- "cfg_aliases",
- "libc",
- "memoffset",
 ]
 
 [[package]]
@@ -2698,17 +2583,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkcs1"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2734,20 +2608,6 @@ name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix 1.1.2",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "portable-atomic"
@@ -4617,13 +4477,13 @@ dependencies = [
 
 [[package]]
 name = "windows-registry"
-version = "0.5.3"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b8a9ed28765efc97bbc954883f4e6796c33a06546ebafacbabee9696967499e"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-link 0.2.1",
+ "windows-result 0.4.1",
+ "windows-strings 0.5.1",
 ]
 
 [[package]]
@@ -4933,16 +4793,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
-name = "xdg-home"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec1cdab258fb55c0da61328dc52c8764709b249011b2cad0454c72f0bf10a1f6"
-dependencies = [
- "libc",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "yoke"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4967,39 +4817,6 @@ dependencies = [
 
 [[package]]
 name = "zbus"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb97012beadd29e654708a0fdb4c84bc046f537aecfde2c3ee0a9e4b4d48c725"
-dependencies = [
- "async-broadcast",
- "async-process",
- "async-recursion",
- "async-trait",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-sink",
- "futures-util",
- "hex",
- "nix 0.29.0",
- "ordered-stream",
- "rand 0.8.5",
- "serde",
- "serde_repr",
- "sha1",
- "static_assertions",
- "tokio",
- "tracing",
- "uds_windows",
- "windows-sys 0.52.0",
- "xdg-home",
- "zbus_macros 4.4.0",
- "zbus_names 3.0.0",
- "zvariant 4.2.0",
-]
-
-[[package]]
-name = "zbus"
 version = "5.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b622b18155f7a93d1cd2dc8c01d2d6a44e08fb9ebb7b3f9e6ed101488bad6c91"
@@ -5012,7 +4829,7 @@ dependencies = [
  "futures-core",
  "futures-lite",
  "hex",
- "nix 0.30.1",
+ "nix",
  "ordered-stream",
  "serde",
  "serde_repr",
@@ -5022,22 +4839,9 @@ dependencies = [
  "uuid",
  "windows-sys 0.61.2",
  "winnow",
- "zbus_macros 5.12.0",
- "zbus_names 4.2.0",
- "zvariant 5.8.0",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "4.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "267db9407081e90bbfa46d841d3cbc60f59c0351838c4bc65199ecd79ab1983e"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils 2.1.0",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
 ]
 
 [[package]]
@@ -5050,20 +4854,9 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zbus_names 4.2.0",
- "zvariant 5.8.0",
- "zvariant_utils 3.2.1",
-]
-
-[[package]]
-name = "zbus_names"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b9b1fef7d021261cc16cba64c351d291b715febe0fa10dc3a443ac5a5022e6c"
-dependencies = [
- "serde",
- "static_assertions",
- "zvariant 4.2.0",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -5075,7 +4868,7 @@ dependencies = [
  "serde",
  "static_assertions",
  "winnow",
- "zvariant 5.8.0",
+ "zvariant",
 ]
 
 [[package]]
@@ -5160,19 +4953,6 @@ dependencies = [
 
 [[package]]
 name = "zvariant"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2084290ab9a1c471c38fc524945837734fbf124487e105daec2bb57fd48c81fe"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "static_assertions",
- "zvariant_derive 4.2.0",
-]
-
-[[package]]
-name = "zvariant"
 version = "5.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2be61892e4f2b1772727be11630a62664a1826b62efa43a6fe7449521cb8744c"
@@ -5181,21 +4961,8 @@ dependencies = [
  "enumflags2",
  "serde",
  "winnow",
- "zvariant_derive 5.8.0",
- "zvariant_utils 3.2.1",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "4.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73e2ba546bda683a90652bac4a279bc146adad1386f25379cf73200d2002c449"
-dependencies = [
- "proc-macro-crate",
- "proc-macro2",
- "quote",
- "syn",
- "zvariant_utils 2.1.0",
+ "zvariant_derive",
+ "zvariant_utils",
 ]
 
 [[package]]
@@ -5208,18 +4975,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
- "zvariant_utils 3.2.1",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "2.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c51bcff7cc3dbb5055396bcf774748c3dab426b4b8659046963523cee4808340"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "zvariant_utils",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ passthrough-decoder = ["librespot-playback/passthrough-decoder"]
 
 # MPRIS: Allow external tool to have access to playback
 # status, metadata and to control the player.
-with-mpris = ["dep:zbus", "dep:zvariant"]
+with-mpris = ["dep:zbus", "dep:zvariant", "dep:time"]
 
 [lib]
 name = "librespot"
@@ -184,7 +184,7 @@ tokio = { version = "1", features = [
     "sync",
     "process",
 ] }
-time = { version = "0.3", features = ["formatting"] }
+time = { version = "0.3", features = ["formatting"], optional = true }
 url = "2.2"
 zbus = { version = "5", default-features = false, features = ["tokio"], optional = true }
 zvariant = { version = "5", default-features = false, optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ repository = "https://github.com/librespot-org/librespot"
 edition = "2024"
 
 [features]
-default = ["native-tls", "rodio-backend", "with-libmdns"]
+default = ["native-tls", "rodio-backend", "with-libmdns", "with-mpris"]
 
 # TLS backends (mutually exclusive - compile-time checks in oauth/src/lib.rs)
 # Note: Feature validation is in oauth crate since it's compiled first in the dependency tree.
@@ -132,6 +132,10 @@ with-dns-sd = ["librespot-discovery/with-dns-sd"]
 # data.
 passthrough-decoder = ["librespot-playback/passthrough-decoder"]
 
+# MPRIS: Allow external tool to have access to playback
+# status, metadata and to control the player.
+with-mpris = ["dep:zbus", "dep:zvariant"]
+
 [lib]
 name = "librespot"
 path = "src/lib.rs"
@@ -180,7 +184,10 @@ tokio = { version = "1", features = [
     "sync",
     "process",
 ] }
+time = { version = "0.3", features = ["formatting"] }
 url = "2.2"
+zbus = { version = "4", default-features = false, features = ["tokio"], optional = true }
+zvariant = { version = "4", default-features = false, optional = true }
 
 [package.metadata.deb]
 maintainer = "Librespot Organization <noreply@github.com>"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -186,8 +186,8 @@ tokio = { version = "1", features = [
 ] }
 time = { version = "0.3", features = ["formatting"] }
 url = "2.2"
-zbus = { version = "4", default-features = false, features = ["tokio"], optional = true }
-zvariant = { version = "4", default-features = false, optional = true }
+zbus = { version = "5", default-features = false, features = ["tokio"], optional = true }
+zvariant = { version = "5", default-features = false, optional = true }
 
 [package.metadata.deb]
 maintainer = "Librespot Organization <noreply@github.com>"

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -131,6 +131,7 @@ enum SpircCommand {
     RepeatTrack(bool),
     Disconnect { pause: bool },
     SetPosition(u32),
+    SeekOffset(i32),
     SetVolume(u16),
     Activate,
     Transfer(Option<TransferRequest>),
@@ -394,6 +395,13 @@ impl Spirc {
     /// Does not overwrite the queue.
     pub fn load(&self, command: LoadRequest) -> Result<(), Error> {
         Ok(self.commands.send(SpircCommand::Load(command))?)
+    }
+
+    /// Seek to given offset.
+    ///
+    /// Does nothing if we are not the active device.
+    pub fn seek_offset(&self, offset_ms: i32) -> Result<(), Error> {
+        Ok(self.commands.send(SpircCommand::SeekOffset(offset_ms))?)
     }
 
     /// Adds a track, episode, album or playlist to the queue.
@@ -745,6 +753,7 @@ impl SpircTask {
             SpircCommand::Repeat(repeat) => self.handle_repeat_context(repeat)?,
             SpircCommand::RepeatTrack(repeat) => self.handle_repeat_track(repeat),
             SpircCommand::SetPosition(position) => self.handle_seek(position),
+            SpircCommand::SeekOffset(offset) => self.handle_seek_offset(offset),
             SpircCommand::SetVolume(volume) => self.set_volume(volume),
             SpircCommand::Load(command) => self.handle_load(command, None, None).await?,
             SpircCommand::AddToQueue(uri) => self.handle_add_to_queue(uri).await,
@@ -1603,6 +1612,25 @@ impl SpircTask {
                 ..
             } => *nominal_start_time = now - position_ms as i64,
         };
+    }
+
+    fn handle_seek_offset(&mut self, offset_ms: i32) {
+        let position_ms = match self.play_status {
+            SpircPlayStatus::Stopped => return,
+            SpircPlayStatus::LoadingPause { position_ms }
+            | SpircPlayStatus::LoadingPlay { position_ms }
+            | SpircPlayStatus::Paused { position_ms, .. } => position_ms,
+            SpircPlayStatus::Playing {
+                nominal_start_time, ..
+            } => {
+                let now = self.now_ms();
+                (now - nominal_start_time) as u32
+            }
+        };
+
+        let position_ms = ((position_ms as i32) + offset_ms).max(0) as u32;
+
+        self.handle_seek(position_ms);
     }
 
     fn handle_shuffle(&mut self, shuffle: bool) -> Result<(), Error> {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -146,6 +146,7 @@ const VOLUME_UPDATE_DELAY: Duration = Duration::from_millis(500);
 const UPDATE_STATE_DELAY: Duration = Duration::from_millis(200);
 
 /// The spotify connect handle
+#[derive(Clone)]
 pub struct Spirc {
     commands: mpsc::UnboundedSender<SpircCommand>,
 }

--- a/metadata/src/audio/item.rs
+++ b/metadata/src/audio/item.rs
@@ -45,6 +45,7 @@ pub enum UniqueFields {
     Track {
         artists: ArtistsWithRole,
         album: String,
+        album_date: Date,
         album_artists: Vec<String>,
         popularity: u8,
         number: u32,
@@ -90,6 +91,8 @@ impl AudioItem {
                 let uri_string = uri.to_uri();
                 let album = track.album.name;
 
+                let album_date = track.album.date;
+
                 let album_artists = track
                     .album
                     .artists
@@ -123,6 +126,7 @@ impl AudioItem {
                 let unique_fields = UniqueFields::Track {
                     artists: track.artists_with_role,
                     album,
+                    album_date,
                     album_artists,
                     popularity,
                     number,

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -729,6 +729,7 @@ enum PlayerState {
         play_request_id: u64,
         start_playback: bool,
         loader: Pin<Box<dyn FusedFuture<Output = Result<PlayerLoadedTrackData, ()>> + Send>>,
+        position_ms: u32,
     },
     Paused {
         track_id: SpotifyUri,
@@ -1382,6 +1383,7 @@ impl Future for PlayerInternal {
                 ref track_id,
                 start_playback,
                 play_request_id,
+                ..
             } = self.state
             {
                 // The loader may be terminated if we are trying to load the same track
@@ -2176,6 +2178,7 @@ impl PlayerInternal {
             play_request_id,
             start_playback: play,
             loader,
+            position_ms,
         };
 
         Ok(())
@@ -2325,12 +2328,13 @@ impl PlayerInternal {
                     PlayerState::Loading {
                         ref track_id,
                         play_request_id,
+                        position_ms,
                         ..
                     } => {
                         let _ = sender.send(PlayerEvent::Loading {
                             play_request_id,
                             track_id: track_id.clone(),
-                            position_ms: 0, // TODO
+                            position_ms,
                         });
                     }
                     PlayerState::Paused {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -2318,7 +2318,51 @@ impl PlayerInternal {
 
             PlayerCommand::SetSession(session) => self.session = session,
 
-            PlayerCommand::AddEventSender(sender) => self.event_senders.push(sender),
+            PlayerCommand::AddEventSender(sender) => {
+                // Send current player state to new event listener
+                match self.state {
+                    PlayerState::Loading {
+                        ref track_id,
+                        play_request_id,
+                        ..
+                    } => {
+                        let _ = sender.send(PlayerEvent::Loading {
+                            play_request_id,
+                            track_id: track_id.clone(),
+                            position_ms: 0, // TODO
+                        });
+                    }
+                    PlayerState::Paused {
+                        ref track_id,
+                        play_request_id,
+                        stream_position_ms,
+                        ..
+                    } => {
+                        let _ = sender.send(PlayerEvent::Paused {
+                            play_request_id,
+                            track_id: track_id.clone(),
+                            position_ms: stream_position_ms,
+                        });
+                    }
+                    PlayerState::Playing { ref audio_item, .. } => {
+                        let audio_item = Box::new(audio_item.clone());
+                        let _ = sender.send(PlayerEvent::TrackChanged { audio_item });
+                    }
+                    PlayerState::EndOfTrack {
+                        play_request_id,
+                        ref track_id,
+                        ..
+                    } => {
+                        let _ = sender.send(PlayerEvent::EndOfTrack {
+                            play_request_id,
+                            track_id: track_id.clone(),
+                        });
+                    }
+                    _ => (),
+                }
+
+                self.event_senders.push(sender);
+            }
 
             PlayerCommand::SetSinkEventCallback(callback) => self.sink_event_callback = callback,
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -161,8 +161,8 @@ pub enum PlayerEvent {
     },
     // Fired when the player is stopped (e.g. by issuing a "stop" command to the player).
     Stopped {
-        play_request_id: u64,
-        track_id: SpotifyUri,
+        play_request_id: Option<u64>,
+        track_id: Option<SpotifyUri>,
     },
     // The player is delayed by loading a track.
     Loading {
@@ -293,7 +293,8 @@ impl PlayerEvent {
                 play_request_id, ..
             }
             | Stopped {
-                play_request_id, ..
+                play_request_id: Some(play_request_id),
+                ..
             }
             | PositionCorrection {
                 play_request_id, ..
@@ -1696,8 +1697,8 @@ impl PlayerInternal {
 
                 self.ensure_sink_stopped(false);
                 self.send_event(PlayerEvent::Stopped {
-                    track_id,
-                    play_request_id,
+                    track_id: Some(track_id),
+                    play_request_id: Some(play_request_id),
                 });
                 self.state = PlayerState::Stopped;
             }
@@ -2358,7 +2359,12 @@ impl PlayerInternal {
                             track_id: track_id.clone(),
                         });
                     }
-                    _ => (),
+                    PlayerState::Invalid | PlayerState::Stopped => {
+                        let _ = sender.send(PlayerEvent::Stopped {
+                            play_request_id: None,
+                            track_id: None,
+                        });
+                    }
                 }
 
                 self.event_senders.push(sender);

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,9 @@ mod mpris_event_handler;
 #[cfg(feature = "with-mpris")]
 use mpris_event_handler::MprisEventHandler;
 
+// Position update interval set to 400ms (Doherty threshold)
+const POSITION_UPDATE_INTERVAL_MS: Duration = Duration::from_millis(400);
+
 fn device_id(name: &str) -> String {
     HEXLOWER.encode(&Sha1::digest(name.as_bytes()))
 }
@@ -275,7 +278,6 @@ async fn get_setup() -> Setup {
     #[cfg(feature = "passthrough-decoder")]
     const PASSTHROUGH: &str = "passthrough";
     const PASSWORD: &str = "password";
-    const POSITION_UPDATE_INTERVAL: &str = "position-update-interval";
     const PROXY: &str = "proxy";
     const QUIET: &str = "quiet";
     const SYSTEM_CACHE: &str = "system-cache";
@@ -322,7 +324,6 @@ async fn get_setup() -> Setup {
     #[cfg(feature = "passthrough-decoder")]
     const PASSTHROUGH_SHORT: &str = "P";
     const PASSWORD_SHORT: &str = "p";
-    const POSITION_UPDATE_INTERVAL_SHORT: &str = ""; // no short flag
     const EMIT_SINK_EVENTS_SHORT: &str = "Q";
     const QUIET_SHORT: &str = "q";
     const INITIAL_VOLUME_SHORT: &str = "R";
@@ -633,12 +634,6 @@ async fn get_setup() -> Setup {
         NORMALISATION_KNEE,
         "Knee width (dB) of the dynamic limiter from 0.0 to 10.0. Defaults to 5.0.",
         "KNEE",
-    )
-    .optopt(
-        POSITION_UPDATE_INTERVAL_SHORT,
-        POSITION_UPDATE_INTERVAL,
-        "Maximum interval in ms for player to send a position event. Defaults to no forced position update.",
-        "POSITION_UPDATE",
     )
     .optopt(
         ZEROCONF_PORT_SHORT,
@@ -1828,22 +1823,6 @@ async fn get_setup() -> Setup {
             },
         };
 
-        let position_update_interval = opt_str(POSITION_UPDATE_INTERVAL).as_deref().map(
-            |position_update| match position_update.parse::<u64>() {
-                Ok(value) => Duration::from_millis(value),
-                _ => {
-                    invalid_error_msg(
-                        POSITION_UPDATE_INTERVAL,
-                        POSITION_UPDATE_INTERVAL_SHORT,
-                        position_update,
-                        "Integer value in ms",
-                        "None",
-                    );
-                    exit(1);
-                }
-            },
-        );
-
         #[cfg(feature = "passthrough-decoder")]
         let passthrough = opt_present(PASSTHROUGH);
         #[cfg(not(feature = "passthrough-decoder"))]
@@ -1862,7 +1841,7 @@ async fn get_setup() -> Setup {
             normalisation_release_cf,
             normalisation_knee_db,
             ditherer,
-            position_update_interval: None,
+            position_update_interval: Some(POSITION_UPDATE_INTERVAL_MS),
             local_file_directories,
         }
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,6 +275,7 @@ async fn get_setup() -> Setup {
     #[cfg(feature = "passthrough-decoder")]
     const PASSTHROUGH: &str = "passthrough";
     const PASSWORD: &str = "password";
+    const POSITION_UPDATE: &str = "position-update";
     const PROXY: &str = "proxy";
     const QUIET: &str = "quiet";
     const SYSTEM_CACHE: &str = "system-cache";
@@ -321,6 +322,7 @@ async fn get_setup() -> Setup {
     #[cfg(feature = "passthrough-decoder")]
     const PASSTHROUGH_SHORT: &str = "P";
     const PASSWORD_SHORT: &str = "p";
+    const POSITION_UPDATE_SHORT: &str = ""; // no short flag
     const EMIT_SINK_EVENTS_SHORT: &str = "Q";
     const QUIET_SHORT: &str = "q";
     const INITIAL_VOLUME_SHORT: &str = "R";
@@ -631,6 +633,12 @@ async fn get_setup() -> Setup {
         NORMALISATION_KNEE,
         "Knee width (dB) of the dynamic limiter from 0.0 to 10.0. Defaults to 5.0.",
         "KNEE",
+    )
+    .optopt(
+        POSITION_UPDATE_SHORT,
+        POSITION_UPDATE,
+        "Update position interval in ms",
+        "POSITION_UPDATE",
     )
     .optopt(
         ZEROCONF_PORT_SHORT,
@@ -1819,6 +1827,22 @@ async fn get_setup() -> Setup {
                 _ => None,
             },
         };
+
+        let position_update_interval = opt_str(POSITION_UPDATE).as_deref().map(|position_update| {
+            match position_update.parse::<u64>() {
+                Ok(value) => Duration::from_millis(value),
+                _ => {
+                    invalid_error_msg(
+                        POSITION_UPDATE,
+                        POSITION_UPDATE_SHORT,
+                        position_update,
+                        "Integer value in ms",
+                        "None",
+                    );
+                    exit(1);
+                }
+            }
+        });
 
         #[cfg(feature = "passthrough-decoder")]
         let passthrough = opt_present(PASSTHROUGH);

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,11 @@ use url::Url;
 mod player_event_handler;
 use player_event_handler::{EventHandler, run_program_on_sink_events};
 
+#[cfg(feature = "with-mpris")]
+mod mpris_event_handler;
+#[cfg(feature = "with-mpris")]
+use mpris_event_handler::MprisEventHandler;
+
 fn device_id(name: &str) -> String {
     HEXLOWER.encode(&Sha1::digest(name.as_bytes()))
 }
@@ -2007,6 +2012,14 @@ async fn main() {
         }
     }
 
+    #[cfg(feature = "with-mpris")]
+    let mpris = MprisEventHandler::spawn(player.clone())
+        .await
+        .unwrap_or_else(|e| {
+            error!("could not initialize MPRIS: {e}");
+            exit(1);
+        });
+
     loop {
         tokio::select! {
             credentials = async {
@@ -2060,6 +2073,10 @@ async fn main() {
                         exit(1);
                     }
                 };
+
+                #[cfg(feature = "with-mpris")]
+                mpris.set_spirc(spirc_.clone());
+
                 spirc = Some(spirc_);
                 spirc_task = Some(Box::pin(spirc_task_));
 
@@ -2104,6 +2121,9 @@ async fn main() {
     info!("Gracefully shutting down");
 
     let mut shutdown_tasks = tokio::task::JoinSet::new();
+
+    #[cfg(feature = "with-mpris")]
+    shutdown_tasks.spawn(mpris.quit_and_join());
 
     // Shutdown spirc if necessary
     if let Some(spirc) = spirc {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2037,7 +2037,7 @@ async fn main() {
     }
 
     #[cfg(feature = "with-mpris")]
-    let mpris = MprisEventHandler::spawn(player.clone(), &setup.connect_config.name)
+    let mpris = MprisEventHandler::spawn(player.clone(), &setup.connect_config.name, None)
         .await
         .unwrap_or_else(|e| {
             error!("could not initialize MPRIS: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -2013,7 +2013,7 @@ async fn main() {
     }
 
     #[cfg(feature = "with-mpris")]
-    let mpris = MprisEventHandler::spawn(player.clone())
+    let mpris = MprisEventHandler::spawn(player.clone(), &setup.connect_config.name)
         .await
         .unwrap_or_else(|e| {
             error!("could not initialize MPRIS: {e}");

--- a/src/main.rs
+++ b/src/main.rs
@@ -275,7 +275,7 @@ async fn get_setup() -> Setup {
     #[cfg(feature = "passthrough-decoder")]
     const PASSTHROUGH: &str = "passthrough";
     const PASSWORD: &str = "password";
-    const POSITION_UPDATE: &str = "position-update";
+    const POSITION_UPDATE_INTERVAL: &str = "position-update-interval";
     const PROXY: &str = "proxy";
     const QUIET: &str = "quiet";
     const SYSTEM_CACHE: &str = "system-cache";
@@ -322,7 +322,7 @@ async fn get_setup() -> Setup {
     #[cfg(feature = "passthrough-decoder")]
     const PASSTHROUGH_SHORT: &str = "P";
     const PASSWORD_SHORT: &str = "p";
-    const POSITION_UPDATE_SHORT: &str = ""; // no short flag
+    const POSITION_UPDATE_INTERVAL_SHORT: &str = ""; // no short flag
     const EMIT_SINK_EVENTS_SHORT: &str = "Q";
     const QUIET_SHORT: &str = "q";
     const INITIAL_VOLUME_SHORT: &str = "R";
@@ -635,9 +635,9 @@ async fn get_setup() -> Setup {
         "KNEE",
     )
     .optopt(
-        POSITION_UPDATE_SHORT,
-        POSITION_UPDATE,
-        "Update position interval in ms",
+        POSITION_UPDATE_INTERVAL_SHORT,
+        POSITION_UPDATE_INTERVAL,
+        "Maximum interval in ms for player to send a position event. Defaults to no forced position update.",
         "POSITION_UPDATE",
     )
     .optopt(
@@ -1828,21 +1828,21 @@ async fn get_setup() -> Setup {
             },
         };
 
-        let position_update_interval = opt_str(POSITION_UPDATE).as_deref().map(|position_update| {
-            match position_update.parse::<u64>() {
+        let position_update_interval = opt_str(POSITION_UPDATE_INTERVAL).as_deref().map(
+            |position_update| match position_update.parse::<u64>() {
                 Ok(value) => Duration::from_millis(value),
                 _ => {
                     invalid_error_msg(
-                        POSITION_UPDATE,
-                        POSITION_UPDATE_SHORT,
+                        POSITION_UPDATE_INTERVAL,
+                        POSITION_UPDATE_INTERVAL_SHORT,
                         position_update,
                         "Integer value in ms",
                         "None",
                     );
                     exit(1);
                 }
-            }
-        });
+            },
+        );
 
         #[cfg(feature = "passthrough-decoder")]
         let passthrough = opt_present(PASSTHROUGH);

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -653,14 +653,6 @@ impl MprisPlayerService {
         Ok(0)
     }
 
-    // Note that the `Position` property is not writable intentionally, see
-    // the `set_position` method above.
-    // #[zbus(property)]
-    // async fn set_position(&self, _value: TimeInUs) -> zbus::fdo::Result<()> {
-    //     // TODO: implement
-    //     Err(zbus::fdo::Error::NotSupported("Player control not implemented".to_owned()))
-    // }
-
     // The minimum value which the `Rate` property can take. Clients should not attempt to set the
     // `Rate` property below this value.
     //

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -150,7 +150,9 @@ type Volume = f64;
 // Time in microseconds.
 type TimeInUs = i64;
 
-struct MprisService {}
+struct MprisService {
+    identity: String,
+}
 
 #[zbus::interface(name = "org.mpris.MediaPlayer2")]
 impl MprisService {
@@ -259,8 +261,7 @@ impl MprisService {
     #[zbus(property)]
     async fn identity(&self) -> String {
         debug!("org.mpris.MediaPlayer2::Identity");
-        // TOOD: use name from config
-        "Librespot".to_owned()
+        self.identity.clone()
     }
 
     // The basename of an installed .desktop file which complies with the
@@ -831,10 +832,12 @@ pub struct MprisEventHandler {
 }
 
 impl MprisEventHandler {
-    pub async fn spawn(player: Arc<Player>) -> Result<MprisEventHandler, MprisError> {
+    pub async fn spawn(player: Arc<Player>, name: &str) -> Result<MprisEventHandler, MprisError> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
 
-        let mpris_service = MprisService {};
+        let mpris_service = MprisService {
+            identity: name.to_string(),
+        };
         let mpris_player_service = MprisPlayerService {
             spirc: None,
             // FIXME: obtain current values from Player

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -516,7 +516,6 @@ impl MprisPlayerService {
 
     #[zbus(property)]
     async fn set_loop_status(&mut self, value: LoopStatus) -> zbus::fdo::Result<()> {
-        // TODO: implement, notify change
         match value {
             LoopStatus::None => {
                 if let Some(spirc) = &self.spirc {

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1,0 +1,1220 @@
+use std::{collections::HashMap, sync::Arc};
+
+use librespot_connect::Spirc;
+use log::{debug, warn};
+use thiserror::Error;
+use time::format_description::well_known::Iso8601;
+use tokio::sync::mpsc;
+use zbus::connection;
+
+use librespot::{
+    core::Error,
+    metadata::audio::UniqueFields,
+    playback::player::{Player, PlayerEvent},
+};
+
+/// A playback state.
+#[derive(Clone, Copy, Debug)]
+enum PlaybackStatus {
+    /// A track is currently playing.
+    Playing,
+
+    /// A track is currently paused.
+    Paused,
+
+    /// There is no track currently playing.
+    Stopped,
+}
+
+impl zvariant::Type for PlaybackStatus {
+    fn signature() -> zvariant::Signature<'static> {
+        zvariant::Signature::try_from("s").unwrap()
+    }
+}
+
+impl TryFrom<zvariant::Value<'_>> for PlaybackStatus {
+    type Error = zvariant::Error;
+
+    fn try_from(value: zvariant::Value<'_>) -> Result<Self, zvariant::Error> {
+        if let zvariant::Value::Str(s) = value {
+            match s.as_str() {
+                "Playing" => Ok(Self::Playing),
+                "Paused" => Ok(Self::Paused),
+                "Stopped" => Ok(Self::Stopped),
+                _ => Err(zvariant::Error::Message("invalid enum value".to_owned())),
+            }
+        } else {
+            Err(zvariant::Error::IncorrectType)
+        }
+    }
+}
+
+impl From<PlaybackStatus> for zvariant::Value<'_> {
+    fn from(value: PlaybackStatus) -> Self {
+        let s = match value {
+            PlaybackStatus::Playing => "Playing",
+            PlaybackStatus::Paused => "Paused",
+            PlaybackStatus::Stopped => "Stopped",
+        };
+
+        s.into()
+    }
+}
+
+/// A repeat / loop status
+#[derive(Clone, Copy, Debug)]
+enum LoopStatus {
+    /// The playback will stop when there are no more tracks to play
+    None,
+
+    /// The current track will start again from the begining once it has finished playing
+    Track,
+
+    /// The playback loops through a list of tracks
+    Playlist,
+}
+
+impl zvariant::Type for LoopStatus {
+    fn signature() -> zvariant::Signature<'static> {
+        zvariant::Signature::try_from("s").unwrap()
+    }
+}
+
+impl TryFrom<zvariant::Value<'_>> for LoopStatus {
+    type Error = zvariant::Error;
+
+    fn try_from(value: zvariant::Value<'_>) -> Result<Self, zvariant::Error> {
+        if let zvariant::Value::Str(s) = value {
+            match s.as_str() {
+                "None" => Ok(Self::None),
+                "Track" => Ok(Self::Track),
+                "Playlist" => Ok(Self::Playlist),
+                _ => Err(zvariant::Error::Message("invalid enum value".to_owned())),
+            }
+        } else {
+            Err(zvariant::Error::IncorrectType)
+        }
+    }
+}
+
+impl From<LoopStatus> for zvariant::Value<'_> {
+    fn from(value: LoopStatus) -> Self {
+        let s = match value {
+            LoopStatus::None => "None",
+            LoopStatus::Track => "Track",
+            LoopStatus::Playlist => "Playlist",
+        };
+
+        s.into()
+    }
+}
+
+// /// Unique track identifier.
+// ///
+// /// If the media player implements the TrackList interface and allows
+// /// the same track to appear multiple times in the tracklist,
+// /// this must be unique within the scope of the tracklist.
+// ///
+// /// Note that this should be a valid D-Bus object id, although clients
+// /// should not assume that any object is actually exported with any
+// /// interfaces at that path.
+// ///
+// /// Media players may not use any paths starting with
+// /// `/org/mpris` unless explicitly allowed by this specification.
+// /// Such paths are intended to have special meaning, such as
+// /// `/org/mpris/MediaPlayer2/TrackList/NoTrack`
+// /// to indicate "no track".
+// ///
+// /// This is a D-Bus object id as that is the definitive way to have
+// /// unique identifiers on D-Bus.  It also allows for future optional
+// /// expansions to the specification where tracks are exported to D-Bus
+// /// with an interface similar to org.gnome.UPnP.MediaItem2.
+// type TrackId = ...;
+
+// A playback rate
+//
+// This is a multiplier, so a value of 0.5 indicates that playback is
+// happening at half speed, while 1.5 means that 1.5 seconds of "track time"
+// is consumed every second.
+type PlaybackRate = f64;
+
+// Audio volume level
+//
+//     - 0.0 means mute.
+//     - 1.0 is a sensible maximum volume level (ex: 0dB).
+//
+// Note that the volume may be higher than 1.0, although generally
+// clients should not attempt to set it above 1.0.
+type Volume = f64;
+
+// Time in microseconds.
+type TimeInUs = i64;
+
+struct MprisService {}
+
+#[zbus::interface(name = "org.mpris.MediaPlayer2")]
+impl MprisService {
+    // Brings the media player's user interface to the front using any appropriate mechanism
+    // available.
+    //
+    // The media player may be unable to control how its user interface is displayed, or it may not
+    // have a graphical user interface at all. In this case, the `CanRaise` property is `false` and
+    // this method does nothing.
+    async fn raise(&self) {
+        debug!("org.mpris.MediaPlayer2::Raise");
+    }
+
+    // Causes the media player to stop running.
+    //
+    // The media player may refuse to allow clients to shut it down. In this case, the `CanQuit`
+    // property is `false` and this method does nothing.
+    //
+    // Note: Media players which can be D-Bus activated, or for which there is no sensibly easy way
+    // to terminate a running instance (via the main interface or a notification area icon for
+    // example) should allow clients to use this method. Otherwise, it should not be needed.
+    //
+    // If the media player does not have a UI, this should be implemented.
+    async fn quit(&self) {
+        debug!("org.mpris.MediaPlayer2::Quit");
+    }
+
+    // If `false`, calling `Quit` will have no effect, and may raise a `NotSupported` error.  If
+    // `true`, calling `Quit` will cause the media application to attempt to quit (although it may
+    // still be prevented from quitting by the user, for example).
+    #[zbus(property)]
+    async fn can_quit(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2::CanQuit");
+        false
+    }
+
+    // Whether the media player is occupying the fullscreen.
+    //
+    // This is typically used for videos.  A value of `true` indicates that the media player is
+    // taking up the full screen.
+    //
+    // Media centre software may well have this value fixed to `true`
+    //
+    // If `CanSetFullscreen` is `true`, clients may set this property to `true` to tell the media
+    // player to enter fullscreen mode, or to `false` to return to windowed mode.
+    //
+    // If `CanSetFullscreen` is `false`, then attempting to set this property should have no
+    // effect, and may raise an error.  However, even if it is `true`, the media player may still
+    // be unable to fulfil the request, in which case attempting to set this property will have no
+    // effect (but should not raise an error).
+    //
+    // Rationale:
+    //
+    //     This allows remote control interfaces, such as LIRC or mobile devices like
+    //     phones, to control whether a video is shown in fullscreen.
+    #[zbus(property)]
+    async fn fullscreen(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2::Fullscreen");
+        false
+    }
+
+    #[zbus(property)]
+    async fn set_fullscreen(&self, _value: bool) {
+        debug!("org.mpris.MediaPlayer2::SetFullscreen");
+    }
+
+    // If `false`, attempting to set `Fullscreen` will have no effect, and may raise an error.  If
+    // `true`, attempting to set `Fullscreen` will not raise an error, and (if it is different from
+    // the current value) will cause the media player to attempt to enter or exit fullscreen mode.
+    //
+    // Note that the media player may be unable to fulfil the request. In this case, the value will
+    // not change.  If the media player knows in advance that it will not be able to fulfil the
+    // request, however, this property should be `false`.
+    //
+    // Rationale:
+    //
+    //     This allows clients to choose whether to display controls for entering
+    //     or exiting fullscreen mode.
+    #[zbus(property)]
+    async fn can_set_fullscreen(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2::CanSetFullscreen");
+        false
+    }
+
+    // If `false`, calling `Raise` will have no effect, and may raise a NotSupported error.  If
+    // `true`, calling `Raise` will cause the media application to attempt to bring its user
+    // interface to the front, although it may be prevented from doing so (by the window manager,
+    // for example).
+    #[zbus(property)]
+    async fn can_raise(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2::CanRaise");
+        false
+    }
+
+    // Indicates whether the `/org/mpris/MediaPlayer2` object implements the
+    // `org.mpris.MediaPlayer2.TrackList` interface.
+    #[zbus(property)]
+    async fn has_track_list(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2::HasTrackList");
+        // TODO: Eventually implement
+        false
+    }
+
+    // A friendly name to identify the media player to users. This should usually match the name
+    // found in .desktop files (eg: "VLC media player").
+    #[zbus(property)]
+    async fn identity(&self) -> String {
+        debug!("org.mpris.MediaPlayer2::Identity");
+        // TOOD: use name from config
+        "Librespot".to_owned()
+    }
+
+    // The basename of an installed .desktop file which complies with the
+    // [Desktop entry specification](http://standards.freedesktop.org/desktop-entry-spec/latest/)
+    // with the `.desktop` extension stripped.
+    //
+    // Example: The desktop entry file is "/usr/share/applications/vlc.desktop", and this property
+    // contains "vlc"
+    //
+    #[zbus(property)]
+    async fn desktop_entry(&self) -> String {
+        debug!("org.mpris.MediaPlayer2::DesktopEntry");
+        // FIXME: The spec doesn't say anything about the case when there is no .desktop.
+        // Is there any convention? Any value that common clients handle in a sane way?
+        "".to_owned()
+    }
+
+    // The URI schemes supported by the media player.
+    //
+    // This can be viewed as protocols supported by the player in almost all cases.  Almost every
+    // media player will include support for the `"file"` scheme.  Other common schemes are
+    // `"http"` and `"rtsp"`.
+    //
+    // Note that URI schemes should be lower-case.
+    //
+    // Rationale:
+    //
+    //     This is important for clients to know when using the editing
+    //     capabilities of the Playlist interface, for example.
+    #[zbus(property)]
+    async fn supported_uri_schemes(&self) -> Vec<String> {
+        debug!("org.mpris.MediaPlayer2::SupportedUriSchemes");
+        vec![]
+    }
+
+    // The mime-types supported by the media player.
+    //
+    // Mime-types should be in the standard format (eg: `audio/mpeg` or `application/ogg`).
+    //
+    // Rationale:
+    //
+    //     This is important for clients to know when using the editing
+    //     capabilities of the Playlist interface, for example.
+    #[zbus(property)]
+    async fn supported_mime_types(&self) -> Vec<String> {
+        debug!("org.mpris.MediaPlayer2::SupportedMimeTypes");
+        vec![]
+    }
+}
+
+struct MprisPlayerService {
+    spirc: Option<Spirc>,
+    repeat: LoopStatus,
+    shuffle: bool,
+    playback_status: PlaybackStatus,
+    volume: f64,
+    metadata: HashMap<String, zbus::zvariant::OwnedValue>,
+}
+
+// This interface implements the methods for querying and providing basic
+// control over what is currently playing.
+#[zbus::interface(name = "org.mpris.MediaPlayer2.Player")]
+impl MprisPlayerService {
+    /// Skips to the next track in the tracklist. If there is no next track (and endless playback
+    /// and track repeat are both off), stop playback.
+    ///
+    /// If playback is paused or stopped, it remains that way.
+    ///
+    /// If self.can_go_next is `false`, attempting to call this method should have no effect.
+    async fn next(&self) {
+        if let Some(spirc) = &self.spirc {
+            let _ = spirc.next();
+        }
+    }
+
+    // Skips to the previous track in the tracklist.
+    //
+    // If there is no previous track (and endless playback and track repeat are both off), stop
+    // playback.
+    //
+    // If playback is paused or stopped, it remains that way.
+    //
+    // If `self.can_go_previous` is `false`, attempting to call this method should have no effect.
+    async fn previous(&self) {
+        if let Some(spirc) = &self.spirc {
+            let _ = spirc.prev();
+        }
+    }
+
+    // Pauses playback.
+    //
+    // If playback is already paused, this has no effect.
+    //
+    // Calling Play after this should cause playback to start again from the same position.
+    //
+    // If `self.can_pause` is `false`, attempting to call this method should have no effect.
+    async fn pause(&self) {
+        // FIXME: This should return an error if can_pause is false
+        if let Some(spirc) = &self.spirc {
+            let _ = spirc.pause();
+        }
+    }
+
+    // Pauses playback.
+    //
+    // If playback is already paused, resumes playback.
+    //
+    // If playback is stopped, starts playback.
+    //
+    // If `self.can_pause` is `false`, attempting to call this method should have no effect and
+    // raise an error.
+    async fn play_pause(&self) {
+        // FIXME: This should return an error if can_pause is false
+        if let Some(spirc) = &self.spirc {
+            let _ = spirc.play_pause();
+        }
+    }
+
+    // Stops playback.
+    //
+    // If playback is already stopped, this has no effect.
+    //
+    // Calling Play after this should cause playback to start again from the beginning of the
+    // track.
+    //
+    // If `CanControl` is `false`, attempting to call this method should have no effect and raise
+    // an error.
+    async fn stop(&self) {
+        // FIXME: This should return an error if can_control is false
+        if let Some(spirc) = &self.spirc {
+            let _ = spirc.pause();
+            let _ = spirc.set_position_ms(0);
+        }
+    }
+
+    // Starts or resumes playback.
+    //
+    // If already playing, this has no effect.
+    //
+    // If paused, playback resumes from the current position.
+    //
+    // If there is no track to play, this has no effect.
+    //
+    // If `self.can_play` is `false`, attempting to call this method should have no effect.
+    async fn play(&self) {
+        if let Some(spirc) = &self.spirc {
+            let _ = spirc.activate();
+            let _ = spirc.play();
+        }
+    }
+
+    // Seeks forward in the current track by the specified number of microseconds.
+    //
+    // A negative value seeks back. If this would mean seeking back further than the start of the
+    // track, the position is set to 0.
+    //
+    // If the value passed in would mean seeking beyond the end of the track, acts like a call to
+    // Next.
+    //
+    // If the `self.can_seek` property is `false`, this has no effect.
+    //
+    // Arguments:
+    //
+    // * `offset`: The number of microseconds to seek forward.
+    async fn seek(&self, offset: TimeInUs) {
+        if let Some(spirc) = &self.spirc {
+            let _ = spirc.seek_offset((offset / 1000) as i32);
+        }
+    }
+
+    // Sets the current track position in microseconds.
+    //
+    // If the Position argument is less than 0, do nothing.
+    //
+    // If the Position argument is greater than the track length, do nothing.
+    //
+    // If the `CanSeek` property is `false`, this has no effect.
+    //
+    // Rationale:
+    //
+    //     The reason for having this method, rather than making `self.position` writable, is to
+    //     include the `track_id` argument to avoid race conditions where a client tries to seek to
+    //     a position when the track has already changed.
+    //
+    // Arguments:
+    //
+    // * `track_id`: The currently playing track's identifier.
+    //               If this does not match the id of the currently-playing track, the call is
+    //               ignored as "stale".
+    //               `/org/mpris/MediaPlayer2/TrackList/NoTrack` is _not_ a valid value for this
+    //               argument.
+    // * `position`: Track position in microseconds. This must be between 0 and `track_length`.
+    async fn set_position(&self, _track_id: zbus::zvariant::ObjectPath<'_>, position: TimeInUs) {
+        // FIXME: handle track_id
+        if position < 0 {
+            return;
+        }
+        if let Some(spirc) = &self.spirc {
+            let _ = spirc.set_position_ms((position / 1000) as u32);
+        }
+    }
+
+    // Opens the Uri given as an argument
+    //
+    // If the playback is stopped, starts playing
+    //
+    // If the uri scheme or the mime-type of the uri to open is not supported, this method does
+    // nothing and may raise an error.  In particular, if the list of available uri schemes is
+    // empty, this method may not be implemented.
+    //
+    // Clients should not assume that the Uri has been opened as soon as this method returns. They
+    // should wait until the mpris:trackid field in the `Metadata` property changes.
+    //
+    // If the media player implements the TrackList interface, then the opened track should be made
+    // part of the tracklist, the `org.mpris.MediaPlayer2.TrackList.TrackAdded` or
+    // `org.mpris.MediaPlayer2.TrackList.TrackListReplaced` signal should be fired, as well as the
+    // `org.freedesktop.DBus.Properties.PropertiesChanged` signal on the tracklist interface.
+    //
+    // Arguments:
+    //
+    // * `uri`: Uri of the track to load. Its uri scheme should be an element of the
+    //          `org.mpris.MediaPlayer2.SupportedUriSchemes` property and the mime-type should
+    //          match one of the elements of the `org.mpris.MediaPlayer2.SupportedMimeTypes`.
+    async fn open_uri(&self, _uri: &str) -> zbus::fdo::Result<()> {
+        Err(zbus::fdo::Error::NotSupported(
+            "OpenUri not supported".to_owned(),
+        ))
+    }
+
+    // The current playback status.
+    //
+    // May be "Playing", "Paused" or "Stopped".
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn playback_status(&self) -> PlaybackStatus {
+        self.playback_status
+    }
+
+    // The current loop / repeat status
+    //
+    // May be:
+    //  - "None" if the playback will stop when there are no more tracks to play
+    //  - "Track" if the current track will start again from the begining once it has finished playing
+    //  - "Playlist" if the playback loops through a list of tracks
+    //
+    // If `self.can_control` is `false`, attempting to set this property should have no effect and
+    // raise an error.
+    //
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn loop_status(&self) -> LoopStatus {
+        self.repeat
+    }
+
+    #[zbus(property)]
+    async fn set_loop_status(&mut self, value: LoopStatus) -> zbus::fdo::Result<()> {
+        // TODO: implement, notify change
+        match value {
+            LoopStatus::None => {
+                if let Some(spirc) = &self.spirc {
+                    let _ = spirc.repeat(false);
+                    let _ = spirc.repeat_track(false);
+                }
+            }
+            LoopStatus::Track => {
+                if let Some(spirc) = &self.spirc {
+                    let _ = spirc.repeat_track(true);
+                }
+            }
+            LoopStatus::Playlist => {
+                if let Some(spirc) = &self.spirc {
+                    let _ = spirc.repeat(true);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    // The current playback rate.
+    //
+    // The value must fall in the range described by `MinimumRate` and `MaximumRate`, and must not
+    // be 0.0.  If playback is paused, the `PlaybackStatus` property should be used to indicate
+    // this.  A value of 0.0 should not be set by the client.  If it is, the media player should
+    // act as though `Pause` was called.
+    //
+    // If the media player has no ability to play at speeds other than the normal playback rate,
+    // this must still be implemented, and must return 1.0.  The `MinimumRate` and `MaximumRate`
+    // properties must also be set to 1.0.
+    //
+    // Not all values may be accepted by the media player.  It is left to media player
+    // implementations to decide how to deal with values they cannot use; they may either ignore
+    // them or pick a "best fit" value. Clients are recommended to only use sensible fractions or
+    // multiples of 1 (eg: 0.5, 0.25, 1.5, 2.0, etc).
+    //
+    // Rationale:
+    //
+    //     This allows clients to display (reasonably) accurate progress bars
+    //     without having to regularly query the media player for the current
+    //     position.
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn rate(&self) -> PlaybackRate {
+        1.0
+    }
+
+    #[zbus(property)]
+    async fn set_rate(&mut self, _value: PlaybackRate) {
+        // ignore
+    }
+
+    // A value of `false` indicates that playback is progressing linearly through a playlist, while
+    // `true` means playback is progressing through a playlist in some other order.
+    //
+    // If `CanControl` is `false`, attempting to set this property should have no effect and raise
+    // an error.
+    //
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn shuffle(&self) -> bool {
+        self.shuffle
+    }
+
+    #[zbus(property)]
+    async fn set_shuffle(&mut self, value: bool) {
+        if let Some(spirc) = &self.spirc {
+            let _ = spirc.shuffle(value);
+        }
+    }
+
+    // The metadata of the current element.
+    //
+    // If there is a current track, this must have a "mpris:trackid" entry (of D-Bus type "o") at
+    // the very least, which contains a D-Bus path that uniquely identifies this track.
+    //
+    // See the type documentation for more details.
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn metadata(
+        &self,
+    ) -> zbus::fdo::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>> {
+        let meta = if self.metadata.is_empty() {
+            let mut meta = HashMap::new();
+            meta.insert(
+                "mpris:trackid".to_owned(),
+                zvariant::Str::from(" /org/mpris/MediaPlayer2/TrackList/NoTrack").into(),
+            );
+            meta
+        } else {
+            self.metadata
+                .iter()
+                .map(|(k, v)| (k.clone(), v.try_clone().unwrap()))
+                .collect()
+        };
+        Ok(meta)
+    }
+
+    // The volume level.
+    //
+    // When setting, if a negative value is passed, the volume should be set to 0.0.
+    //
+    // If `CanControl` is `false`, attempting to set this property should have no effect and raise
+    // an error.
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn volume(&self) -> Volume {
+        self.volume
+    }
+
+    #[zbus(property)]
+    async fn set_volume(&mut self, _value: Volume) -> zbus::fdo::Result<()> {
+        // TODO: implement
+        Err(zbus::fdo::Error::NotSupported(
+            "Player control not implemented".to_owned(),
+        ))
+    }
+
+    // The current track position in microseconds, between 0 and the 'mpris:length' metadata entry
+    // (see Metadata).
+    //
+    // Note: If the media player allows it, the current playback position can be changed either the
+    // SetPosition method or the Seek method on this interface.  If this is not the case, the
+    // `CanSeek` property is false, and setting this property has no effect and can raise an error.
+    //
+    // If the playback progresses in a way that is inconstistant with the `Rate` property, the
+    // `Seeked` signal is emited.
+    #[zbus(property(emits_changed_signal = "false"))]
+    async fn position(&self) -> zbus::fdo::Result<TimeInUs> {
+        // todo!("fetch up-to-date position from player")
+        Ok(0)
+    }
+
+    // Note that the `Position` property is not writable intentionally, see
+    // the `set_position` method above.
+    // #[zbus(property)]
+    // async fn set_position(&self, _value: TimeInUs) -> zbus::fdo::Result<()> {
+    //     // TODO: implement
+    //     Err(zbus::fdo::Error::NotSupported("Player control not implemented".to_owned()))
+    // }
+
+    // The minimum value which the `Rate` property can take. Clients should not attempt to set the
+    // `Rate` property below this value.
+    //
+    // Note that even if this value is 0.0 or negative, clients should not attempt to set the
+    // `Rate` property to 0.0.
+    //
+    // This value should always be 1.0 or less.
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn minimum_rate(&self) -> PlaybackRate {
+        // TODO: implement
+        1.0
+    }
+
+    // The maximum value which the `Rate` property can take. Clients should not attempt to set the
+    // `Rate` property above this value.
+    //
+    // This value should always be 1.0 or greater.
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn maximum_rate(&self) -> PlaybackRate {
+        // TODO: implement
+        1.0
+    }
+
+    // Whether the client can call the `Next` method on this interface and expect the current track
+    // to change.
+    //
+    // If it is unknown whether a call to `Next` will be successful (for example, when streaming
+    // tracks), this property should be set to `true`.
+    //
+    // If `CanControl` is `false`, this property should also be `false`.
+    //
+    // Rationale:
+    //
+    //     Even when playback can generally be controlled, there may not
+    //     always be a next track to move to.
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn can_go_next(&self) -> bool {
+        true
+    }
+
+    // Whether the client can call the `Previous` method on this interface and expect the current
+    // track to change.
+    //
+    // If it is unknown whether a call to `Previous` will be successful (for example, when
+    // streaming tracks), this property should be set to `true`.
+    //
+    // If `CanControl` is `false`, this property should also be `false`.
+    //
+    // Rationale:
+    //
+    //     Even when playback can generally be controlled, there may not
+    //     always be a next previous to move to.
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn can_go_previous(&self) -> bool {
+        true
+    }
+
+    // Whether playback can be started using `Play` or `PlayPause`.
+    //
+    // Note that this is related to whether there is a "current track": the value should not depend
+    // on whether the track is currently paused or playing.  In fact, if a track is currently
+    // playing (and `CanControl` is `true`), this should be `true`.
+    //
+    // If `CanControl` is `false`, this property should also be `false`.
+    //
+    // Rationale:
+    //
+    //     Even when playback can generally be controlled, it may not be
+    //     possible to enter a "playing" state, for example if there is no
+    //     "current track".
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn can_play(&self) -> bool {
+        !self.metadata.is_empty()
+    }
+
+    // Whether playback can be paused using `Pause` or `PlayPause`.
+    //
+    // Note that this is an intrinsic property of the current track: its value should not depend on
+    // whether the track is currently paused or playing.  In fact, if playback is currently paused
+    // (and `CanControl` is `true`), this should be `true`.
+    //
+    //
+    // If `CanControl` is `false`, this property should also be `false`.
+    //
+    // Rationale:
+    //
+    //     Not all media is pausable: it may not be possible to pause some
+    //     streamed media, for example.
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn can_pause(&self) -> bool {
+        !self.metadata.is_empty()
+    }
+
+    // Whether the client can control the playback position using `Seek` and `SetPosition`.  This
+    // may be different for different tracks.
+    //
+    // If `CanControl` is `false`, this property should also be `false`.
+    //
+    // Rationale:
+    //
+    //     Not all media is seekable: it may not be possible to seek when
+    //     playing some streamed media, for example.
+    #[zbus(property(emits_changed_signal = "true"))]
+    async fn can_seek(&self) -> bool {
+        true
+    }
+
+    // Whether the media player may be controlled over this interface.
+    //
+    // This property is not expected to change, as it describes an intrinsic capability of the
+    // implementation.
+    //
+    // If this is `false`, clients should assume that all properties on this interface are
+    // read-only (and will raise errors if writing to them is attempted), no methods are
+    // implemented and all other properties starting with "can_" are also `false`.
+    //
+    // Rationale:
+    //
+    //     This allows clients to determine whether to present and enable controls to the user in
+    //     advance of attempting to call methods and write to properties.
+    #[zbus(property(emits_changed_signal = "const"))]
+    async fn can_control(&self) -> bool {
+        true
+    }
+
+    // Indicates that the track position has changed in a way that is inconsistant with the current
+    // playing state.
+    //
+    // When this signal is not received, clients should assume that:
+    // - When playing, the position progresses according to the rate property.
+    // - When paused, it remains constant.
+    //
+    // This signal does not need to be emitted when playback starts or when the track changes,
+    // unless the track is starting at an unexpected position. An expected position would be the
+    // last known one when going from Paused to Playing, and 0 when going from Stopped to Playing.
+    //
+    // Arguments:
+    //
+    // * `position`: The new position, in microseconds.
+    #[zbus(signal)]
+    async fn seeked(signal_ctxt: &zbus::SignalContext<'_>, position: TimeInUs) -> zbus::Result<()>;
+    // FIXME: signal on appropriate player events!
+}
+
+#[derive(Debug, Error)]
+pub enum MprisError {
+    #[error("zbus error: {0}")]
+    DbusError(zbus::Error),
+}
+
+impl From<MprisError> for Error {
+    fn from(err: MprisError) -> Self {
+        use MprisError::*;
+        match err {
+            DbusError(_) => Error::internal(err),
+        }
+    }
+}
+
+impl From<zbus::Error> for MprisError {
+    fn from(err: zbus::Error) -> Self {
+        Self::DbusError(err)
+    }
+}
+
+enum MprisCommand {
+    SetSpirc(Spirc),
+    Quit,
+}
+
+pub struct MprisEventHandler {
+    cmd_tx: mpsc::UnboundedSender<MprisCommand>,
+    join_handle: tokio::task::JoinHandle<()>,
+}
+
+impl MprisEventHandler {
+    pub async fn spawn(player: Arc<Player>) -> Result<MprisEventHandler, MprisError> {
+        let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+
+        let mpris_service = MprisService {};
+        let mpris_player_service = MprisPlayerService {
+            spirc: None,
+            // FIXME: obtain current values from Player
+            repeat: LoopStatus::None,
+            shuffle: false,
+            playback_status: PlaybackStatus::Stopped,
+            volume: 1.0,
+            metadata: HashMap::new(),
+        };
+
+        let connection = connection::Builder::session()?
+            // FIXME: retry with "org.mpris.MediaPlayer2.librespot.instance<pid>"
+            // on error
+            .name("org.mpris.MediaPlayer2.librespot")?
+            .serve_at("/org/mpris/MediaPlayer2", mpris_service)?
+            .serve_at("/org/mpris/MediaPlayer2", mpris_player_service)?
+            .build()
+            .await?;
+
+        let mpris_task = MprisTask {
+            player,
+            connection,
+            cmd_rx,
+        };
+
+        let join_handle = tokio::spawn(mpris_task.run());
+
+        Ok(MprisEventHandler {
+            cmd_tx,
+            join_handle,
+        })
+    }
+
+    pub fn set_spirc(&self, spirc: Spirc) {
+        let _ = self.cmd_tx.send(MprisCommand::SetSpirc(spirc));
+    }
+
+    pub async fn quit_and_join(self) {
+        let _ = self.cmd_tx.send(MprisCommand::Quit);
+        let _ = self.join_handle.await;
+    }
+}
+
+struct MprisTask {
+    player: Arc<Player>,
+    connection: zbus::Connection,
+    cmd_rx: mpsc::UnboundedReceiver<MprisCommand>,
+}
+
+impl MprisTask {
+    async fn run(mut self) {
+        let mut player_events = self.player.get_player_event_channel();
+
+        loop {
+            tokio::select! {
+                Some(event) = player_events.recv() => {
+                    if let Err(e) = self.handle_event(event).await {
+                        warn!("Error handling PlayerEvent: {e}");
+                    }
+                }
+
+                cmd = self.cmd_rx.recv() => {
+                    match cmd {
+                        Some(MprisCommand::SetSpirc(spirc)) => {
+                            // TODO: Update playback status, metadata, etc (?)
+                            self.mpris_player_iface().await
+                                .get_mut().await
+                                .spirc = Some(spirc);
+
+                        }
+                        Some(MprisCommand::Quit) => break,
+
+                        // Keep running if the cmd sender was dropped
+                        None => (),
+                    }
+                }
+
+                // If player_events yields None, shutdown
+                else => break,
+            }
+        }
+
+        debug!("Shutting down MprisTask ...");
+    }
+
+    #[allow(dead_code)]
+    async fn mpris_iface(&self) -> zbus::object_server::InterfaceRef<MprisService> {
+        self.connection
+            .object_server()
+            .interface::<_, MprisService>("/org/mpris/MediaPlayer2")
+            .await
+            .expect("iface missing on object server")
+    }
+
+    async fn mpris_player_iface(&self) -> zbus::object_server::InterfaceRef<MprisPlayerService> {
+        self.connection
+            .object_server()
+            .interface::<_, MprisPlayerService>("/org/mpris/MediaPlayer2")
+            .await
+            .expect("iface missing on object server")
+    }
+
+    async fn handle_event(&self, event: PlayerEvent) -> zbus::Result<()> {
+        match event {
+            PlayerEvent::PlayRequestIdChanged { play_request_id: _ } => {}
+            PlayerEvent::TrackChanged { audio_item } => {
+                match audio_item.track_id.to_id() {
+                    Err(e) => {
+                        warn!("PlayerEvent::TrackChanged: Invalid track id: {e}")
+                    }
+                    Ok(track_id) => {
+                        let iface_ref = self.mpris_player_iface().await;
+                        let mut iface = iface_ref.get_mut().await;
+
+                        let meta = &mut iface.metadata;
+                        meta.clear();
+
+                        let mut trackid = String::new();
+                        trackid.push_str("/org/librespot/track/");
+                        trackid.push_str(&track_id);
+                        meta.insert(
+                            "mpris:trackid".into(),
+                            zvariant::ObjectPath::try_from(trackid).unwrap().into(),
+                        );
+
+                        meta.insert(
+                            "xesam:title".into(),
+                            zvariant::Str::from(audio_item.name).into(),
+                        );
+
+                        if audio_item.covers.is_empty() {
+                            meta.remove("mpris:artUrl");
+                        } else {
+                            // TODO: Select image by size
+                            let url = &audio_item.covers[0].url;
+                            meta.insert("mpris.artUrl".into(), zvariant::Str::from(url).into());
+                        }
+
+                        meta.insert(
+                            "mpris:length".into(),
+                            (audio_item.duration_ms as i64 * 1000).into(),
+                        );
+
+                        match audio_item.unique_fields {
+                            UniqueFields::Track {
+                                artists,
+                                album,
+                                album_date,
+                                album_artists,
+                                popularity: _,
+                                number,
+                                disc_number,
+                            } => {
+                                let artists = artists
+                                    .0
+                                    .into_iter()
+                                    .map(|a| a.name)
+                                    .collect::<Vec<String>>();
+                                meta.insert(
+                                    "xesam:artist".into(),
+                                    // try_to_owned only fails if the Value contains file
+                                    // descriptors, so the unwrap never panics here
+                                    zvariant::Value::from(artists).try_to_owned().unwrap(),
+                                );
+
+                                meta.insert(
+                                    "xesam:albumArtist".into(),
+                                    // try_to_owned only fails if the Value contains file
+                                    // descriptors, so the unwrap never panics here
+                                    zvariant::Value::from(&album_artists)
+                                        .try_to_owned()
+                                        .unwrap(),
+                                );
+
+                                meta.insert(
+                                    "xesam:album".into(),
+                                    zvariant::Str::from(album).into(),
+                                );
+
+                                meta.insert("xesam:trackNumber".into(), (number as i32).into());
+
+                                meta.insert("xesam:discNumber".into(), (disc_number as i32).into());
+
+                                meta.insert(
+                                    "xesam:contentCreated".into(),
+                                    zvariant::Str::from(
+                                        album_date.0.format(&Iso8601::DATE).unwrap(),
+                                    )
+                                    .into(),
+                                );
+                            }
+                            UniqueFields::Episode {
+                                description,
+                                publish_time,
+                                show_name,
+                            } => {
+                                meta.insert(
+                                    "xesam:album".into(),
+                                    zvariant::Str::from(show_name).into(),
+                                );
+
+                                meta.insert(
+                                    "xesam:comment".into(),
+                                    zvariant::Str::from(description).into(),
+                                );
+
+                                meta.insert(
+                                    "xesam:contentCreated".into(),
+                                    zvariant::Str::from(
+                                        publish_time.0.format(&Iso8601::DATE).unwrap(),
+                                    )
+                                    .into(),
+                                );
+                            }
+                        }
+
+                        iface.metadata_changed(iface_ref.signal_context()).await?;
+                    }
+                }
+            }
+            PlayerEvent::Stopped { track_id, .. } => match track_id.to_id() {
+                Err(e) => warn!("PlayerEvent::Stopped: Invalid track id: {e}"),
+                Ok(track_id) => {
+                    let iface_ref = self.mpris_player_iface().await;
+                    let mut iface = iface_ref.get_mut().await;
+                    let meta = &mut iface.metadata;
+
+                    // TODO: Check if metadata changed, if so clear
+                    let mut trackid = String::new();
+                    trackid.push_str("/org/librespot/track/");
+                    trackid.push_str(&track_id);
+                    meta.insert(
+                        "mpris:trackid".into(),
+                        zvariant::ObjectPath::try_from(trackid).unwrap().into(),
+                    );
+                    iface.metadata_changed(iface_ref.signal_context()).await?;
+
+                    iface.playback_status = PlaybackStatus::Stopped;
+                    iface
+                        .playback_status_changed(iface_ref.signal_context())
+                        .await?;
+                }
+            },
+            PlayerEvent::Playing {
+                track_id,
+                // position_ms,
+                ..
+            } => match track_id.to_id() {
+                Err(e) => warn!("PlayerEvent::Playing: Invalid track id: {e}"),
+                Ok(track_id) => {
+                    // TODO: update position
+                    let iface_ref = self.mpris_player_iface().await;
+                    let mut iface = iface_ref.get_mut().await;
+                    let meta = &mut iface.metadata;
+
+                    // TODO: Check if metadata changed, if so clear
+                    let mut trackid = String::new();
+                    trackid.push_str("/org/librespot/track/");
+                    trackid.push_str(&track_id);
+                    meta.insert(
+                        "mpris:trackid".into(),
+                        zvariant::ObjectPath::try_from(trackid).unwrap().into(),
+                    );
+                    iface.metadata_changed(iface_ref.signal_context()).await?;
+
+                    iface.playback_status = PlaybackStatus::Playing;
+                    iface
+                        .playback_status_changed(iface_ref.signal_context())
+                        .await?;
+                }
+            },
+            PlayerEvent::Paused {
+                track_id,
+                // position_ms,
+                ..
+            } => match track_id.to_id() {
+                Err(e) => warn!("PlayerEvent::Paused: Invalid track id: {e}"),
+                Ok(track_id) => {
+                    // TODO: update position
+                    let iface_ref = self.mpris_player_iface().await;
+                    let mut iface = iface_ref.get_mut().await;
+                    let meta = &mut iface.metadata;
+
+                    // TODO: Check if metadata changed, if so clear
+                    let mut trackid = String::new();
+                    trackid.push_str("/org/librespot/track/");
+                    trackid.push_str(&track_id);
+                    meta.insert(
+                        "mpris:trackid".into(),
+                        zvariant::ObjectPath::try_from(trackid).unwrap().into(),
+                    );
+                    iface.metadata_changed(iface_ref.signal_context()).await?;
+
+                    iface.playback_status = PlaybackStatus::Paused;
+                    iface
+                        .playback_status_changed(iface_ref.signal_context())
+                        .await?;
+                }
+            },
+            PlayerEvent::Loading { .. } => {}
+            PlayerEvent::Preloading { .. } => {}
+            PlayerEvent::TimeToPreloadNextTrack { .. } => {}
+            PlayerEvent::EndOfTrack { track_id, .. } => match track_id.to_id() {
+                Err(e) => warn!("PlayerEvent::EndOfTrack: Invalid track id: {e}"),
+                Ok(_id) => {
+                    // TODO: ?
+                }
+            },
+            PlayerEvent::Unavailable { .. } => {}
+            PlayerEvent::VolumeChanged {
+                // volume
+                ..
+            } => {
+                // TODO: Handle volume
+            }
+            PlayerEvent::Seeked {
+                track_id,
+                // position_ms,
+                ..
+            } => match track_id.to_id() {
+                Err(e) => warn!("PlayerEvent::Seeked: Invalid track id: {e}"),
+                Ok(track_id) => {
+                    // TODO: Update position + track_id
+                    let iface_ref = self.mpris_player_iface().await;
+                    let mut iface = iface_ref.get_mut().await;
+                    let meta = &mut iface.metadata;
+
+                    // TODO: Check if metadata changed, if so clear
+                    let mut trackid = String::new();
+                    trackid.push_str("/org/librespot/track/");
+                    trackid.push_str(&track_id);
+                    meta.insert(
+                        "mpris:trackid".into(),
+                        zvariant::ObjectPath::try_from(trackid).unwrap().into(),
+                    );
+                    iface.metadata_changed(iface_ref.signal_context()).await?;
+                }
+            },
+            PlayerEvent::PositionCorrection {
+                track_id,
+                // position_ms,
+                ..
+            } => match track_id.to_id() {
+                Err(e) => {
+                    warn!("PlayerEvent::PositionCorrection: Invalid track id: {e}")
+                }
+                Ok(_id) => {
+                    // TODO: Update position + track_id
+                }
+            },
+            PlayerEvent::PositionChanged { .. } => {
+                // TODO
+            }
+            PlayerEvent::SessionConnected { .. } => {}
+            PlayerEvent::SessionDisconnected { .. } => {}
+            PlayerEvent::SessionClientChanged { .. } => {}
+            PlayerEvent::ShuffleChanged { shuffle } => {
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
+                iface.shuffle = shuffle;
+                iface.shuffle_changed(iface_ref.signal_context()).await?;
+            }
+            PlayerEvent::RepeatChanged { context, track } => {
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
+                if context {
+                    iface.repeat = LoopStatus::Playlist;
+                } else if track {
+                    iface.repeat = LoopStatus::Track;
+                } else {
+                    iface.repeat = LoopStatus::None;
+                }
+                iface
+                    .loop_status_changed(iface_ref.signal_context())
+                    .await?;
+            }
+            PlayerEvent::AutoPlayChanged { .. } => {}
+            PlayerEvent::FilterExplicitContentChanged { .. } => {}
+        }
+
+        Ok(())
+    }
+}

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -662,7 +662,7 @@ impl MprisPlayerService {
     // This value should always be 1.0 or less.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn minimum_rate(&self) -> PlaybackRate {
-        // TODO: implement
+        // Setting minimum and maximum rate to 1 disallow client to set rate.
         1.0
     }
 
@@ -672,7 +672,7 @@ impl MprisPlayerService {
     // This value should always be 1.0 or greater.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn maximum_rate(&self) -> PlaybackRate {
-        // TODO: implement
+        // Setting minimum and maximum rate to 1 disallow client to set rate.
         1.0
     }
 

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -844,7 +844,8 @@ impl MprisEventHandler {
         };
         let mpris_player_service = MprisPlayerService {
             spirc: None,
-            // FIXME: obtain current values from Player
+            // Values are updated upon reception of first player state, right after MprisTask event
+            // handler registration
             repeat: LoopStatus::None,
             shuffle: false,
             playback_status: PlaybackStatus::Stopped,

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1222,7 +1222,6 @@ impl MprisTask {
                 cmd = self.cmd_rx.recv() => {
                     match cmd {
                         Some(MprisCommand::SetSpirc(spirc)) => {
-                            // TODO: Update playback status, metadata, etc (?)
                             self.mpris_player_iface().await
                                 .get_mut().await
                                 .spirc = Some(spirc);

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -5,7 +5,8 @@ use log::{debug, info, warn};
 use thiserror::Error;
 use time::format_description::well_known::Iso8601;
 use tokio::sync::mpsc;
-use zbus::{connection, fdo};
+use zbus::{connection, fdo, object_server::SignalEmitter};
+use zvariant::Type;
 
 use librespot::{
     core::date::Date,
@@ -15,7 +16,7 @@ use librespot::{
 };
 
 /// A playback state.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Type)]
 enum PlaybackStatus {
     /// A track is currently playing.
     Playing,
@@ -25,12 +26,6 @@ enum PlaybackStatus {
 
     /// There is no track currently playing.
     Stopped,
-}
-
-impl zvariant::Type for PlaybackStatus {
-    fn signature() -> zvariant::Signature<'static> {
-        zvariant::Signature::try_from("s").unwrap()
-    }
 }
 
 impl TryFrom<zvariant::Value<'_>> for PlaybackStatus {
@@ -63,7 +58,7 @@ impl From<PlaybackStatus> for zvariant::Value<'_> {
 }
 
 /// A repeat / loop status
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, Type)]
 enum LoopStatus {
     /// The playback will stop when there are no more tracks to play
     None,
@@ -73,12 +68,6 @@ enum LoopStatus {
 
     /// The playback loops through a list of tracks
     Playlist,
-}
-
-impl zvariant::Type for LoopStatus {
-    fn signature() -> zvariant::Signature<'static> {
-        zvariant::Signature::try_from("s").unwrap()
-    }
 }
 
 impl TryFrom<zvariant::Value<'_>> for LoopStatus {
@@ -1114,7 +1103,7 @@ impl MprisPlayerService {
     //
     // * `position`: The new position, in microseconds.
     #[zbus(signal)]
-    async fn seeked(signal_ctxt: &zbus::SignalContext<'_>, position: TimeInUs) -> zbus::Result<()>;
+    async fn seeked(signal_emitter: &SignalEmitter<'_>, position: TimeInUs) -> zbus::Result<()>;
 }
 
 #[derive(Debug, Error)]
@@ -1309,7 +1298,7 @@ impl MprisTask {
 
                 meta.xesam = audio_item.unique_fields.into();
 
-                iface.metadata_changed(iface_ref.signal_context()).await?;
+                iface.metadata_changed(iface_ref.signal_emitter()).await?;
             }
             PlayerEvent::Stopped { track_id, .. } => {
                 let iface_ref = self.mpris_player_iface().await;
@@ -1320,12 +1309,12 @@ impl MprisTask {
                     *meta = Metadata::default();
                     meta.mpris.track_id = track_id;
                     warn!("Missed TrackChanged event, metadata missing");
-                    iface.metadata_changed(iface_ref.signal_context()).await?;
+                    iface.metadata_changed(iface_ref.signal_emitter()).await?;
                 }
 
                 iface.playback_status = PlaybackStatus::Stopped;
                 iface
-                    .playback_status_changed(iface_ref.signal_context())
+                    .playback_status_changed(iface_ref.signal_emitter())
                     .await?;
             }
             PlayerEvent::Playing {
@@ -1344,12 +1333,12 @@ impl MprisTask {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
                     warn!("Missed TrackChanged event, metadata missing");
-                    iface.metadata_changed(iface_ref.signal_context()).await?;
+                    iface.metadata_changed(iface_ref.signal_emitter()).await?;
                 }
 
                 iface.playback_status = PlaybackStatus::Playing;
                 iface
-                    .playback_status_changed(iface_ref.signal_context())
+                    .playback_status_changed(iface_ref.signal_emitter())
                     .await?;
             }
             PlayerEvent::Paused {
@@ -1368,12 +1357,12 @@ impl MprisTask {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
                     warn!("Missed TrackChanged event, metadata missing");
-                    iface.metadata_changed(iface_ref.signal_context()).await?;
+                    iface.metadata_changed(iface_ref.signal_emitter()).await?;
                 }
 
                 iface.playback_status = PlaybackStatus::Paused;
                 iface
-                    .playback_status_changed(iface_ref.signal_context())
+                    .playback_status_changed(iface_ref.signal_emitter())
                     .await?;
             }
             PlayerEvent::Loading { .. } => {}
@@ -1394,7 +1383,7 @@ impl MprisTask {
                     meta.mpris.track_id = Some(track_id);
                     warn!("Missed TrackChanged event, metadata missing");
                     iface.position = None;
-                    iface.metadata_changed(iface_ref.signal_context()).await?;
+                    iface.metadata_changed(iface_ref.signal_emitter()).await?;
                 }
             }
             PlayerEvent::Unavailable { .. } => {}
@@ -1403,7 +1392,7 @@ impl MprisTask {
                 let mut iface = iface_ref.get_mut().await;
                 if iface.volume != volume {
                     iface.volume = volume;
-                    iface.volume_changed(iface_ref.signal_context()).await?;
+                    iface.volume_changed(iface_ref.signal_emitter()).await?;
                 }
             }
             PlayerEvent::Seeked {
@@ -1416,7 +1405,7 @@ impl MprisTask {
 
                 iface.position = Some(Position::from(position_ms));
 
-                MprisPlayerService::seeked(iface_ref.signal_context(), position_ms as i64 * 1000)
+                MprisPlayerService::seeked(iface_ref.signal_emitter(), position_ms as i64 * 1000)
                     .await?;
 
                 let meta = &mut iface.metadata;
@@ -1424,7 +1413,7 @@ impl MprisTask {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
                     warn!("Missed TrackChanged event, metadata missing");
-                    iface.metadata_changed(iface_ref.signal_context()).await?;
+                    iface.metadata_changed(iface_ref.signal_emitter()).await?;
                 }
             }
             PlayerEvent::PositionCorrection {
@@ -1437,7 +1426,7 @@ impl MprisTask {
 
                 iface.position = Some(Position::from(position_ms));
 
-                MprisPlayerService::seeked(iface_ref.signal_context(), position_ms as i64 * 1000)
+                MprisPlayerService::seeked(iface_ref.signal_emitter(), position_ms as i64 * 1000)
                     .await?;
 
                 let meta = &mut iface.metadata;
@@ -1445,7 +1434,7 @@ impl MprisTask {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
                     warn!("Missed TrackChanged event, metadata missing");
-                    iface.metadata_changed(iface_ref.signal_context()).await?;
+                    iface.metadata_changed(iface_ref.signal_emitter()).await?;
                 }
             }
             PlayerEvent::PositionChanged {
@@ -1458,15 +1447,14 @@ impl MprisTask {
 
                 iface.position = Some(Position::from(position_ms));
 
-                MprisPlayerService::seeked(iface_ref.signal_context(), position_ms as i64 * 1000)
-                    .await?;
+                iface_ref.seeked(position_ms as i64 * 1000).await?;
 
                 let meta = &mut iface.metadata;
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
                     warn!("Missed TrackChanged event, metadata missing");
-                    iface.metadata_changed(iface_ref.signal_context()).await?;
+                    iface.metadata_changed(iface_ref.signal_emitter()).await?;
                 }
             }
             PlayerEvent::SessionConnected { .. } => {}
@@ -1476,7 +1464,7 @@ impl MprisTask {
                 let iface_ref = self.mpris_player_iface().await;
                 let mut iface = iface_ref.get_mut().await;
                 iface.shuffle = shuffle;
-                iface.shuffle_changed(iface_ref.signal_context()).await?;
+                iface.shuffle_changed(iface_ref.signal_emitter()).await?;
             }
             PlayerEvent::RepeatChanged { context, track } => {
                 let iface_ref = self.mpris_player_iface().await;
@@ -1489,7 +1477,7 @@ impl MprisTask {
                     iface.repeat = LoopStatus::None;
                 }
                 iface
-                    .loop_status_changed(iface_ref.signal_context())
+                    .loop_status_changed(iface_ref.signal_emitter())
                     .await?;
             }
             PlayerEvent::AutoPlayChanged { .. } => {}

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1277,6 +1277,8 @@ impl MprisTask {
                 let meta = &mut iface.metadata;
                 *meta = Metadata::default();
 
+                meta.xesam = audio_item.unique_fields.into();
+
                 meta.mpris.track_id = Some(audio_item.track_id);
                 meta.xesam.title = Some(audio_item.name);
 
@@ -1291,8 +1293,6 @@ impl MprisTask {
                 }
 
                 meta.mpris.length = Some(audio_item.duration_ms as i64 * 1000);
-
-                meta.xesam = audio_item.unique_fields.into();
 
                 iface.metadata_changed(iface_ref.signal_emitter()).await?;
             }

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -8,7 +8,8 @@ use tokio::sync::mpsc;
 use zbus::connection;
 
 use librespot::{
-    core::Error,
+    core::date::Date,
+    core::{Error, SpotifyUri},
     metadata::audio::UniqueFields,
     playback::player::{Player, PlayerEvent},
 };
@@ -312,13 +313,272 @@ impl MprisService {
     }
 }
 
+/// MPRIS-specific metadata
+#[derive(Default, Clone)]
+struct MprisMetadata {
+    /// D-Bus path: A unique identity for this track within the context of an MPRIS object (eg: tracklist).
+    track_id: Option<SpotifyUri>,
+    /// 64-bit integer: The duration of the track in microseconds.
+    length: Option<i64>,
+    /// URI: The location of an image representing the track or album. Clients should not assume this will continue to exist when the media player stops giving out the URL.
+    art_url: Option<String>,
+}
+
+/// Common audio properties from the Xesam specification
+#[derive(Default, Clone)]
+struct XesamMetadata {
+    /// String: The album name.
+    album: Option<String>,
+    /// List of Strings: The album artist(s).
+    album_artist: Option<Vec<String>>,
+    /// List of Strings: The track artist(s).
+    artist: Option<Vec<String>>,
+    /// String: The track lyrics.
+    as_text: Option<String>,
+    /// Integer: The speed of the music, in beats per minute.
+    audio_bpm: Option<u32>,
+    /// Float: An automatically-generated rating, based on things such as how often it has been played. This should be in the range 0.0 to 1.0.
+    auto_rating: Option<f64>,
+    /// List of Strings: A (list of) freeform comment(s).
+    comment: Option<Vec<String>>,
+    /// List of Strings: The composer(s) of the track.
+    composer: Option<Vec<String>>,
+    /// Date/Time: When the track was created. Usually only the year component will be useful.
+    content_created: Option<Date>,
+    /// Integer: The disc number on the album that this track is from.
+    disc_number: Option<i32>,
+    /// Date/Time: When the track was first played.
+    first_used: Option<Date>,
+    /// List of Strings: The genre(s) of the track.
+    genre: Option<Vec<String>>,
+    /// Date/Time: When the track was last played.
+    last_used: Option<Date>,
+    /// List of Strings: The lyricist(s) of the track.
+    lyricist: Option<Vec<String>>,
+    /// String: The track title.
+    title: Option<String>,
+    /// Integer: The track number on the album disc.
+    track_number: Option<i32>,
+    /// URI: The location of the media file.
+    url: Option<String>,
+    /// Integer: The number of times the track has been played.
+    use_count: Option<u16>,
+    /// Float: A user-specified rating. This should be in the range 0.0 to 1.0.
+    user_rating: Option<f64>,
+}
+
+impl From<UniqueFields> for XesamMetadata {
+    fn from(value: UniqueFields) -> Self {
+        let mut xesam = Self::default();
+
+        match value {
+            UniqueFields::Track {
+                artists,
+                album,
+                album_date,
+                album_artists,
+                popularity: _,
+                number,
+                disc_number,
+            } => {
+                let artists = artists
+                    .0
+                    .into_iter()
+                    .map(|a| a.name)
+                    .collect::<Vec<String>>();
+                xesam.artist = Some(artists);
+                xesam.album_artist = Some(album_artists);
+                xesam.album = Some(album);
+                xesam.track_number = Some(number as i32);
+                xesam.disc_number = Some(disc_number as i32);
+                xesam.content_created = Some(album_date);
+            }
+            UniqueFields::Episode {
+                description,
+                publish_time,
+                show_name,
+            } => {
+                xesam.album = Some(show_name);
+                xesam.comment = Some(vec![description]);
+                xesam.content_created = Some(publish_time);
+            }
+            UniqueFields::Local {
+                artists,
+                album,
+                album_artists,
+                number,
+                disc_number,
+                path,
+            } => {
+                xesam.artist = artists.map(|artists| vec![artists]);
+                xesam.album_artist = album_artists.map(|album_artists| vec![album_artists]);
+                xesam.album = album;
+                xesam.track_number = number.map(|number| number as i32);
+                xesam.disc_number = disc_number.map(|disc_number| disc_number as i32);
+                xesam.url = Some(format!("file://{}", path.display()));
+            }
+        }
+
+        xesam
+    }
+}
+
+#[derive(Default, Clone)]
+struct Metadata {
+    mpris: MprisMetadata,
+    xesam: XesamMetadata,
+}
+
+impl TryInto<HashMap<String, zbus::zvariant::OwnedValue>> for Metadata {
+    type Error = zbus::Error;
+
+    fn try_into(self) -> Result<HashMap<String, zbus::zvariant::OwnedValue>, Self::Error> {
+        let mut meta: HashMap<String, zbus::zvariant::OwnedValue> = HashMap::new();
+
+        let track_id = self.mpris.track_id.map(|track_id| {
+            track_id
+                .to_id()
+                .map(|id| format!("/org/librespot/track/{id}"))
+                .ok()
+        });
+        let track_id = track_id
+            .flatten()
+            .unwrap_or(" /org/mpris/MediaPlayer2/TrackList/NoTrack".to_string());
+        meta.insert(
+            String::from("mpris:trackId"),
+            zvariant::ObjectPath::try_from(track_id)?.into(),
+        );
+
+        if let Some(length) = self.mpris.length {
+            meta.insert(String::from("mpris:length"), length.into());
+        }
+        if let Some(art_url) = self.mpris.art_url {
+            meta.insert(
+                String::from("mpris:artUrl"),
+                zvariant::Str::from(art_url).into(),
+            );
+        }
+
+        if let Some(album) = self.xesam.album {
+            meta.insert(
+                String::from("xesam:album"),
+                zvariant::Str::from(album).into(),
+            );
+        }
+        if let Some(album_artist) = self.xesam.album_artist {
+            meta.insert(
+                String::from("xesam:albumArtist"),
+                zvariant::Array::from(album_artist).try_into()?,
+            );
+        }
+        if let Some(artist) = self.xesam.artist {
+            meta.insert(
+                String::from("xesam:artist"),
+                zvariant::Array::from(artist).try_into()?,
+            );
+        }
+        if let Some(as_text) = self.xesam.as_text {
+            meta.insert(
+                String::from("xesam:asText"),
+                zvariant::Str::from(as_text).into(),
+            );
+        }
+        if let Some(audio_bpm) = self.xesam.audio_bpm {
+            meta.insert(String::from("xesam:audioBPM"), audio_bpm.into());
+        }
+        if let Some(auto_rating) = self.xesam.auto_rating {
+            meta.insert(String::from("xesam:autoRating"), auto_rating.into());
+        }
+        if let Some(comment) = self.xesam.comment {
+            meta.insert(
+                String::from("xesam:comment"),
+                zvariant::Array::from(comment).try_into()?,
+            );
+        }
+        if let Some(composer) = self.xesam.composer {
+            meta.insert(
+                String::from("xesam:composer"),
+                zvariant::Array::from(composer).try_into()?,
+            );
+        }
+        if let Some(content_created) = self.xesam.content_created {
+            meta.insert(
+                String::from("xesam:contentCreated"),
+                zvariant::Str::from(
+                    content_created
+                        .format(&Iso8601::DEFAULT)
+                        .map_err(|err| zvariant::Error::Message(format!("{err}")))?,
+                )
+                .into(),
+            );
+        }
+        if let Some(disc_number) = self.xesam.disc_number {
+            meta.insert(String::from("xesam:discNumber"), disc_number.into());
+        }
+        if let Some(first_used) = self.xesam.first_used {
+            meta.insert(
+                String::from("xesam:firstUsed"),
+                zvariant::Str::from(
+                    first_used
+                        .format(&Iso8601::DEFAULT)
+                        .map_err(|err| zvariant::Error::Message(format!("{err}")))?,
+                )
+                .into(),
+            );
+        }
+        if let Some(genre) = self.xesam.genre {
+            meta.insert(
+                String::from("xesam:genre"),
+                zvariant::Array::from(genre).try_into()?,
+            );
+        }
+        if let Some(last_used) = self.xesam.last_used {
+            meta.insert(
+                String::from("xesam:lastUsed"),
+                zvariant::Str::from(
+                    last_used
+                        .format(&Iso8601::DEFAULT)
+                        .map_err(|err| zvariant::Error::Message(format!("{err}")))?,
+                )
+                .into(),
+            );
+        }
+        if let Some(lyricist) = self.xesam.lyricist {
+            meta.insert(
+                String::from("xesam:lyricist"),
+                zvariant::Array::from(lyricist).try_into()?,
+            );
+        }
+        if let Some(title) = self.xesam.title {
+            meta.insert(
+                String::from("xesam:title"),
+                zvariant::Str::from(title).into(),
+            );
+        }
+        if let Some(track_number) = self.xesam.track_number {
+            meta.insert(String::from("xesam:trackNumber"), track_number.into());
+        }
+        if let Some(url) = self.xesam.url {
+            meta.insert(String::from("xesam:url"), zvariant::Str::from(url).into());
+        }
+        if let Some(use_count) = self.xesam.use_count {
+            meta.insert(String::from("xesam:useCount"), use_count.into());
+        }
+        if let Some(user_rating) = self.xesam.user_rating {
+            meta.insert(String::from("xesam:userRating"), user_rating.into());
+        }
+
+        Ok(meta)
+    }
+}
+
 struct MprisPlayerService {
     spirc: Option<Spirc>,
     repeat: LoopStatus,
     shuffle: bool,
     playback_status: PlaybackStatus,
     volume: u16,
-    metadata: HashMap<String, zbus::zvariant::OwnedValue>,
+    metadata: Metadata,
 }
 
 // This interface implements the methods for querying and providing basic
@@ -597,20 +857,10 @@ impl MprisPlayerService {
     async fn metadata(
         &self,
     ) -> zbus::fdo::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>> {
-        let meta = if self.metadata.is_empty() {
-            let mut meta = HashMap::new();
-            meta.insert(
-                "mpris:trackid".to_owned(),
-                zvariant::Str::from(" /org/mpris/MediaPlayer2/TrackList/NoTrack").into(),
-            );
-            meta
-        } else {
-            self.metadata
-                .iter()
-                .map(|(k, v)| (k.clone(), v.try_clone().unwrap()))
-                .collect()
-        };
-        Ok(meta)
+        self.metadata
+            .clone()
+            .try_into()
+            .map_err(zbus::fdo::Error::ZBus)
     }
 
     // The volume level.
@@ -725,7 +975,7 @@ impl MprisPlayerService {
     //     "current track".
     #[zbus(property(emits_changed_signal = "true"))]
     async fn can_play(&self) -> bool {
-        !self.metadata.is_empty()
+        self.metadata.mpris.track_id.is_some()
     }
 
     // Whether playback can be paused using `Pause` or `PlayPause`.
@@ -743,7 +993,7 @@ impl MprisPlayerService {
     //     streamed media, for example.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn can_pause(&self) -> bool {
-        !self.metadata.is_empty()
+        self.metadata.mpris.track_id.is_some()
     }
 
     // Whether the client can control the playback position using `Seek` and `SetPosition`.  This
@@ -841,7 +1091,7 @@ impl MprisEventHandler {
             shuffle: false,
             playback_status: PlaybackStatus::Stopped,
             volume: u16::MAX,
-            metadata: HashMap::new(),
+            metadata: Metadata::default(),
         };
 
         connection::Builder::session()?
@@ -954,199 +1204,86 @@ impl MprisTask {
         match event {
             PlayerEvent::PlayRequestIdChanged { play_request_id: _ } => {}
             PlayerEvent::TrackChanged { audio_item } => {
-                match audio_item.track_id.to_id() {
-                    Err(e) => {
-                        warn!("PlayerEvent::TrackChanged: Invalid track id: {e}")
-                    }
-                    Ok(track_id) => {
-                        let iface_ref = self.mpris_player_iface().await;
-                        let mut iface = iface_ref.get_mut().await;
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
 
-                        let meta = &mut iface.metadata;
-                        meta.clear();
+                let meta = &mut iface.metadata;
+                *meta = Metadata::default();
 
-                        let mut trackid = String::new();
-                        trackid.push_str("/org/librespot/track/");
-                        trackid.push_str(&track_id);
-                        meta.insert(
-                            "mpris:trackid".into(),
-                            zvariant::ObjectPath::try_from(trackid).unwrap().into(),
-                        );
+                meta.mpris.track_id = Some(audio_item.track_id);
+                meta.xesam.title = Some(audio_item.name);
 
-                        meta.insert(
-                            "xesam:title".into(),
-                            zvariant::Str::from(audio_item.name).into(),
-                        );
+                // TODO: Select image by size
+                let url = &audio_item.covers[0].url;
+                meta.mpris.art_url = Some(String::from(url));
 
-                        if audio_item.covers.is_empty() {
-                            meta.remove("mpris:artUrl");
-                        } else {
-                            // TODO: Select image by size
-                            let url = &audio_item.covers[0].url;
-                            meta.insert("mpris.artUrl".into(), zvariant::Str::from(url).into());
-                        }
+                meta.mpris.length = Some(audio_item.duration_ms as i64 * 1000);
 
-                        meta.insert(
-                            "mpris:length".into(),
-                            (audio_item.duration_ms as i64 * 1000).into(),
-                        );
+                meta.xesam = audio_item.unique_fields.into();
 
-                        match audio_item.unique_fields {
-                            UniqueFields::Track {
-                                artists,
-                                album,
-                                album_date,
-                                album_artists,
-                                popularity: _,
-                                number,
-                                disc_number,
-                            } => {
-                                let artists = artists
-                                    .0
-                                    .into_iter()
-                                    .map(|a| a.name)
-                                    .collect::<Vec<String>>();
-                                meta.insert(
-                                    "xesam:artist".into(),
-                                    // try_to_owned only fails if the Value contains file
-                                    // descriptors, so the unwrap never panics here
-                                    zvariant::Value::from(artists).try_to_owned().unwrap(),
-                                );
-
-                                meta.insert(
-                                    "xesam:albumArtist".into(),
-                                    // try_to_owned only fails if the Value contains file
-                                    // descriptors, so the unwrap never panics here
-                                    zvariant::Value::from(&album_artists)
-                                        .try_to_owned()
-                                        .unwrap(),
-                                );
-
-                                meta.insert(
-                                    "xesam:album".into(),
-                                    zvariant::Str::from(album).into(),
-                                );
-
-                                meta.insert("xesam:trackNumber".into(), (number as i32).into());
-
-                                meta.insert("xesam:discNumber".into(), (disc_number as i32).into());
-
-                                meta.insert(
-                                    "xesam:contentCreated".into(),
-                                    zvariant::Str::from(
-                                        album_date.0.format(&Iso8601::DATE).unwrap(),
-                                    )
-                                    .into(),
-                                );
-                            }
-                            UniqueFields::Episode {
-                                description,
-                                publish_time,
-                                show_name,
-                            } => {
-                                meta.insert(
-                                    "xesam:album".into(),
-                                    zvariant::Str::from(show_name).into(),
-                                );
-
-                                meta.insert(
-                                    "xesam:comment".into(),
-                                    zvariant::Str::from(description).into(),
-                                );
-
-                                meta.insert(
-                                    "xesam:contentCreated".into(),
-                                    zvariant::Str::from(
-                                        publish_time.0.format(&Iso8601::DATE).unwrap(),
-                                    )
-                                    .into(),
-                                );
-                            }
-                        }
-
-                        iface.metadata_changed(iface_ref.signal_context()).await?;
-                    }
-                }
+                iface.metadata_changed(iface_ref.signal_context()).await?;
             }
-            PlayerEvent::Stopped { track_id, .. } => match track_id.to_id() {
-                Err(e) => warn!("PlayerEvent::Stopped: Invalid track id: {e}"),
-                Ok(track_id) => {
-                    let iface_ref = self.mpris_player_iface().await;
-                    let mut iface = iface_ref.get_mut().await;
-                    let meta = &mut iface.metadata;
+            PlayerEvent::Stopped { track_id, .. } => {
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
+                let meta = &mut iface.metadata;
 
-                    // TODO: Check if metadata changed, if so clear
-                    let mut trackid = String::new();
-                    trackid.push_str("/org/librespot/track/");
-                    trackid.push_str(&track_id);
-                    meta.insert(
-                        "mpris:trackid".into(),
-                        zvariant::ObjectPath::try_from(trackid).unwrap().into(),
-                    );
+                if meta.mpris.track_id.as_ref() != Some(&track_id) {
+                    *meta = Metadata::default();
+                    meta.mpris.track_id = Some(track_id);
+                    // TODO: Fetch all metadata from AudioItem
                     iface.metadata_changed(iface_ref.signal_context()).await?;
-
-                    iface.playback_status = PlaybackStatus::Stopped;
-                    iface
-                        .playback_status_changed(iface_ref.signal_context())
-                        .await?;
                 }
-            },
+
+                iface.playback_status = PlaybackStatus::Stopped;
+                iface
+                    .playback_status_changed(iface_ref.signal_context())
+                    .await?;
+            }
             PlayerEvent::Playing {
                 track_id,
                 // position_ms,
                 ..
-            } => match track_id.to_id() {
-                Err(e) => warn!("PlayerEvent::Playing: Invalid track id: {e}"),
-                Ok(track_id) => {
-                    // TODO: update position
-                    let iface_ref = self.mpris_player_iface().await;
-                    let mut iface = iface_ref.get_mut().await;
-                    let meta = &mut iface.metadata;
+            } => {
+                // TODO: update position
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
+                let meta = &mut iface.metadata;
 
-                    // TODO: Check if metadata changed, if so clear
-                    let mut trackid = String::new();
-                    trackid.push_str("/org/librespot/track/");
-                    trackid.push_str(&track_id);
-                    meta.insert(
-                        "mpris:trackid".into(),
-                        zvariant::ObjectPath::try_from(trackid).unwrap().into(),
-                    );
+                if meta.mpris.track_id.as_ref() != Some(&track_id) {
+                    *meta = Metadata::default();
+                    meta.mpris.track_id = Some(track_id);
+                    // TODO: Fetch all metadata from AudioItem
                     iface.metadata_changed(iface_ref.signal_context()).await?;
-
-                    iface.playback_status = PlaybackStatus::Playing;
-                    iface
-                        .playback_status_changed(iface_ref.signal_context())
-                        .await?;
                 }
-            },
+
+                iface.playback_status = PlaybackStatus::Playing;
+                iface
+                    .playback_status_changed(iface_ref.signal_context())
+                    .await?;
+            }
             PlayerEvent::Paused {
                 track_id,
                 // position_ms,
                 ..
-            } => match track_id.to_id() {
-                Err(e) => warn!("PlayerEvent::Paused: Invalid track id: {e}"),
-                Ok(track_id) => {
-                    // TODO: update position
-                    let iface_ref = self.mpris_player_iface().await;
-                    let mut iface = iface_ref.get_mut().await;
-                    let meta = &mut iface.metadata;
+            } => {
+                // TODO: update position
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
+                let meta = &mut iface.metadata;
 
-                    // TODO: Check if metadata changed, if so clear
-                    let mut trackid = String::new();
-                    trackid.push_str("/org/librespot/track/");
-                    trackid.push_str(&track_id);
-                    meta.insert(
-                        "mpris:trackid".into(),
-                        zvariant::ObjectPath::try_from(trackid).unwrap().into(),
-                    );
+                if meta.mpris.track_id.as_ref() != Some(&track_id) {
+                    *meta = Metadata::default();
+                    meta.mpris.track_id = Some(track_id);
+                    // TODO: Fetch all metadata from AudioItem
                     iface.metadata_changed(iface_ref.signal_context()).await?;
-
-                    iface.playback_status = PlaybackStatus::Paused;
-                    iface
-                        .playback_status_changed(iface_ref.signal_context())
-                        .await?;
                 }
-            },
+
+                iface.playback_status = PlaybackStatus::Paused;
+                iface
+                    .playback_status_changed(iface_ref.signal_context())
+                    .await?;
+            }
             PlayerEvent::Loading { .. } => {}
             PlayerEvent::Preloading { .. } => {}
             PlayerEvent::TimeToPreloadNextTrack { .. } => {}
@@ -1169,39 +1306,46 @@ impl MprisTask {
                 track_id,
                 // position_ms,
                 ..
-            } => match track_id.to_id() {
-                Err(e) => warn!("PlayerEvent::Seeked: Invalid track id: {e}"),
-                Ok(track_id) => {
-                    // TODO: Update position + track_id
-                    let iface_ref = self.mpris_player_iface().await;
-                    let mut iface = iface_ref.get_mut().await;
-                    let meta = &mut iface.metadata;
+            } => {
+                // TODO: Update position + track_id
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
+                let meta = &mut iface.metadata;
 
-                    // TODO: Check if metadata changed, if so clear
-                    let mut trackid = String::new();
-                    trackid.push_str("/org/librespot/track/");
-                    trackid.push_str(&track_id);
-                    meta.insert(
-                        "mpris:trackid".into(),
-                        zvariant::ObjectPath::try_from(trackid).unwrap().into(),
-                    );
+                if meta.mpris.track_id.as_ref() != Some(&track_id) {
+                    *meta = Metadata::default();
+                    meta.mpris.track_id = Some(track_id);
+                    // TODO: Fetch all metadata from AudioItem
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
-            },
+            }
             PlayerEvent::PositionCorrection {
                 track_id,
                 // position_ms,
                 ..
-            } => match track_id.to_id() {
-                Err(e) => {
-                    warn!("PlayerEvent::PositionCorrection: Invalid track id: {e}")
+            } => {
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
+                let meta = &mut iface.metadata;
+
+                if meta.mpris.track_id.as_ref() != Some(&track_id) {
+                    *meta = Metadata::default();
+                    meta.mpris.track_id = Some(track_id);
+                    // TODO: Fetch all metadata from AudioItem
+                    iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
-                Ok(_id) => {
-                    // TODO: Update position + track_id
+            }
+            PlayerEvent::PositionChanged { track_id, .. } => {
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
+                let meta = &mut iface.metadata;
+
+                if meta.mpris.track_id.as_ref() != Some(&track_id) {
+                    *meta = Metadata::default();
+                    meta.mpris.track_id = Some(track_id);
+                    // TODO: Fetch all metadata from AudioItem
+                    iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
-            },
-            PlayerEvent::PositionChanged { .. } => {
-                // TODO
             }
             PlayerEvent::SessionConnected { .. } => {}
             PlayerEvent::SessionDisconnected { .. } => {}

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1482,6 +1482,7 @@ impl MprisTask {
             }
             PlayerEvent::AutoPlayChanged { .. } => {}
             PlayerEvent::FilterExplicitContentChanged { .. } => {}
+            PlayerEvent::SetQueue { .. } => {}
         }
 
         Ok(())

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -748,12 +748,12 @@ impl MprisPlayerService {
             return;
         }
         if let Some(spirc) = &self.spirc {
-            let current_track_id = self.metadata.mpris.track_id.as_ref().and_then(|track_id| {
-                track_id
-                    .to_id()
-                    .ok()
-                    .map(|id| format!("/org/librespot/track/{id}"))
-            });
+            let current_track_id = self
+                .metadata
+                .mpris
+                .track_id
+                .as_ref()
+                .map(|track_id| format!("/org/librespot/track/{}", track_id.to_id()));
             if current_track_id.as_deref() == Some(track_id.as_str()) {
                 let _ = spirc.set_position_ms((position / 1000) as u32);
             } else {

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1126,7 +1126,6 @@ impl MprisPlayerService {
     // * `position`: The new position, in microseconds.
     #[zbus(signal)]
     async fn seeked(signal_ctxt: &zbus::SignalContext<'_>, position: TimeInUs) -> zbus::Result<()>;
-    // FIXME: signal on appropriate player events!
 }
 
 #[derive(Debug, Error)]
@@ -1428,8 +1427,10 @@ impl MprisTask {
 
                 iface.position = Some(Position::from(position_ms));
 
-                let meta = &mut iface.metadata;
+                MprisPlayerService::seeked(iface_ref.signal_context(), position_ms as i64 * 1000)
+                    .await?;
 
+                let meta = &mut iface.metadata;
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
@@ -1447,8 +1448,10 @@ impl MprisTask {
 
                 iface.position = Some(Position::from(position_ms));
 
-                let meta = &mut iface.metadata;
+                MprisPlayerService::seeked(iface_ref.signal_context(), position_ms as i64 * 1000)
+                    .await?;
 
+                let meta = &mut iface.metadata;
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
@@ -1466,8 +1469,10 @@ impl MprisTask {
 
                 iface.position = Some(Position::from(position_ms));
 
-                let meta = &mut iface.metadata;
+                MprisPlayerService::seeked(iface_ref.signal_context(), position_ms as i64 * 1000)
+                    .await?;
 
+                let meta = &mut iface.metadata;
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -636,11 +636,16 @@ impl MprisPlayerService {
     // Calling Play after this should cause playback to start again from the same position.
     //
     // If `self.can_pause` is `false`, attempting to call this method should have no effect.
-    async fn pause(&self) {
+    async fn pause(&self) -> zbus::fdo::Result<()> {
         debug!("org.mpris.MediaPlayer2.Player::Pause");
-        // FIXME: This should return an error if can_pause is false
-        if let Some(spirc) = &self.spirc {
-            let _ = spirc.pause();
+        match (&self.spirc, &self.metadata.mpris.track_id) {
+            (Some(spirc), Some(_)) => spirc
+                .pause()
+                .map_err(|err| zbus::fdo::Error::Failed(format!("{err}"))),
+            (Some(_), None) => {
+                zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("No track")))
+            }
+            _ => zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("Can't play/pause"))),
         }
     }
 
@@ -652,11 +657,16 @@ impl MprisPlayerService {
     //
     // If `self.can_pause` is `false`, attempting to call this method should have no effect and
     // raise an error.
-    async fn play_pause(&self) {
+    async fn play_pause(&self) -> zbus::fdo::Result<()> {
         debug!("org.mpris.MediaPlayer2.Player::PlayPause");
-        // FIXME: This should return an error if can_pause is false
-        if let Some(spirc) = &self.spirc {
-            let _ = spirc.play_pause();
+        match (&self.spirc, &self.metadata.mpris.track_id) {
+            (Some(spirc), Some(_)) => spirc
+                .play_pause()
+                .map_err(|err| zbus::fdo::Error::Failed(format!("{err}"))),
+            (Some(_), None) => {
+                zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("No track")))
+            }
+            _ => zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("Can't play/pause"))),
         }
     }
 
@@ -671,7 +681,6 @@ impl MprisPlayerService {
     // an error.
     async fn stop(&self) {
         debug!("org.mpris.MediaPlayer2.Player::Stop");
-        // FIXME: This should return an error if can_control is false
         if let Some(spirc) = &self.spirc {
             let _ = spirc.pause();
             let _ = spirc.set_position_ms(0);
@@ -687,11 +696,24 @@ impl MprisPlayerService {
     // If there is no track to play, this has no effect.
     //
     // If `self.can_play` is `false`, attempting to call this method should have no effect.
-    async fn play(&self) {
+    async fn play(&self) -> zbus::fdo::Result<()> {
         debug!("org.mpris.MediaPlayer2.Player::Play");
         if let Some(spirc) = &self.spirc {
             let _ = spirc.activate();
             let _ = spirc.play();
+        }
+        match (&self.spirc, &self.metadata.mpris.track_id) {
+            (Some(spirc), Some(_)) => {
+                let result: Result<(), Error> = (|| {
+                    spirc.activate()?;
+                    spirc.play()
+                })();
+                result.map_err(|err| zbus::fdo::Error::Failed(format!("{err}")))
+            }
+            (Some(_), None) => {
+                zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("No track")))
+            }
+            _ => zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("Can't play/pause"))),
         }
     }
 

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1241,9 +1241,15 @@ impl MprisTask {
                 meta.mpris.track_id = Some(audio_item.track_id);
                 meta.xesam.title = Some(audio_item.name);
 
-                // TODO: Select image by size
-                let url = &audio_item.covers[0].url;
-                meta.mpris.art_url = Some(String::from(url));
+                // Choose biggest cover
+                if let Some(url) = audio_item
+                    .covers
+                    .iter()
+                    .max_by(|a, b| (a.size as u8).cmp(&(b.size as u8)))
+                    .map(|cover| &cover.url)
+                {
+                    meta.mpris.art_url = Some(String::from(url));
+                }
 
                 meta.mpris.length = Some(audio_item.duration_ms as i64 * 1000);
 

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -153,6 +153,7 @@ type TimeInUs = i64;
 
 struct MprisService {
     identity: String,
+    desktop_entry: Option<String>,
 }
 
 #[zbus::interface(name = "org.mpris.MediaPlayer2")]
@@ -277,7 +278,7 @@ impl MprisService {
         debug!("org.mpris.MediaPlayer2::DesktopEntry");
         // FIXME: The spec doesn't say anything about the case when there is no .desktop.
         // Is there any convention? Any value that common clients handle in a sane way?
-        "".to_owned()
+        self.desktop_entry.clone().unwrap_or_default()
     }
 
     // The URI schemes supported by the media player.
@@ -1138,9 +1139,14 @@ pub struct MprisEventHandler {
 }
 
 impl MprisEventHandler {
-    fn connection_builder<'a>(identity: &str, name: &str) -> zbus::Result<connection::Builder<'a>> {
+    fn connection_builder<'a>(
+        identity: &str,
+        name: &str,
+        desktop_entry: Option<&str>,
+    ) -> zbus::Result<connection::Builder<'a>> {
         let mpris_service = MprisService {
             identity: identity.to_string(),
+            desktop_entry: desktop_entry.map(|desktop_entry| desktop_entry.to_string()),
         };
         let mpris_player_service = MprisPlayerService {
             spirc: None,
@@ -1160,19 +1166,26 @@ impl MprisEventHandler {
             .serve_at("/org/mpris/MediaPlayer2", mpris_player_service)
     }
 
-    pub async fn spawn(player: Arc<Player>, name: &str) -> Result<MprisEventHandler, MprisError> {
+    pub async fn spawn(
+        player: Arc<Player>,
+        name: &str,
+        desktop_entry: Option<&str>,
+    ) -> Result<MprisEventHandler, MprisError> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
 
-        let connection = Self::connection_builder(name, "org.mpris.MediaPlayer2.librespot")?
-            .build()
-            .await;
+        let connection =
+            Self::connection_builder(name, "org.mpris.MediaPlayer2.librespot", desktop_entry)?
+                .build()
+                .await;
         let connection = match connection {
             Err(zbus::Error::NameTaken) => {
                 let pid_name =
                     format!("org.mpris.MediaPlayer2.librespot.instance{}", process::id());
                 warn!("zbus name taken, trying with pid specific name: {pid_name}");
 
-                Self::connection_builder(name, &pid_name)?.build().await
+                Self::connection_builder(name, &pid_name, desktop_entry)?
+                    .build()
+                    .await
             }
             _ => connection,
         }?;

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, process, sync::Arc};
+use std::{collections::HashMap, process, sync::Arc, time::Instant};
 
 use librespot_connect::Spirc;
 use log::{debug, warn};
@@ -572,12 +572,27 @@ impl TryInto<HashMap<String, zbus::zvariant::OwnedValue>> for Metadata {
     }
 }
 
+struct Position {
+    ms: u32,
+    last_update: Instant,
+}
+
+impl From<u32> for Position {
+    fn from(value: u32) -> Self {
+        Self {
+            ms: value,
+            last_update: Instant::now(),
+        }
+    }
+}
+
 struct MprisPlayerService {
     spirc: Option<Spirc>,
     repeat: LoopStatus,
     shuffle: bool,
     playback_status: PlaybackStatus,
     volume: u16,
+    position: Option<Position>,
     metadata: Metadata,
 }
 
@@ -919,8 +934,15 @@ impl MprisPlayerService {
     #[zbus(property(emits_changed_signal = "false"))]
     async fn position(&self) -> zbus::fdo::Result<TimeInUs> {
         debug!("org.mpris.MediaPlayer2.Player::Position");
-        // todo!("fetch up-to-date position from player")
-        Ok(0)
+
+        self.position
+            .as_ref()
+            .map(|position| {
+                let corrected = (position.ms as u128)
+                    .saturating_add(position.last_update.elapsed().as_millis());
+                corrected as i64 * 1000
+            })
+            .ok_or(zbus::fdo::Error::Failed(String::from("Got no position")))
     }
 
     // The minimum value which the `Rate` property can take. Clients should not attempt to set the
@@ -1119,6 +1141,7 @@ impl MprisEventHandler {
             shuffle: false,
             playback_status: PlaybackStatus::Stopped,
             volume: u16::MAX,
+            position: None,
             metadata: Metadata::default(),
         };
 
@@ -1276,12 +1299,14 @@ impl MprisTask {
             }
             PlayerEvent::Playing {
                 track_id,
-                // position_ms,
+                position_ms,
                 ..
             } => {
-                // TODO: update position
                 let iface_ref = self.mpris_player_iface().await;
                 let mut iface = iface_ref.get_mut().await;
+
+                iface.position = Some(Position::from(position_ms));
+
                 let meta = &mut iface.metadata;
 
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
@@ -1298,12 +1323,14 @@ impl MprisTask {
             }
             PlayerEvent::Paused {
                 track_id,
-                // position_ms,
+                position_ms,
                 ..
             } => {
-                // TODO: update position
                 let iface_ref = self.mpris_player_iface().await;
                 let mut iface = iface_ref.get_mut().await;
+
+                iface.position = Some(Position::from(position_ms));
+
                 let meta = &mut iface.metadata;
 
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
@@ -1322,15 +1349,20 @@ impl MprisTask {
             PlayerEvent::Preloading { .. } => {}
             PlayerEvent::TimeToPreloadNextTrack { .. } => {}
             PlayerEvent::EndOfTrack { track_id, .. } => {
-                // TODO: Update position
                 let iface_ref = self.mpris_player_iface().await;
                 let mut iface = iface_ref.get_mut().await;
                 let meta = &mut iface.metadata;
 
-                if meta.mpris.track_id.as_ref() != Some(&track_id) {
+                if meta.mpris.track_id.as_ref() == Some(&track_id) {
+                    iface.position = meta
+                        .mpris
+                        .length
+                        .map(|length| Position::from((length as f64 / 1000.) as u32));
+                } else {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
                     warn!("Missed TrackChanged event, metadata missing");
+                    iface.position = None;
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
             }
@@ -1345,12 +1377,14 @@ impl MprisTask {
             }
             PlayerEvent::Seeked {
                 track_id,
-                // position_ms,
+                position_ms,
                 ..
             } => {
-                // TODO: Update position
                 let iface_ref = self.mpris_player_iface().await;
                 let mut iface = iface_ref.get_mut().await;
+
+                iface.position = Some(Position::from(position_ms));
+
                 let meta = &mut iface.metadata;
 
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
@@ -1362,11 +1396,14 @@ impl MprisTask {
             }
             PlayerEvent::PositionCorrection {
                 track_id,
-                // position_ms,
+                position_ms,
                 ..
             } => {
                 let iface_ref = self.mpris_player_iface().await;
                 let mut iface = iface_ref.get_mut().await;
+
+                iface.position = Some(Position::from(position_ms));
+
                 let meta = &mut iface.metadata;
 
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
@@ -1376,9 +1413,16 @@ impl MprisTask {
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
             }
-            PlayerEvent::PositionChanged { track_id, .. } => {
+            PlayerEvent::PositionChanged {
+                track_id,
+                position_ms,
+                ..
+            } => {
                 let iface_ref = self.mpris_player_iface().await;
                 let mut iface = iface_ref.get_mut().await;
+
+                iface.position = Some(Position::from(position_ms));
+
                 let meta = &mut iface.metadata;
 
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -425,15 +425,11 @@ impl TryInto<HashMap<String, zbus::zvariant::OwnedValue>> for Metadata {
     fn try_into(self) -> Result<HashMap<String, zbus::zvariant::OwnedValue>, Self::Error> {
         let mut meta: HashMap<String, zbus::zvariant::OwnedValue> = HashMap::new();
 
-        let track_id = self.mpris.track_id.map(|track_id| {
-            track_id
-                .to_id()
-                .map(|id| format!("/org/librespot/track/{id}"))
-                .ok()
-        });
-        let track_id = track_id
-            .flatten()
-            .unwrap_or(" /org/mpris/MediaPlayer2/TrackList/NoTrack".to_string());
+        let track_id = self
+            .mpris
+            .track_id
+            .map(|track_id| format!("/org/librespot/track/{}", track_id.to_id()));
+        let track_id = track_id.unwrap_or(" /org/mpris/MediaPlayer2/TrackList/NoTrack".to_string());
         meta.insert(
             String::from("mpris:trackId"),
             zvariant::ObjectPath::try_from(track_id)?.into(),

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1321,12 +1321,19 @@ impl MprisTask {
             PlayerEvent::Loading { .. } => {}
             PlayerEvent::Preloading { .. } => {}
             PlayerEvent::TimeToPreloadNextTrack { .. } => {}
-            PlayerEvent::EndOfTrack { track_id, .. } => match track_id.to_id() {
-                Err(e) => warn!("PlayerEvent::EndOfTrack: Invalid track id: {e}"),
-                Ok(_id) => {
-                    // TODO: ?
+            PlayerEvent::EndOfTrack { track_id, .. } => {
+                // TODO: Update position
+                let iface_ref = self.mpris_player_iface().await;
+                let mut iface = iface_ref.get_mut().await;
+                let meta = &mut iface.metadata;
+
+                if meta.mpris.track_id.as_ref() != Some(&track_id) {
+                    *meta = Metadata::default();
+                    meta.mpris.track_id = Some(track_id);
+                    warn!("Missed TrackChanged event, metadata missing");
+                    iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
-            },
+            }
             PlayerEvent::Unavailable { .. } => {}
             PlayerEvent::VolumeChanged { volume, .. } => {
                 let iface_ref = self.mpris_player_iface().await;
@@ -1341,7 +1348,7 @@ impl MprisTask {
                 // position_ms,
                 ..
             } => {
-                // TODO: Update position + track_id
+                // TODO: Update position
                 let iface_ref = self.mpris_player_iface().await;
                 let mut iface = iface_ref.get_mut().await;
                 let meta = &mut iface.metadata;

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -5,7 +5,7 @@ use log::{debug, info, warn};
 use thiserror::Error;
 use time::format_description::well_known::Iso8601;
 use tokio::sync::mpsc;
-use zbus::connection;
+use zbus::{connection, fdo};
 
 use librespot::{
     core::date::Date,
@@ -636,16 +636,14 @@ impl MprisPlayerService {
     // Calling Play after this should cause playback to start again from the same position.
     //
     // If `self.can_pause` is `false`, attempting to call this method should have no effect.
-    async fn pause(&self) -> zbus::fdo::Result<()> {
+    async fn pause(&self) -> fdo::Result<()> {
         debug!("org.mpris.MediaPlayer2.Player::Pause");
         match (&self.spirc, &self.metadata.mpris.track_id) {
             (Some(spirc), Some(_)) => spirc
                 .pause()
-                .map_err(|err| zbus::fdo::Error::Failed(format!("{err}"))),
-            (Some(_), None) => {
-                zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("No track")))
-            }
-            _ => zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("Can't play/pause"))),
+                .map_err(|err| fdo::Error::Failed(format!("{err}"))),
+            (Some(_), None) => fdo::Result::Err(fdo::Error::Failed(String::from("No track"))),
+            _ => fdo::Result::Err(fdo::Error::Failed(String::from("Can't play/pause"))),
         }
     }
 
@@ -657,16 +655,14 @@ impl MprisPlayerService {
     //
     // If `self.can_pause` is `false`, attempting to call this method should have no effect and
     // raise an error.
-    async fn play_pause(&self) -> zbus::fdo::Result<()> {
+    async fn play_pause(&self) -> fdo::Result<()> {
         debug!("org.mpris.MediaPlayer2.Player::PlayPause");
         match (&self.spirc, &self.metadata.mpris.track_id) {
             (Some(spirc), Some(_)) => spirc
                 .play_pause()
-                .map_err(|err| zbus::fdo::Error::Failed(format!("{err}"))),
-            (Some(_), None) => {
-                zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("No track")))
-            }
-            _ => zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("Can't play/pause"))),
+                .map_err(|err| fdo::Error::Failed(format!("{err}"))),
+            (Some(_), None) => fdo::Result::Err(fdo::Error::Failed(String::from("No track"))),
+            _ => fdo::Result::Err(fdo::Error::Failed(String::from("Can't play/pause"))),
         }
     }
 
@@ -696,7 +692,7 @@ impl MprisPlayerService {
     // If there is no track to play, this has no effect.
     //
     // If `self.can_play` is `false`, attempting to call this method should have no effect.
-    async fn play(&self) -> zbus::fdo::Result<()> {
+    async fn play(&self) -> fdo::Result<()> {
         debug!("org.mpris.MediaPlayer2.Player::Play");
         if let Some(spirc) = &self.spirc {
             let _ = spirc.activate();
@@ -708,12 +704,10 @@ impl MprisPlayerService {
                     spirc.activate()?;
                     spirc.play()
                 })();
-                result.map_err(|err| zbus::fdo::Error::Failed(format!("{err}")))
+                result.map_err(|err| fdo::Error::Failed(format!("{err}")))
             }
-            (Some(_), None) => {
-                zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("No track")))
-            }
-            _ => zbus::fdo::Result::Err(zbus::fdo::Error::Failed(String::from("Can't play/pause"))),
+            (Some(_), None) => fdo::Result::Err(fdo::Error::Failed(String::from("No track"))),
+            _ => fdo::Result::Err(fdo::Error::Failed(String::from("Can't play/pause"))),
         }
     }
 
@@ -800,11 +794,9 @@ impl MprisPlayerService {
     // * `uri`: Uri of the track to load. Its uri scheme should be an element of the
     //          `org.mpris.MediaPlayer2.SupportedUriSchemes` property and the mime-type should
     //          match one of the elements of the `org.mpris.MediaPlayer2.SupportedMimeTypes`.
-    async fn open_uri(&self, uri: &str) -> zbus::fdo::Result<()> {
+    async fn open_uri(&self, uri: &str) -> fdo::Result<()> {
         debug!("org.mpris.MediaPlayer2.Player::OpenUri({uri:?})");
-        Err(zbus::fdo::Error::NotSupported(
-            "OpenUri not supported".to_owned(),
-        ))
+        Err(fdo::Error::NotSupported("OpenUri not supported".to_owned()))
     }
 
     // The current playback status.
@@ -833,7 +825,7 @@ impl MprisPlayerService {
     }
 
     #[zbus(property)]
-    async fn set_loop_status(&mut self, value: LoopStatus) -> zbus::fdo::Result<()> {
+    async fn set_loop_status(&mut self, value: LoopStatus) -> fdo::Result<()> {
         debug!("org.mpris.MediaPlayer2.Player::LoopStatus({value:?})");
         match value {
             LoopStatus::None => {
@@ -919,12 +911,9 @@ impl MprisPlayerService {
     #[zbus(property(emits_changed_signal = "true"))]
     async fn metadata(
         &self,
-    ) -> zbus::fdo::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>> {
+    ) -> fdo::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>> {
         debug!("org.mpris.MediaPlayer2.Player::Metadata");
-        self.metadata
-            .clone()
-            .try_into()
-            .map_err(zbus::fdo::Error::ZBus)
+        self.metadata.clone().try_into().map_err(fdo::Error::ZBus)
     }
 
     // The volume level.
@@ -940,7 +929,7 @@ impl MprisPlayerService {
     }
 
     #[zbus(property)]
-    async fn set_volume(&mut self, value: Volume) -> zbus::fdo::Result<()> {
+    async fn set_volume(&mut self, value: Volume) -> fdo::Result<()> {
         debug!("org.mpris.MediaPlayer2.Player::Volume({value})");
         if let Some(spirc) = &self.spirc {
             // As of rust 1.45, cast is guaranteed to round to 0 and saturate.
@@ -949,7 +938,7 @@ impl MprisPlayerService {
             let mapped_volume = (value * (u16::MAX as f64)).round() as u16;
             spirc
                 .set_volume(mapped_volume)
-                .map_err(|err| zbus::fdo::Error::Failed(format!("{err}")))?;
+                .map_err(|err| fdo::Error::Failed(format!("{err}")))?;
         }
         Ok(())
     }
@@ -964,7 +953,7 @@ impl MprisPlayerService {
     // If the playback progresses in a way that is inconstistant with the `Rate` property, the
     // `Seeked` signal is emited.
     #[zbus(property(emits_changed_signal = "false"))]
-    async fn position(&self) -> zbus::fdo::Result<TimeInUs> {
+    async fn position(&self) -> fdo::Result<TimeInUs> {
         debug!("org.mpris.MediaPlayer2.Player::Position");
 
         self.position
@@ -974,7 +963,7 @@ impl MprisPlayerService {
                     .saturating_add(position.last_update.elapsed().as_millis());
                 corrected as i64 * 1000
             })
-            .ok_or(zbus::fdo::Error::Failed(String::from("Got no position")))
+            .ok_or(fdo::Error::Failed(String::from("Got no position")))
     }
 
     // The minimum value which the `Rate` property can take. Clients should not attempt to set the

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -592,6 +592,7 @@ impl MprisPlayerService {
     ///
     /// If self.can_go_next is `false`, attempting to call this method should have no effect.
     async fn next(&self) {
+        log::debug!("org.mpris.MediaPlayer2.Player::Next");
         if let Some(spirc) = &self.spirc {
             let _ = spirc.next();
         }
@@ -606,6 +607,7 @@ impl MprisPlayerService {
     //
     // If `self.can_go_previous` is `false`, attempting to call this method should have no effect.
     async fn previous(&self) {
+        log::debug!("org.mpris.MediaPlayer2.Player::Previous");
         if let Some(spirc) = &self.spirc {
             let _ = spirc.prev();
         }
@@ -619,6 +621,7 @@ impl MprisPlayerService {
     //
     // If `self.can_pause` is `false`, attempting to call this method should have no effect.
     async fn pause(&self) {
+        debug!("org.mpris.MediaPlayer2.Player::Pause");
         // FIXME: This should return an error if can_pause is false
         if let Some(spirc) = &self.spirc {
             let _ = spirc.pause();
@@ -634,6 +637,7 @@ impl MprisPlayerService {
     // If `self.can_pause` is `false`, attempting to call this method should have no effect and
     // raise an error.
     async fn play_pause(&self) {
+        debug!("org.mpris.MediaPlayer2.Player::PlayPause");
         // FIXME: This should return an error if can_pause is false
         if let Some(spirc) = &self.spirc {
             let _ = spirc.play_pause();
@@ -650,6 +654,7 @@ impl MprisPlayerService {
     // If `CanControl` is `false`, attempting to call this method should have no effect and raise
     // an error.
     async fn stop(&self) {
+        debug!("org.mpris.MediaPlayer2.Player::Stop");
         // FIXME: This should return an error if can_control is false
         if let Some(spirc) = &self.spirc {
             let _ = spirc.pause();
@@ -667,6 +672,7 @@ impl MprisPlayerService {
     //
     // If `self.can_play` is `false`, attempting to call this method should have no effect.
     async fn play(&self) {
+        debug!("org.mpris.MediaPlayer2.Player::Play");
         if let Some(spirc) = &self.spirc {
             let _ = spirc.activate();
             let _ = spirc.play();
@@ -687,6 +693,7 @@ impl MprisPlayerService {
     //
     // * `offset`: The number of microseconds to seek forward.
     async fn seek(&self, offset: TimeInUs) {
+        debug!("org.mpris.MediaPlayer2.Player::Seek({offset:?})");
         if let Some(spirc) = &self.spirc {
             let _ = spirc.seek_offset((offset / 1000) as i32);
         }
@@ -714,7 +721,8 @@ impl MprisPlayerService {
     //               `/org/mpris/MediaPlayer2/TrackList/NoTrack` is _not_ a valid value for this
     //               argument.
     // * `position`: Track position in microseconds. This must be between 0 and `track_length`.
-    async fn set_position(&self, _track_id: zbus::zvariant::ObjectPath<'_>, position: TimeInUs) {
+    async fn set_position(&self, track_id: zbus::zvariant::ObjectPath<'_>, position: TimeInUs) {
+        debug!("org.mpris.MediaPlayer2.Player::SetPosition({track_id:?}, {position:?})");
         // FIXME: handle track_id
         if position < 0 {
             return;
@@ -745,7 +753,8 @@ impl MprisPlayerService {
     // * `uri`: Uri of the track to load. Its uri scheme should be an element of the
     //          `org.mpris.MediaPlayer2.SupportedUriSchemes` property and the mime-type should
     //          match one of the elements of the `org.mpris.MediaPlayer2.SupportedMimeTypes`.
-    async fn open_uri(&self, _uri: &str) -> zbus::fdo::Result<()> {
+    async fn open_uri(&self, uri: &str) -> zbus::fdo::Result<()> {
+        debug!("org.mpris.MediaPlayer2.Player::OpenUri({uri:?})");
         Err(zbus::fdo::Error::NotSupported(
             "OpenUri not supported".to_owned(),
         ))
@@ -756,6 +765,7 @@ impl MprisPlayerService {
     // May be "Playing", "Paused" or "Stopped".
     #[zbus(property(emits_changed_signal = "true"))]
     async fn playback_status(&self) -> PlaybackStatus {
+        debug!("org.mpris.MediaPlayer2.Player::PlaybackStatus");
         self.playback_status
     }
 
@@ -771,11 +781,13 @@ impl MprisPlayerService {
     //
     #[zbus(property(emits_changed_signal = "true"))]
     async fn loop_status(&self) -> LoopStatus {
+        debug!("org.mpris.MediaPlayer2.Player::LoopStatus");
         self.repeat
     }
 
     #[zbus(property)]
     async fn set_loop_status(&mut self, value: LoopStatus) -> zbus::fdo::Result<()> {
+        debug!("org.mpris.MediaPlayer2.Player::LoopStatus({value:?})");
         match value {
             LoopStatus::None => {
                 if let Some(spirc) = &self.spirc {
@@ -821,11 +833,13 @@ impl MprisPlayerService {
     //     position.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn rate(&self) -> PlaybackRate {
+        debug!("org.mpris.MediaPlayer2.Player::Rate");
         1.0
     }
 
     #[zbus(property)]
-    async fn set_rate(&mut self, _value: PlaybackRate) {
+    async fn set_rate(&mut self, value: PlaybackRate) {
+        debug!("org.mpris.MediaPlayer2.Player::Rate({value:?})");
         // ignore
     }
 
@@ -837,11 +851,13 @@ impl MprisPlayerService {
     //
     #[zbus(property(emits_changed_signal = "true"))]
     async fn shuffle(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2.Player::Shuffle");
         self.shuffle
     }
 
     #[zbus(property)]
     async fn set_shuffle(&mut self, value: bool) {
+        debug!("org.mpris.MediaPlayer2.Player::Shuffle({value:?})");
         if let Some(spirc) = &self.spirc {
             let _ = spirc.shuffle(value);
         }
@@ -857,6 +873,7 @@ impl MprisPlayerService {
     async fn metadata(
         &self,
     ) -> zbus::fdo::Result<std::collections::HashMap<String, zbus::zvariant::OwnedValue>> {
+        debug!("org.mpris.MediaPlayer2.Player::Metadata");
         self.metadata
             .clone()
             .try_into()
@@ -871,11 +888,13 @@ impl MprisPlayerService {
     // an error.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn volume(&self) -> Volume {
+        debug!("org.mpris.MediaPlayer2.Player::Volume");
         self.volume as f64 / u16::MAX as f64
     }
 
     #[zbus(property)]
     async fn set_volume(&mut self, value: Volume) -> zbus::fdo::Result<()> {
+        debug!("org.mpris.MediaPlayer2.Player::Volume({value})");
         if let Some(spirc) = &self.spirc {
             // As of rust 1.45, cast is guaranteed to round to 0 and saturate.
             // MPRIS volume is expected to range between 0 and 1, see
@@ -899,6 +918,7 @@ impl MprisPlayerService {
     // `Seeked` signal is emited.
     #[zbus(property(emits_changed_signal = "false"))]
     async fn position(&self) -> zbus::fdo::Result<TimeInUs> {
+        debug!("org.mpris.MediaPlayer2.Player::Position");
         // todo!("fetch up-to-date position from player")
         Ok(0)
     }
@@ -912,6 +932,7 @@ impl MprisPlayerService {
     // This value should always be 1.0 or less.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn minimum_rate(&self) -> PlaybackRate {
+        debug!("org.mpris.MediaPlayer2.Player::MinimumRate");
         // Setting minimum and maximum rate to 1 disallow client to set rate.
         1.0
     }
@@ -922,6 +943,7 @@ impl MprisPlayerService {
     // This value should always be 1.0 or greater.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn maximum_rate(&self) -> PlaybackRate {
+        debug!("org.mpris.MediaPlayer2.Player::MaximumRate");
         // Setting minimum and maximum rate to 1 disallow client to set rate.
         1.0
     }
@@ -940,6 +962,7 @@ impl MprisPlayerService {
     //     always be a next track to move to.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn can_go_next(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2.Player::CanGoNext");
         true
     }
 
@@ -957,6 +980,7 @@ impl MprisPlayerService {
     //     always be a next previous to move to.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn can_go_previous(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2.Player::CanGoPrevious");
         true
     }
 
@@ -975,6 +999,7 @@ impl MprisPlayerService {
     //     "current track".
     #[zbus(property(emits_changed_signal = "true"))]
     async fn can_play(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2.Player::CanPlay");
         self.metadata.mpris.track_id.is_some()
     }
 
@@ -993,6 +1018,7 @@ impl MprisPlayerService {
     //     streamed media, for example.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn can_pause(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2.Player::CanPause");
         self.metadata.mpris.track_id.is_some()
     }
 
@@ -1007,6 +1033,7 @@ impl MprisPlayerService {
     //     playing some streamed media, for example.
     #[zbus(property(emits_changed_signal = "true"))]
     async fn can_seek(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2.Player::CanSeek");
         true
     }
 
@@ -1025,6 +1052,7 @@ impl MprisPlayerService {
     //     advance of attempting to call methods and write to properties.
     #[zbus(property(emits_changed_signal = "const"))]
     async fn can_control(&self) -> bool {
+        debug!("org.mpris.MediaPlayer2.Player::CanControl");
         true
     }
 
@@ -1110,7 +1138,7 @@ impl MprisEventHandler {
             Err(zbus::Error::NameTaken) => {
                 let pid_name =
                     format!("org.mpris.MediaPlayer2.librespot.instance{}", process::id());
-                log::warn!("MPRIS: zbus name taken, trying with pid specific name: {pid_name}");
+                warn!("zbus name taken, trying with pid specific name: {pid_name}");
 
                 Self::connection_builder(name, &pid_name)?.build().await
             }
@@ -1231,7 +1259,7 @@ impl MprisTask {
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
-                    // TODO: Fetch all metadata from AudioItem
+                    warn!("Missed TrackChanged event, metadata missing");
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
 
@@ -1253,7 +1281,7 @@ impl MprisTask {
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
-                    // TODO: Fetch all metadata from AudioItem
+                    warn!("Missed TrackChanged event, metadata missing");
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
 
@@ -1275,7 +1303,7 @@ impl MprisTask {
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
-                    // TODO: Fetch all metadata from AudioItem
+                    warn!("Missed TrackChanged event, metadata missing");
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
 
@@ -1315,7 +1343,7 @@ impl MprisTask {
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
-                    // TODO: Fetch all metadata from AudioItem
+                    warn!("Missed TrackChanged event, metadata missing");
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
             }
@@ -1331,7 +1359,7 @@ impl MprisTask {
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
-                    // TODO: Fetch all metadata from AudioItem
+                    warn!("Missed TrackChanged event, metadata missing");
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
             }
@@ -1343,7 +1371,7 @@ impl MprisTask {
                 if meta.mpris.track_id.as_ref() != Some(&track_id) {
                     *meta = Metadata::default();
                     meta.mpris.track_id = Some(track_id);
-                    // TODO: Fetch all metadata from AudioItem
+                    warn!("Missed TrackChanged event, metadata missing");
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }
             }

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1316,9 +1316,9 @@ impl MprisTask {
                 let mut iface = iface_ref.get_mut().await;
                 let meta = &mut iface.metadata;
 
-                if meta.mpris.track_id.as_ref() != Some(&track_id) {
+                if meta.mpris.track_id.as_ref() != track_id.as_ref() {
                     *meta = Metadata::default();
-                    meta.mpris.track_id = Some(track_id);
+                    meta.mpris.track_id = track_id;
                     warn!("Missed TrackChanged event, metadata missing");
                     iface.metadata_changed(iface_ref.signal_context()).await?;
                 }

--- a/src/mpris_event_handler.rs
+++ b/src/mpris_event_handler.rs
@@ -1,7 +1,7 @@
 use std::{collections::HashMap, process, sync::Arc, time::Instant};
 
 use librespot_connect::Spirc;
-use log::{debug, warn};
+use log::{debug, info, warn};
 use thiserror::Error;
 use time::format_description::well_known::Iso8601;
 use tokio::sync::mpsc;
@@ -738,12 +738,21 @@ impl MprisPlayerService {
     // * `position`: Track position in microseconds. This must be between 0 and `track_length`.
     async fn set_position(&self, track_id: zbus::zvariant::ObjectPath<'_>, position: TimeInUs) {
         debug!("org.mpris.MediaPlayer2.Player::SetPosition({track_id:?}, {position:?})");
-        // FIXME: handle track_id
         if position < 0 {
             return;
         }
         if let Some(spirc) = &self.spirc {
-            let _ = spirc.set_position_ms((position / 1000) as u32);
+            let current_track_id = self.metadata.mpris.track_id.as_ref().and_then(|track_id| {
+                track_id
+                    .to_id()
+                    .ok()
+                    .map(|id| format!("/org/librespot/track/{id}"))
+            });
+            if current_track_id.as_deref() == Some(track_id.as_str()) {
+                let _ = spirc.set_position_ms((position / 1000) as u32);
+            } else {
+                info!("SetPosition on wrong trackId, ignoring as stale");
+            }
         }
     }
 

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -123,7 +123,9 @@ impl EventHandler {
                             }
                             PlayerEvent::Stopped { track_id, .. } => {
                                 env_vars.insert("PLAYER_EVENT", "stopped".to_string());
-                                env_vars.insert("TRACK_ID", track_id.to_id());
+                                if let Some(track_id) = track_id {
+                                    env_vars.insert("TRACK_ID", track_id.to_id());
+                                }
                             }
                             PlayerEvent::Playing {
                                 track_id,

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -50,6 +50,7 @@ impl EventHandler {
                                     UniqueFields::Track {
                                         artists,
                                         album,
+                                        album_date,
                                         album_artists,
                                         popularity,
                                         number,
@@ -67,6 +68,10 @@ impl EventHandler {
                                         );
                                         env_vars.insert("ALBUM_ARTISTS", album_artists.join("\n"));
                                         env_vars.insert("ALBUM", album);
+                                        env_vars.insert(
+                                            "ALBUM_DATE",
+                                            album_date.unix_timestamp().to_string(),
+                                        );
                                         env_vars.insert("POPULARITY", popularity.to_string());
                                         env_vars.insert("NUMBER", number.to_string());
                                         env_vars.insert("DISC_NUMBER", disc_number.to_string());


### PR DESCRIPTION
Taking back on @wisp3rwind work for adding MPRIS support #1341.

 - Rebased on recent dev branch
 - ensure cargo fmt and cargo clippy passes on each commit
 - fix a few todos
 - send signal when position changed
 - return error when MPRIS command are done in wrong context or internal fails
 - handle position
 - handle identity
 - choose biggest art url
 - ensure metadata are always up to date or at least not invalid
 - notify on various property change

Not sure about:

 - Sending current state of player for all new listener (59767ce) 