### PR TITLE
Document how to create a fat binary for Mac x86_64 and Apple Silicon

### DIFF
--- a/COMPILING.md
+++ b/COMPILING.md
@@ -180,6 +180,33 @@ Or to use rustls-tls with ALSA:
 cargo build --no-default-features --features "rustls-tls alsa-backend with-libmdns"
 ```
 
+### Compiling on Apple Silicon (M1+) for Apple x86_64
+
+Install the additional `x86_64-apple-darwin` target using rustup:
+
+```bash
+rustup target install x86_64-apple-darwin
+```
+
+Then run the build with some additional environment variables:
+
+```bash
+SDKROOT=$(xcrun -sdk macosx11.3 --show-sdk-path) \
+MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.3 --show-sdk-platform-version) \
+cargo build --target=x86_64-apple-darwin --release
+```
+
+The `sdk` value can vary, depending on what XCode version you're using.
+
+You can then use the `lipo` tool to create a single fat (universal) binary for both platforms:
+
+```bash
+lipo -create \
+    -arch x86_64 target/x86_64-apple-darwin/release/librespot \
+    -arch arm64 target/aarch64-apple-darwin/release/librespot \
+    -output librespot
+```
+
 ### Running
 
 Assuming you just compiled a ```debug``` build, you can run librespot with the following command:

--- a/COMPILING.md
+++ b/COMPILING.md
@@ -188,15 +188,11 @@ Install the additional `x86_64-apple-darwin` target using rustup:
 rustup target install x86_64-apple-darwin
 ```
 
-Then run the build with some additional environment variables:
+Then run the build with the additional target parameter:
 
 ```bash
-SDKROOT=$(xcrun -sdk macosx11.3 --show-sdk-path) \
-MACOSX_DEPLOYMENT_TARGET=$(xcrun -sdk macosx11.3 --show-sdk-platform-version) \
 cargo build --target=x86_64-apple-darwin --release
 ```
-
-The `sdk` value can vary, depending on what XCode version you're using.
 
 You can then use the `lipo` tool to create a single fat (universal) binary for both platforms:
 


### PR DESCRIPTION
Just a few lines so I don't forget 😁. The universal binary then can be used on both Mac platforms.