### PR TITLE
feat(oauth): add --oauth-host parameter for custom redirect host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [core] Add `SpotifyUri` type to represent more types of URI than `SpotifyId` can
+- [oauth] Add `--oauth-host` parameter to specify custom redirect host for OAuth flow
 
 ### Changed
 
+- [oauth] OAuth callback server now binds to `0.0.0.0` to support Docker/WSL2 port forwarding
 - [playback] Changed type of `SpotifyId` fields in `PlayerEvent` members to `SpotifyUri` (breaking)
 - [metadata] Changed arguments for `Metadata` trait from `&SpotifyId` to `&SpotifyUri` (breaking)
 - [player] `load` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -170,6 +170,7 @@ fn get_authcode_stdin() -> Result<AuthorizationCode, OAuthError> {
 fn get_authcode_listener(
     socket_address: SocketAddr,
     message: String,
+    redirect_host: &str,
 ) -> Result<AuthorizationCode, OAuthError> {
     let listener =
         TcpListener::bind(socket_address).map_err(|e| OAuthError::AuthCodeListenerBind {
@@ -194,7 +195,7 @@ fn get_authcode_listener(
         .split_whitespace()
         .nth(1)
         .ok_or(OAuthError::AuthCodeListenerParse)?;
-    let code = get_code(&("http://localhost".to_string() + redirect_url));
+    let code = get_code(&(format!("http://{redirect_host}") + redirect_url));
 
     let response = format!(
         "HTTP/1.1 200 OK\r\ncontent-length: {}\r\n\r\n{}",
@@ -210,15 +211,20 @@ fn get_authcode_listener(
 
 // If the specified `redirect_uri` is HTTP and contains a port,
 // then the corresponding socket address is returned.
+//
+// Always binds to 0.0.0.0 to support scenarios where the public-facing
+// redirect host differs from the local bind address (e.g. Docker port forwarding).
 fn get_socket_address(redirect_uri: &str) -> Option<SocketAddr> {
     let url = match Url::parse(redirect_uri) {
         Ok(u) if u.scheme() == "http" && u.port().is_some() => u,
         _ => return None,
     };
-    match url.socket_addrs(|| None) {
-        Ok(mut addrs) => addrs.pop(),
-        _ => None,
-    }
+
+    let port = url.port()?;
+    Some(SocketAddr::new(
+        std::net::IpAddr::V4(std::net::Ipv4Addr::new(0, 0, 0, 0)),
+        port,
+    ))
 }
 
 /// Struct that handle obtaining and refreshing access tokens.
@@ -286,7 +292,13 @@ impl OAuthClient {
         let pkce_verifier = self.set_auth_url();
 
         let code = match get_socket_address(&self.redirect_uri) {
-            Some(addr) => get_authcode_listener(addr, self.message.clone()),
+            Some(addr) => {
+                let redirect_host = Url::parse(&self.redirect_uri)
+                    .ok()
+                    .and_then(|u| u.host_str().map(|h| h.to_string()))
+                    .unwrap_or_else(|| "localhost".to_string());
+                get_authcode_listener(addr, self.message.clone(), &redirect_host)
+            }
             _ => get_authcode_stdin(),
         }?;
         trace!("Exchange {code:?} for access token");
@@ -328,7 +340,13 @@ impl OAuthClient {
         let pkce_verifier = self.set_auth_url();
 
         let code = match get_socket_address(&self.redirect_uri) {
-            Some(addr) => get_authcode_listener(addr, self.message.clone()),
+            Some(addr) => {
+                let redirect_host = Url::parse(&self.redirect_uri)
+                    .ok()
+                    .and_then(|u| u.host_str().map(|h| h.to_string()))
+                    .unwrap_or_else(|| "localhost".to_string());
+                get_authcode_listener(addr, self.message.clone(), &redirect_host)
+            }
             _ => get_authcode_stdin(),
         }?;
         trace!("Exchange {code:?} for access token");
@@ -470,7 +488,17 @@ pub fn get_access_token(
     println!("Browse to: {auth_url}");
 
     let code = match get_socket_address(redirect_uri) {
-        Some(addr) => get_authcode_listener(addr, String::from("Go back to your terminal :)")),
+        Some(addr) => {
+            let redirect_host = Url::parse(redirect_uri)
+                .ok()
+                .and_then(|u| u.host_str().map(|h| h.to_string()))
+                .unwrap_or_else(|| "localhost".to_string());
+            get_authcode_listener(
+                addr,
+                String::from("Go back to your terminal :)"),
+                &redirect_host,
+            )
+        }
         _ => get_authcode_stdin(),
     }?;
     trace!("Exchange {code:?} for access token");

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -541,7 +541,7 @@ pub fn get_access_token(
 
 #[cfg(test)]
 mod test {
-    use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 
     use super::*;
 
@@ -564,7 +564,10 @@ mod test {
             get_socket_address("http://127.0.0.1:1234/foo"),
             Some(any_v4_1234)
         );
-        assert_eq!(get_socket_address("http://8.8.8.8:1234/foo"), Some(any_v4_1234));
+        assert_eq!(
+            get_socket_address("http://8.8.8.8:1234/foo"),
+            Some(any_v4_1234)
+        );
         assert_eq!(
             get_socket_address("http://[0:0:0:0:0:0:0:1]:8888/foo"),
             Some(any_v4_8888)

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -557,33 +557,25 @@ mod test {
 
     #[test]
     fn get_socket_address_some() {
-        let localhost_v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 1234);
-        let localhost_v6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::new(0, 0, 0, 0, 0, 0, 0, 1)), 8888);
-        let addr_v4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(8, 8, 8, 8)), 1234);
-        let addr_v6 = SocketAddr::new(
-            IpAddr::V6(Ipv6Addr::new(0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888)),
-            8888,
-        );
+        let any_v4_1234 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 1234);
+        let any_v4_8888 = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(0, 0, 0, 0)), 8888);
 
-        // Loopback addresses
         assert_eq!(
             get_socket_address("http://127.0.0.1:1234/foo"),
-            Some(localhost_v4)
+            Some(any_v4_1234)
         );
+        assert_eq!(get_socket_address("http://8.8.8.8:1234/foo"), Some(any_v4_1234));
         assert_eq!(
             get_socket_address("http://[0:0:0:0:0:0:0:1]:8888/foo"),
-            Some(localhost_v6)
+            Some(any_v4_8888)
         );
         assert_eq!(
             get_socket_address("http://[::1]:8888/foo"),
-            Some(localhost_v6)
+            Some(any_v4_8888)
         );
-
-        // Non-loopback addresses
-        assert_eq!(get_socket_address("http://8.8.8.8:1234/foo"), Some(addr_v4));
         assert_eq!(
             get_socket_address("http://[2001:4860:4860::8888]:8888/foo"),
-            Some(addr_v6)
+            Some(any_v4_8888)
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -216,6 +216,7 @@ struct Setup {
     credentials: Option<Credentials>,
     enable_oauth: bool,
     oauth_port: Option<u16>,
+    oauth_host: Option<String>,
     zeroconf_port: u16,
     player_event_program: Option<String>,
     emit_sink_events: bool,
@@ -266,6 +267,7 @@ async fn get_setup() -> Setup {
     const NORMALISATION_RELEASE: &str = "normalisation-release";
     const NORMALISATION_THRESHOLD: &str = "normalisation-threshold";
     const OAUTH_PORT: &str = "oauth-port";
+    const OAUTH_HOST: &str = "oauth-host";
     const ONEVENT: &str = "onevent";
     #[cfg(feature = "passthrough-decoder")]
     const PASSTHROUGH: &str = "passthrough";
@@ -305,6 +307,7 @@ async fn get_setup() -> Setup {
     const ZEROCONF_INTERFACE_SHORT: &str = "i";
     const ENABLE_OAUTH_SHORT: &str = "j";
     const OAUTH_PORT_SHORT: &str = "K";
+    const OAUTH_HOST_SHORT: &str = "J";
     const ACCESS_TOKEN_SHORT: &str = "k";
     const CACHE_SIZE_LIMIT_SHORT: &str = "M";
     const MIXER_TYPE_SHORT: &str = "m";
@@ -516,6 +519,12 @@ async fn get_setup() -> Setup {
         ACCESS_TOKEN,
         "Spotify access token to sign in with.",
         "TOKEN",
+    )
+    .optopt(
+        OAUTH_HOST_SHORT,
+        OAUTH_HOST,
+        "The host for the oauth redirect server. Defaults to 127.0.0.1.",
+        "HOST",
     )
     .optopt(
         OAUTH_PORT_SHORT,
@@ -1271,6 +1280,17 @@ async fn get_setup() -> Setup {
         Some(5588)
     };
 
+    let oauth_host = if opt_present(OAUTH_HOST) {
+        if !enable_oauth {
+            warn!(
+                "Without the `--{ENABLE_OAUTH}` / `-{ENABLE_OAUTH_SHORT}` flag set `--{OAUTH_HOST}` / `-{OAUTH_HOST_SHORT}` has no effect."
+            );
+        }
+        opt_str(OAUTH_HOST)
+    } else {
+        None
+    };
+
     if let Some(reason) = no_discovery_reason.as_deref() {
         if opt_present(ZEROCONF_PORT) {
             warn!("With {reason} `--{ZEROCONF_PORT}` / `-{ZEROCONF_PORT_SHORT}` has no effect.");
@@ -1838,6 +1858,7 @@ async fn get_setup() -> Setup {
         credentials,
         enable_oauth,
         oauth_port,
+        oauth_host,
         zeroconf_port,
         player_event_program,
         emit_sink_events,
@@ -1936,9 +1957,10 @@ async fn main() {
             Some(port) => format!(":{port}"),
             _ => String::new(),
         };
+        let host = setup.oauth_host.as_deref().unwrap_or("127.0.0.1");
         let client = OAuthClientBuilder::new(
             &setup.session_config.client_id,
-            &format!("http://127.0.0.1{port_str}/login"),
+            &format!("http://{host}{port_str}/login"),
             OAUTH_SCOPES.to_vec(),
         )
         .open_in_browser()


### PR DESCRIPTION
Adds `--oauth-host` flag where OAuth now binds `0.0.0.0` to support Docker/WSL2 port forwarding scenarios. Defaults to `127.0.0.1`