### PR TITLE
CI: Improve feature checking for binary

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ name: build
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -D warnings
+  LINUX_FEATURES: alsa-backend,pulseaudio-backend,jackaudio-backend,with-avahi
 
 jobs:
   test:
@@ -78,11 +79,18 @@ jobs:
           --exclude-no-default-features --exclude-all-features
           --include-features native-tls,rustls-tls-native-roots,rustls-tls-webpki-roots
 
-      - name: Check binary with each-feature (native-tls)
+      - name: Check binary features (platform independent)
         run: >
           cargo hack check -p librespot --each-feature
-          --exclude-no-default-features --exclude-all-features
-          --features native-tls --skip rustls-tls-native-roots,rustls-tls-webpki-roots
+          --exclude-no-default-features --exclude-all-features --features native-tls 
+          --exclude-features rustls-tls-native-roots,rustls-tls-webpki-roots,${{ env.LINUX_FEATURES }}
+
+      - name: Check binary features (linux)
+        if: runner.os == 'Linux'
+        run: >
+          cargo hack check -p librespot --each-feature
+          --exclude-no-default-features --exclude-all-features --features native-tls
+          --include-features ${{ env.LINUX_FEATURES }}
 
       - name: Build binary with default features
         run: cargo build --frozen

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -D warnings
   GSTREAMER_WIN_PATH: D:\gstreamer
-  NOT_WINDOWS_FEATURES: alsa-backend,pulseaudio-backend,jackaudio-backend,rodiojack-backend,with-avahi
+  NOT_WINDOWS_FEATURES: alsa-backend,pulseaudio-backend,jackaudio-backend,rodiojack-backend,with-avahi,with-dns-sd
 
 jobs:
   test:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,12 @@ jobs:
         toolchain:
           - "1.85" # MSRV (Minimum supported rust version)
           - stable
+        isDefault:
+          - ${{ github.ref_name == github.event.repository.default_branch }}
+        exclude:
+          - isDefault: false
+            os: 'windows-latest'
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -96,7 +102,7 @@ jobs:
           --exclude-no-default-features --exclude-all-features
           --include-features native-tls,rustls-tls-native-roots,rustls-tls-webpki-roots
 
-      - name: Check binary features (platform independent)
+      - name: Check binary features (cross-platform)
         env:
           PKG_CONFIG_PATH: ${{ env.GSTREAMER_WIN_PATH }}\1.0\msvc_x86_64\lib\pkgconfig
         run: >

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,6 +14,7 @@ name: build
       - "**/Dockerfile*"
       - "test.sh"
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -42,11 +43,15 @@ jobs:
         toolchain:
           - "1.85" # MSRV (Minimum supported rust version)
           - stable
-        isDefault:
-          - ${{ github.ref_name == github.event.repository.default_branch }}
+        isPR:
+          - ${{ github.event.pull_request }}
+        isCIWindows:
+          - ${{ github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'CI:Windows') }}
         exclude:
-          - isDefault: false
-            os: 'windows-latest'
+          # excludes windows in a PR by default, unless labeled with 'CI:Windows'
+          - os: 'windows-latest'
+            isPR: true
+            isCIWindows: false
 
     steps:
       - name: Checkout code

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -D warnings
   GSTREAMER_WIN_PATH: D:\gstreamer
-  LINUX_FEATURES: alsa-backend,pulseaudio-backend,jackaudio-backend,with-avahi
+  NOT_WINDOWS_FEATURES: alsa-backend,pulseaudio-backend,jackaudio-backend,rodiojack-backend,with-avahi
 
 jobs:
   test:
@@ -102,14 +102,14 @@ jobs:
         run: >
           cargo hack check -p librespot --each-feature
           --exclude-no-default-features --exclude-all-features --features native-tls 
-          --exclude-features rustls-tls-native-roots,rustls-tls-webpki-roots,${{ env.LINUX_FEATURES }}
+          --exclude-features rustls-tls-native-roots,rustls-tls-webpki-roots,${{ env.NOT_WINDOWS_FEATURES }}
 
       - name: Check binary features (linux)
         if: runner.os == 'Linux'
         run: >
           cargo hack check -p librespot --each-feature
           --exclude-no-default-features --exclude-all-features --features native-tls
-          --include-features ${{ env.LINUX_FEATURES }}
+          --include-features ${{ env.NOT_WINDOWS_FEATURES }}
 
       - name: Build binary with default features
         run: cargo build --frozen

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,11 +44,11 @@ jobs:
           - "1.85" # MSRV (Minimum supported rust version)
           - stable
         isPR:
-          - ${{ github.event.pull_request }}
+          - ${{ github.event_name == 'pull_request' }}
         isCIWindows:
-          - ${{ github.event.pull_request && contains(github.event.pull_request.labels.*.name, 'CI:Windows') }}
+          - ${{ github.event.pull_request && contains(github.event.pull_request.labels.*.name, format('CI{0} Windows', ':')) }}
         exclude:
-          # excludes windows in a PR by default, unless labeled with 'CI:Windows'
+          # excludes windows in a PR by default, unless labeled with 'CI: Windows'
           - os: 'windows-latest'
             isPR: true
             isCIWindows: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,7 @@ name: build
 env:
   RUST_BACKTRACE: 1
   RUSTFLAGS: -D warnings
