### PR TITLE
fix: connection issues after system suspend on Linux

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Fixed failed transferring with transfer data that had an empty context uri and no tracks
 - [connect] Use the provided index or the first as fallback value to always play a track on loading
 - [core] Fixed a problem where the metadata didn't include the audio file by switching to `get_extended_metadata`
+- [core] Fixed connection issues after system suspend on Linux
 
 ### Removed
 

--- a/core/src/login5.rs
+++ b/core/src/login5.rs
@@ -16,7 +16,7 @@ use librespot_protocol::{
 };
 use protobuf::well_known_types::duration::Duration as ProtoDuration;
 use protobuf::{Message, MessageField};
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime};
 use thiserror::Error;
 use tokio::time::sleep;
 
@@ -264,7 +264,7 @@ impl Login5Manager {
             expires_in: Duration::from_secs(expires_in.try_into().unwrap_or(3600)),
             token_type: "Bearer".to_string(),
             scopes: vec![],
-            timestamp: Instant::now(),
+            timestamp: SystemTime::now(),
         }
     }
 }

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -1,6 +1,6 @@
 use std::{
     fmt::Write,
-    time::{Duration, Instant},
+    time::{Duration, SystemTime},
 };
 
 use crate::config::{OS, os_version};
@@ -364,7 +364,7 @@ impl SpClient {
                     .iter()
                     .map(|d| d.domain.clone())
                     .collect(),
-                timestamp: Instant::now(),
+                timestamp: SystemTime::now(),
             };
 
             inner.client_token = Some(client_token);

--- a/core/src/token.rs
+++ b/core/src/token.rs
@@ -8,7 +8,7 @@
 //   user-library-modify, user-library-read, user-follow-modify, user-follow-read, streaming,
 //   app-remote-control
 
-use std::time::{Duration, Instant};
+use std::time::{Duration, SystemTime};
 
 use serde::Deserialize;
 use thiserror::Error;
@@ -39,7 +39,7 @@ pub struct Token {
     pub expires_in: Duration,
     pub token_type: String,
     pub scopes: Vec<String>,
-    pub timestamp: Instant,
+    pub timestamp: SystemTime,
 }
 
 #[derive(Deserialize)]
@@ -115,12 +115,12 @@ impl Token {
             expires_in: Duration::from_secs(data.expires_in),
             token_type: data.token_type,
             scopes: data.scope,
-            timestamp: Instant::now(),
+            timestamp: SystemTime::now(),
         })
     }
 
     pub fn is_expired(&self) -> bool {
-        self.timestamp + (self.expires_in.saturating_sub(Self::EXPIRY_THRESHOLD)) < Instant::now()
+        self.timestamp + self.expires_in.saturating_sub(Self::EXPIRY_THRESHOLD) < SystemTime::now()
     }
 
     pub fn in_scope(&self, scope: &str) -> bool {


### PR DESCRIPTION
Using `Instant::now()` for `is_expired` doesn't account for time spent suspended on Linux as it internally uses `CLOCK_MONOTONIC`. Using `SystemTime::now()` instead (adjusting `timestamp` to `SystemTime` accordingly) fixes this.

Although `SystemTime` could go backwards (e.g. due to NTP updates), expiration deals with external systems and thus this should be a non-local time anyhow.

Fixes #1617