### PR TITLE
Fix: Use the provided index or the first track as fallback value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [player] `preload` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
 - [spclient] `get_radio_for_track` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
 
+### Fixed
+
+- [connect] Use the provided index or the first as fallback value to always play a track on loading
 
 ### Removed
 

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -406,7 +406,7 @@ fn launch_libmdns(
             }
             .map_err(|e| DiscoveryError::DnsSdError(Box::new(e)))?;
 
-            let svc = responder.register(&DNS_SD_SERVICE_NAME, &name, port, &TXT_RECORD);
+            let svc = responder.register(DNS_SD_SERVICE_NAME, &name, port, &TXT_RECORD);
 
             let _ = shutdown_rx.blocking_recv();
 


### PR DESCRIPTION
Pretty much just forwards the index given by `skip_to` so that a track is always played, even when the given uri and the album uri don't match. This seems to be a rare case for some albums.

Fixes #1591