### PR TITLE
Add rustfmt and clippy to toolchain components

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+components = ["rustfmt", "clippy"]


### PR DESCRIPTION
Be explicit about required components to avoid https://github.com/rust-lang/rustup/issues/4337 and fix our code-quality action:

> Run cargo fmt --all -- --check
error: 'cargo-fmt' is not installed for the toolchain 'stable-x86_64-unknown-linux-gnu'.