### PR TITLE
Draft: Try to fix rustfmt in CI

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -37,6 +37,8 @@ jobs:
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
+        with:
+          components: "rustfmt"
 
       - name: Check formatting
         run: cargo fmt --all -- --check


### PR DESCRIPTION
Try to fix failing rustfmt in CI

See https://github.com/librespot-org/librespot/actions/runs/18135403381/job/51612710285 for an exemple of failing job.