### PR TITLE
Change cross-compile to debian stable(trixie)

### DIFF
--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -8,16 +8,12 @@
 # The compiled binaries will be located in /tmp/librespot-build
 #
 # If only one architecture is desired, cargo can be invoked directly with the appropriate options :
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features "alsa-backend with-libmdns"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features "alsa-backend with-libmdns native-tls"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns native-tls"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns native-tls"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns native-tls"
 
-FROM debian:bookworm
-
-RUN echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list && \
-	echo "deb http://deb.debian.org/debian bookworm-updates main" >> /etc/apt/sources.list && \
-	echo "deb http://deb.debian.org/debian-security bookworm-security main" >> /etc/apt/sources.list
+FROM debian:trixie
 
 RUN dpkg --add-architecture arm64 && \
 	dpkg --add-architecture armhf && \
@@ -40,10 +36,15 @@ RUN dpkg --add-architecture arm64 && \
 	libpulse0:arm64 \
 	libpulse0:armel \
 	libpulse0:armhf \
+	libssl-dev \
+	libssl-dev:arm64 \
+	libssl-dev:armel \
+	libssl-dev:armhf \
 	pkg-config
 
 ENV PATH="/root/.cargo/bin/:${PATH}"
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.85 -y && \
+RUN apt-get install rustup && \
+	rustup default stable && \
 	rustup target add aarch64-unknown-linux-gnu && \
 	rustup target add arm-unknown-linux-gnueabi && \
 	rustup target add arm-unknown-linux-gnueabihf && \

--- a/contrib/docker-build.sh
+++ b/contrib/docker-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-cargo build --release --no-default-features --features "alsa-backend with-libmdns"
-cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns"
-cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns"
-cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns"
+cargo build --release --no-default-features --features "alsa-backend with-libmdns native-tls"
+cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns native-tls"
+cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns native-tls"
+cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns native-tls"


### PR DESCRIPTION
Switch to running the distro provided rustup runtime fixing the issue of failing to build using native-tls.

I've test-compiled to all arches/examples given in the Dockerfile and compilation succeeds in all cases
I verified that the binary was executable for the aarch64-unknown-linux-gnu target since I'm running that myself.