### PR TITLE
CI: Create a PR for the release preparations

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -58,14 +58,14 @@ jobs:
           branch: "prepare-release/v${{ steps.get-version.outputs.VERSION }}"
           assignees: ${{ github.actor }}
           body: |
-            This PR prepares for the next ${{ github.event.inputs.versionBump }} release v${{ github.event.inputs.versionBump }}.
+            This PR prepares for the next ${{ github.event.inputs.versionBump }} release v${{ steps.get-version.outputs.VERSION }}.
 
             **Files that should be automatically modified:**
             - `Cargo.toml` (version bump)
               - `<crate>/Cargo.toml` (version bump)
               > for patch versions only the necessary crates will receive an update
             - `Cargo.lock` (only bumps own crate versions)
-            - `CHANGELOG.md` (finalize changelog for upcomming version)
+            - `CHANGELOG.md` (finalize changelog for upcoming version)
             
             **Review checklist:**
             - [ ] Confirm the version bump in `Cargo.toml` is correct
@@ -75,6 +75,6 @@ jobs:
             Please verify these changes before merging.
             
             ---
-            After merging, continue by creating a new release with the tag `v${{ github.event.inputs.versionBump }}`.
+            After merging, continue by creating a new release with the tag `v${{ steps.get-version.outputs.VERSION }}`.
 
             > See [PUBLISHING.md](https://github.com/librespot-org/librespot/blob/dev/PUBLISHING.md) for further infos.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -49,9 +50,11 @@ jobs:
           tag: v${{ steps.get-version.outputs.VERSION }}
           version: ${{ steps.get-version.outputs.VERSION }}
 
-      - name: Commit version prepare
-        uses: stefanzweifel/git-auto-commit-action@v6
-        if: ${{ !env.ACT }}
+      - name: Create PR to review automated changes
+        uses: peter-evans/create-pull-request@v7
         with:
-          commit_message: 'Prepare for v${{ steps.get-version.outputs.VERSION }} release'
-          file_pattern: '*.md *.toml *.lock'
+          commit-message: 'Preparations for v${{ steps.get-version.outputs.VERSION }}'
+          title: "Preparations for v${{ steps.get-version.outputs.VERSION }}"
+          branch: "prepare-release/v${{ steps.get-version.outputs.VERSION }}"
+          assignees: ${{ github.actor }}
+          body: "General preparations for the next ${{ github.event.inputs.versionBump }} release v${{ steps.get-version.outputs.VERSION }}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -57,4 +57,24 @@ jobs:
           title: "Preparations for v${{ steps.get-version.outputs.VERSION }}"
           branch: "prepare-release/v${{ steps.get-version.outputs.VERSION }}"
           assignees: ${{ github.actor }}
-          body: "General preparations for the next ${{ github.event.inputs.versionBump }} release v${{ steps.get-version.outputs.VERSION }}"
+          body: |
+            This PR prepares for the next ${{ github.event.inputs.versionBump }} release v${{ github.event.inputs.versionBump }}.
+
+            **Files that should be automatically modified:**
+            - `Cargo.toml` (version bump)
+              - `<crate>/Cargo.toml` (version bump)
+              > for patch versions only the necessary crates will receive an update
+            - `Cargo.lock` (only bumps own crate versions)
+            - `CHANGELOG.md` (finalize changelog for upcomming version)
+            
+            **Review checklist:**
+            - [ ] Confirm the version bump in `Cargo.toml` is correct
+            - [ ] Ensure `Cargo.lock` did only update our crates
+            - [ ] Review the changelog for accuracy and completeness
+            
+            Please verify these changes before merging.
+            
+            ---
+            After merging, continue by creating a new release with the tag `v${{ github.event.inputs.versionBump }}`.
+
+            > See [PUBLISHING.md](https://github.com/librespot-org/librespot/blob/dev/PUBLISHING.md) for further infos.

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -52,6 +52,7 @@ jobs:
 
       - name: Create PR to review automated changes
         uses: peter-evans/create-pull-request@v7
+        if: ${{ !env.ACT }}
         with:
           commit-message: 'Preparations for v${{ steps.get-version.outputs.VERSION }}'
           title: "Preparations for v${{ steps.get-version.outputs.VERSION }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: release.yml
+name: publish on release creation
 on:
   release:
     types:
@@ -31,4 +31,4 @@ jobs:
         if: ${{ !env.ACT }}
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
-        run: cargo publish --workspace --no-verify
+        run: cargo publish --workspace


### PR DESCRIPTION
I would have liked to have the automated changes directly committed without any interactions, but as the committer is the github-action bot and not the actor itself, we would need to give the bot bypass access (which is besides the point that it's not possible because of the following reason). Which in return would mean, anyone could bypass the protection of the branches. Which might probably a bad idea.

That's why we are sorta forced creating a PR for the automated changes. I will stop here for now as it's pretty late and will continue tomorrow.