### PR TITLE
feat: Add aliases to discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [core] Add `SpotifyUri` type to represent more types of URI than `SpotifyId` can
+- [discovery] Add support for [device aliases](https://developer.spotify.com/documentation/commercial-hardware/implementation/guides/zeroconf#device-aliases)
 
 ### Changed
 

--- a/discovery/src/lib.rs
+++ b/discovery/src/lib.rs
@@ -437,6 +437,7 @@ impl Builder {
                 is_group: false,
                 device_id: device_id.into(),
                 client_id: client_id.into(),
+                aliases: Vec::new(),
             },
             port: 0,
             zeroconf_ip: vec![],
@@ -459,6 +460,21 @@ impl Builder {
     /// Sets whether the device is a group. This affects the icon in Spotify clients. Default is `false`.
     pub fn is_group(mut self, is_group: bool) -> Self {
         self.server_config.is_group = is_group;
+        self
+    }
+
+    /// Adds an alias for this device. Multiple aliases can be added by calling this method multiple times.
+    pub fn add_alias(
+        mut self,
+        alias: impl Into<Cow<'static, str>>,
+        id: u32,
+        is_group: bool,
+    ) -> Self {
+        self.server_config.aliases.push(server::Alias {
+            name: alias.into(),
+            id,
+            is_group,
+        });
         self
     }
 

--- a/discovery/src/server.rs
+++ b/discovery/src/server.rs
@@ -31,12 +31,19 @@ type Aes128Ctr = ctr::Ctr128BE<aes::Aes128>;
 
 type Params<'a> = BTreeMap<Cow<'a, str>, Cow<'a, str>>;
 
+pub struct Alias {
+    pub name: Cow<'static, str>,
+    pub id: u32,
+    pub is_group: bool,
+}
+
 pub struct Config {
     pub name: Cow<'static, str>,
     pub device_type: DeviceType,
     pub device_id: String,
     pub is_group: bool,
     pub client_id: String,
+    pub aliases: Vec<Alias>,
 }
 
 struct RequestHandler {
@@ -110,6 +117,13 @@ impl RequestHandler {
             // undocumented but should still work
             "accountReq": "PREMIUM",
             "activeUser": active_user,
+            "aliases": self.config.aliases.iter().map(|alias| {
+                json!({
+                    "name": alias.name,
+                    "id": alias.id.to_string(),
+                    "isGroup": alias.is_group.to_string(),
+                })
+            }).collect::<Vec<_>>(),
             // others seen-in-the-wild:
             // - "deviceAPI_isGroup": False
         })


### PR DESCRIPTION
Add support for aliases on devices in discovery.

SDK documentation: https://developer.spotify.com/documentation/commercial-hardware/implementation/guides/zeroconf#device-aliases