+  GSTREAMER_WIN_PATH: D:\gstreamer
   LINUX_FEATURES: alsa-backend,pulseaudio-backend,jackaudio-backend,with-avahi
 
 jobs:
@@ -61,6 +62,22 @@ jobs:
           gstreamer1.0-dev libgstreamer-plugins-base1.0-dev
           libavahi-compat-libdnssd-dev
 
+      - name: Install developer package dependencies (Windows)
+        if: runner.os == 'Windows'
+        run: choco install pkgconfiglite
+
+      - name: Cache gstreamer (Windows)
+        uses: actions/cache@v4
+        id: cache-gstreamer
+        if: runner.os == 'Windows'
+        with:
+          path: ${{ env.GSTREAMER_WIN_PATH }}
+          key: gstreamer-Windows-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Install gstreamer (Windows)
+        if: ${{ runner.os == 'Windows' && !steps.cache-gstreamer.outputs.cache-hit }}
+        run: choco install gstreamer-devel
+
       - name: Fetch dependencies
         run: cargo fetch --locked
 
@@ -80,6 +97,8 @@ jobs:
           --include-features native-tls,rustls-tls-native-roots,rustls-tls-webpki-roots
 
       - name: Check binary features (platform independent)
+        env:
+          PKG_CONFIG_PATH: ${{ env.GSTREAMER_WIN_PATH }}\1.0\msvc_x86_64\lib\pkgconfig
         run: >
           cargo hack check -p librespot --each-feature
           --exclude-no-default-features --exclude-all-features --features native-tls 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,27 +72,17 @@ jobs:
       - name: Install cargo-hack
         uses: taiki-e/install-action@cargo-hack
 
-      - name: Check packages without TLS requirements
-        run: cargo hack check -p librespot-protocol --each-feature
-
-      - name: Check workspace with native-tls
+      - name: Check binary with any tls option
         run: >
-          cargo hack check -p librespot --each-feature --exclude-all-features
-          --include-features native-tls
-          --exclude-features rustls-tls-native-roots,rustls-tls-webpki-roots
+          cargo hack check -p librespot --each-feature
+          --exclude-no-default-features --exclude-all-features
+          --include-features native-tls,rustls-tls-native-roots,rustls-tls-webpki-roots
 
-      - name: Check workspace with rustls-tls-native-roots
+      - name: Check binary with each-feature (native-tls)
         run: >
-          cargo hack check -p librespot --each-feature --exclude-all-features
-          --include-features rustls-tls-native-roots
-          --exclude-features native-tls,rustls-tls-webpki-roots
-
-      - name: Check discovery features (Linux only)
-        if: runner.os == 'Linux'
-        run: >
-          cargo hack check -p librespot-discovery --each-feature --exclude-all-features
-          --include-features native-tls
-          --exclude-features rustls-tls-native-roots,rustls-tls-webpki-roots
+          cargo hack check -p librespot --each-feature
+          --exclude-no-default-features --exclude-all-features
+          --features native-tls --skip rustls-tls-native-roots,rustls-tls-webpki-roots
 
       - name: Build binary with default features
         run: cargo build --frozen

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,9 +78,6 @@ rustls-tls-webpki-roots = [
 # on macOS.
 rodio-backend = ["librespot-playback/rodio-backend"]
 
-# rodiojack-backend: Rodio backend with JACK support for professional audio setups.
-rodiojack-backend = ["librespot-playback/rodiojack-backend"]
-
 # gstreamer-backend: Uses GStreamer multimedia framework for audio output.
 # Provides extensive audio processing capabilities.
 gstreamer-backend = ["librespot-playback/gstreamer-backend"]
@@ -104,6 +101,9 @@ pulseaudio-backend = ["librespot-playback/pulseaudio-backend"]
 # jackaudio-backend: JACK Audio Connection Kit backend.
 # Professional audio backend for low-latency, high-quality audio routing.
 jackaudio-backend = ["librespot-playback/jackaudio-backend"]
+
+# rodiojack-backend: Rodio backend with JACK support for professional audio setups. (not windows, yet)
+rodiojack-backend = ["librespot-playback/rodiojack-backend"]
 
 # Network discovery backends - choose one for Spotify Connect device discovery
 # See COMPILING.md for dependencies and platform support.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -119,7 +119,7 @@ with-libmdns = ["librespot-discovery/with-libmdns"]
 # libavahi-client-dev.
 with-avahi = ["librespot-discovery/with-avahi"]
 
-# with-dns-sd: Uses DNS Service Discovery (cross-platform).
+# with-dns-sd: Uses DNS Service Discovery (Linux and macOS only).
 # On macOS uses Bonjour, on Linux uses Avahi compatibility layer. Choose this for tight system
 # integration on macOS or when using Avahi's dns-sd compatibility mode on Linux.
 with-dns-sd = ["librespot-discovery/with-dns-sd"]


### PR DESCRIPTION
Simple adjustment to the ci that checks all tls features and each-feature with native-tls.

We previously had `--each-feature` executions, but if `--include-features` is provided, each-feature will only execute for the features provided by that flag. Because of that we only tested `rustls-tls-native-roots` and `native-tls`.

This should hopefully prevent compilation issues like:
- https://github.com/librespot-org/librespot/pull/1600
- https://github.com/librespot-org/librespot/pull/1630