### PR TITLE
chore: update alpine version to 3.20 and ensure openssl-dev is included

### DIFF
--- a/.devcontainer/Dockerfile.alpine
+++ b/.devcontainer/Dockerfile.alpine
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1
-ARG alpine_version=alpine3.19
+ARG alpine_version=alpine3.20
 ARG rust_version=1.85.0
 FROM rust:${rust_version}-${alpine_version}
 
@@ -15,6 +15,7 @@ RUN apk add --no-cache \
         pkgconf \
         musl-dev \
         # developer dependencies
+        openssl-dev \
         libunwind-dev \
         pulseaudio-dev \
         portaudio-dev \


### PR DESCRIPTION
fixes devcontainer build issue with alpine 3.19, which is not available anymore.

also openssl-dev was missing in the devcontainer