### PR TITLE
chore: remove async-trait

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [core] Made `SpotifyId::to_base62`, `SpotifyId::to_base16`, `FileId::to_base16`, `SpotifyUri::to_id` infallible (breaking)
+- [metadata] Removed `async-trait`. Implementations of `Metadata` don't need the `async-trait` annotation anymore. (breaking)
 
 ## [0.8.0] - 2025-11-10
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1946,7 +1946,6 @@ dependencies = [
 name = "librespot-metadata"
 version = "0.8.0"
 dependencies = [
- "async-trait",
  "bytes",
  "librespot-core",
  "librespot-protocol",

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -21,7 +21,6 @@ rustls-tls-webpki-roots = ["librespot-core/rustls-tls-webpki-roots"]
 librespot-core = { version = "0.8.0", path = "../core", default-features = false }
 librespot-protocol = { version = "0.8.0", path = "../protocol", default-features = false }
 
-async-trait = "0.1"
 bytes = "1"
 log = "0.4"
 protobuf = "3.7"

--- a/metadata/src/album.rs
+++ b/metadata/src/album.rs
@@ -70,7 +70,6 @@ impl Album {
     }
 }
 
-#[async_trait]
 impl Metadata for Album {
     type Message = protocol::metadata::Album;
 

--- a/metadata/src/artist.rs
+++ b/metadata/src/artist.rs
@@ -167,7 +167,6 @@ impl Artist {
     }
 }
 
-#[async_trait]
 impl Metadata for Artist {
     type Message = protocol::metadata::Artist;
 

--- a/metadata/src/episode.rs
+++ b/metadata/src/episode.rs
@@ -53,7 +53,6 @@ pub struct Episodes(pub Vec<SpotifyUri>);
 
 impl_deref_wrapped!(Episodes, Vec<SpotifyUri>);
 
-#[async_trait]
 impl Metadata for Episode {
     type Message = protocol::metadata::Episode;
 

--- a/metadata/src/lib.rs
+++ b/metadata/src/lib.rs
@@ -1,10 +1,8 @@
 #[macro_use]
 extern crate log;
 
-#[macro_use]
-extern crate async_trait;
-
 use protobuf::Message;
+use std::future::Future;
 
 use librespot_core::{Error, Session, SpotifyUri};
 
@@ -39,20 +37,34 @@ pub use playlist::Playlist;
 pub use show::Show;
 pub use track::Track;
 
-#[async_trait]
 pub trait Metadata: Send + Sized + 'static {
-    type Message: protobuf::Message + std::fmt::Debug;
+    type Message: Message + std::fmt::Debug;
 
     // Request a protobuf
-    async fn request(session: &Session, id: &SpotifyUri) -> RequestResult;
+    fn request(
+        session: &Session,
+        id: &SpotifyUri,
+    ) -> impl Future<Output = RequestResult> + Send + Sized;
 
     // Request a metadata struct
-    async fn get(session: &Session, id: &SpotifyUri) -> Result<Self, Error> {
-        let response = Self::request(session, id).await?;
-        let msg = Self::Message::parse_from_bytes(&response)?;
-        trace!("Received metadata: {msg:#?}");
-        Self::parse(&msg, id)
+    fn get(
+        session: &Session,
+        id: &SpotifyUri,
+    ) -> impl Future<Output = Result<Self, Error>> + Send + Sized {
+        map_request_to_message(Self::request(session, id), id)
     }
 
     fn parse(msg: &Self::Message, _: &SpotifyUri) -> Result<Self, Error>;
+}
+
+async fn map_request_to_message<M, P, F>(response: F, uri: &SpotifyUri) -> Result<M, Error>
+where
+    P: Message + std::fmt::Debug,
+    M: Metadata<Message = P>,
+    F: Future<Output = RequestResult> + Send + Sized,
+{
+    let response = response.await?;
+    let msg = P::parse_from_bytes(&response)?;
+    trace!("Received metadata: {msg:#?}");
+    M::parse(&msg, uri)
 }

--- a/metadata/src/playlist/annotation.rs
+++ b/metadata/src/playlist/annotation.rs
@@ -21,7 +21,6 @@ pub struct PlaylistAnnotation {
     pub abuse_report_state: AbuseReportState,
 }
 
-#[async_trait]
 impl Metadata for PlaylistAnnotation {
     type Message = protocol::playlist_annotate3::PlaylistAnnotation;
 

--- a/metadata/src/playlist/list.rs
+++ b/metadata/src/playlist/list.rs
@@ -84,7 +84,6 @@ impl Playlist {
     }
 }
 
-#[async_trait]
 impl Metadata for Playlist {
     type Message = protocol::playlist4_external::SelectedListContent;
 

--- a/metadata/src/request.rs
+++ b/metadata/src/request.rs
@@ -6,7 +6,6 @@ use librespot_core::{Error, Session};
 
 pub type RequestResult = Result<bytes::Bytes, Error>;
 
-#[async_trait]
 pub trait MercuryRequest {
     async fn request(session: &Session, uri: &str) -> RequestResult {
         let mut metrics_uri = uri.to_owned();

--- a/metadata/src/show.rs
+++ b/metadata/src/show.rs
@@ -32,7 +32,6 @@ pub struct Show {
     pub is_audiobook: bool,
 }
 
-#[async_trait]
 impl Metadata for Show {
     type Message = protocol::metadata::Show;
 

--- a/metadata/src/track.rs
+++ b/metadata/src/track.rs
@@ -54,7 +54,6 @@ pub struct Tracks(pub Vec<SpotifyUri>);
 
 impl_deref_wrapped!(Tracks, Vec<SpotifyUri>);
 
-#[async_trait]
 impl Metadata for Track {
     type Message = protocol::metadata::Track;
 


### PR DESCRIPTION
Removes the `async-trait` crate as our MSRV is higher then 1.75, which introduced the feature. 

> This change is not necessary and sadly doesn't remove `async-trait` from our build chain completely, as `zbus` still includes it. I looked into removing `async-trait` from `zbus`... but they use it so much, that removing it is a huge task itself.