### PR TITLE
fix: correct dependabot config file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,15 @@
 version: 2
+
 updates:
-- package-ecosystem: github-actions
-  directory: "/"
-  schedule:
-    interval: weekly
-    day: saturday
-    time: "10:00"
-  open-pull-requests-limit: 10
-  target-branch: dev
+  - package-ecosystem: github-actions
+    schedule:
+      interval: weekly
+      day: saturday
+      time: "10:00"
+    groups:
+      gha-deps:
+        patterns:
+          - "*"
+    target-branch: dev
+    directories:
+      - "/.github/workflows"


### PR DESCRIPTION
Given the GitHub Actions "ecosystem", Dependabot will:

  - Check for new deps in workflow files, weekly on Saturday (unchanged)
  - Create a grouped PR with all the deps (as opposed to atomic PRs)
  - Use the correct path to workflow files (which was misconfigured)