### PR TITLE
update cross-compile oldstable debian to stable(trixie)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- [compilation] Switched contrib/Dockerfile to new Debian stable (trixie)
 - [playback] Changed type of `SpotifyId` fields in `PlayerEvent` members to `SpotifyUri` (breaking)
 - [metadata] Changed arguments for `Metadata` trait from `&SpotifyId` to `&SpotifyUri` (breaking)
 - [player] `load` function changed from accepting a `SpotifyId` to accepting a `SpotifyUri` (breaking)
@@ -38,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [core] Fix issue where building with native-tls would fail
 - [connect] Repeat context will not go into autoplay anymore and triggering autoplay while shuffling shouldn't reshuffle anymore
 - [connect] Only deletes the connect state on dealer shutdown instead on disconnecting
 - [core] Fixed a problem where in `spclient` where an HTTP/411 error was thrown because the header was set wrong

--- a/contrib/Dockerfile
+++ b/contrib/Dockerfile
@@ -8,16 +8,12 @@
 # The compiled binaries will be located in /tmp/librespot-build
 #
 # If only one architecture is desired, cargo can be invoked directly with the appropriate options :
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
-# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --no-default-features --features "alsa-backend with-libmdns native-tls"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns native-tls"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns native-tls"
+# $ docker run -v /tmp/librespot-build:/build librespot-cross cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns native-tls"
 
-FROM debian:bookworm
-
-RUN echo "deb http://deb.debian.org/debian bookworm main" > /etc/apt/sources.list && \
-	echo "deb http://deb.debian.org/debian bookworm-updates main" >> /etc/apt/sources.list && \
-	echo "deb http://deb.debian.org/debian-security bookworm-security main" >> /etc/apt/sources.list
+FROM debian:trixie
 
 RUN dpkg --add-architecture arm64 && \
 	dpkg --add-architecture armhf && \
@@ -40,10 +36,15 @@ RUN dpkg --add-architecture arm64 && \
 	libpulse0:arm64 \
 	libpulse0:armel \
 	libpulse0:armhf \
-	pkg-config
+	libssl-dev \
+	libssl-dev:arm64 \
+	libssl-dev:armel \
+	libssl-dev:armhf \
+	pkg-config \
+	rustup
 
 ENV PATH="/root/.cargo/bin/:${PATH}"
-RUN curl https://sh.rustup.rs -sSf | sh -s -- --default-toolchain 1.85 -y && \
+RUN rustup default stable && \
 	rustup target add aarch64-unknown-linux-gnu && \
 	rustup target add arm-unknown-linux-gnueabi && \
 	rustup target add arm-unknown-linux-gnueabihf && \

--- a/contrib/docker-build.sh
+++ b/contrib/docker-build.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-cargo build --release --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
-cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
-cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
-cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns rustls-tls-native-roots"
+cargo build --release --no-default-features --features "alsa-backend with-libmdns native-tls"
+cargo build --release --target aarch64-unknown-linux-gnu --no-default-features --features "alsa-backend with-libmdns native-tls"
+cargo build --release --target arm-unknown-linux-gnueabihf --no-default-features --features "alsa-backend with-libmdns native-tls"
+cargo build --release --target arm-unknown-linux-gnueabi --no-default-features --features "alsa-backend with-libmdns native-tls"


### PR DESCRIPTION
This is mainly so we can  cross-compile to the stable Debian Trixie changing from old-stable (Bookworm)

It seems using native-tls was broken in the previous build container.
Since debian trixie provides rustup in the repositories I switch to running that which fixes the issue of failing to build using native-tls so it fixes [this bug](https://github.com/librespot-org/librespot/issues/1605)


I tested building towards all the targets in the Dockerfile and compilation was successful and actually tested the binary itself on aarch64-unknown-linux-gnu, since that's what I'm running