### PR TITLE
make SpotifyUri::to_uri() infallible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- [core] Made `SpotifyId::to_base62`, `SpotifyId::to_base16`, `FileId::to_base16`, `SpotifyUri::to_id` infallible (breaking)
+- [core] Made `SpotifyId::to_base62`, `SpotifyId::to_base16`, `FileId::to_base16`, `SpotifyUri::to_id`, `SpotifyUri::to_uri` infallible (breaking)
 
 ## [0.8.0] - 2025-11-10
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -806,7 +806,7 @@ impl SpircTask {
             }
             PlayerEvent::Unavailable { track_id, .. } => {
                 self.handle_unavailable(&track_id)?;
-                if self.connect_state.current_track(|t| &t.uri) == &track_id.to_uri()? {
+                if self.connect_state.current_track(|t| &t.uri) == &track_id.to_uri() {
                     self.handle_next(None)?
                 }
             }

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -456,7 +456,7 @@ impl ConnectState {
             _ => Err(StateError::InvalidTrackUri(None))?,
         };
 
-        let uri = id.to_uri()?.replace("unknown", "track");
+        let uri = id.to_uri().replace("unknown", "track");
 
         let provider = if self.unavailable_uri.contains(&uri) {
             Provider::Unavailable

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -382,7 +382,7 @@ impl<'ct> ConnectState {
     }
 
     pub fn mark_unavailable(&mut self, id: &SpotifyUri) -> Result<(), Error> {
-        let uri = id.to_uri()?;
+        let uri = id.to_uri();
 
         debug!("marking {uri} as unavailable");
 

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -595,7 +595,7 @@ impl SpClient {
     pub async fn get_metadata(&self, kind: ExtensionKind, id: &SpotifyUri) -> SpClientResult {
         let req = BatchedEntityRequest {
             entity_request: vec![EntityRequest {
-                entity_uri: id.to_uri()?,
+                entity_uri: id.to_uri(),
                 query: vec![ExtensionQuery {
                     extension_kind: EnumOrUnknown::new(kind),
                     ..Default::default()
@@ -716,7 +716,7 @@ impl SpClient {
     pub async fn get_radio_for_track(&self, track_uri: &SpotifyUri) -> SpClientResult {
         let endpoint = format!(
             "/inspiredby-mix/v2/seed_to_playlist/{}?response-format=json",
-            track_uri.to_uri()?
+            track_uri.to_uri()
         );
 
         self.request_as_json(&Method::GET, &endpoint, None, None)

--- a/core/src/spotify_uri.rs
+++ b/core/src/spotify_uri.rs
@@ -203,18 +203,18 @@ impl SpotifyUri {
     /// `spotify:user:{user}:{type}:{id}`.
     ///
     /// [Spotify URI]: https://developer.spotify.com/documentation/web-api/concepts/spotify-uris-ids
-    pub fn to_uri(&self) -> Result<String, Error> {
+    pub fn to_uri(&self) -> String {
         let item_type = self.item_type();
-        let name = self.to_id();
 
         if let SpotifyUri::Playlist {
             id,
             user: Some(user),
         } = self
         {
-            Ok(format!("spotify:user:{user}:{item_type}:{id}"))
+            format!("spotify:user:{user}:{item_type}:{id}")
         } else {
-            Ok(format!("spotify:{item_type}:{name}"))
+            let name = self.to_id();
+            format!("spotify:{item_type}:{name}")
         }
     }
 
@@ -231,15 +231,13 @@ impl SpotifyUri {
 
 impl fmt::Debug for SpotifyUri {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.debug_tuple("SpotifyUri")
-            .field(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
-            .finish()
+        f.debug_tuple("SpotifyUri").field(&self.to_uri()).finish()
     }
 }
 
 impl fmt::Display for SpotifyUri {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.to_uri().unwrap_or_else(|_| "invalid uri".into()))
+        f.write_str(&self.to_uri())
     }
 }
 
@@ -597,7 +595,7 @@ mod tests {
     #[test]
     fn to_uri() {
         for c in &CONV_VALID {
-            assert_eq!(c.parsed.to_uri().unwrap(), c.uri);
+            assert_eq!(c.parsed.to_uri(), c.uri);
         }
     }
 
@@ -608,6 +606,6 @@ mod tests {
         let actual =
             SpotifyUri::from_uri("spotify:user:spotify:playlist:37i9dQZF1DWSw8liJZcPOI").unwrap();
 
-        assert_eq!(actual.to_uri().unwrap(), string);
+        assert_eq!(actual.to_uri(), string);
     }
 }

--- a/metadata/src/audio/item.rs
+++ b/metadata/src/audio/item.rs
@@ -87,7 +87,7 @@ impl AudioItem {
                     return Err(Error::unavailable(MetadataError::ExplicitContentFiltered));
                 }
 
-                let uri_string = uri.to_uri()?;
+                let uri_string = uri.to_uri();
                 let album = track.album.name;
 
                 let album_artists = track
@@ -156,7 +156,7 @@ impl AudioItem {
                     return Err(Error::unavailable(MetadataError::ExplicitContentFiltered));
                 }
 
-                let uri_string = uri.to_uri()?;
+                let uri_string = uri.to_uri();
 
                 let covers = get_covers(episode.covers, image_url);
 

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1287,7 +1287,7 @@ impl PlayerTrackLoader {
             is_explicit: false,
             audio_item: AudioItem {
                 duration_ms: duration.as_millis() as u32,
-                uri: track_uri.to_uri().unwrap_or_default(),
+                uri: track_uri.to_uri(),
                 track_id: track_uri,
                 files: Default::default(),
                 name,


### PR DESCRIPTION
Tiny follow-up to #1635