### PR TITLE
People should run latest version before opening issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -8,7 +8,7 @@ assignees: ''
 ---
 
 ### Look for similar bugs
-Please check if there's [already an issue](https://github.com/librespot-org/librespot/issues) for your problem.
+Please check if there's [already an issue](https://github.com/librespot-org/librespot/issues) for your problem, and you're running at least the [latest release](https://github.com/librespot-org/librespot/releases/latest).
 If you've only a "me too" comment to make, consider if a :+1: [reaction](https://github.blog/news-insights/product-news/add-reactions-to-pull-requests-issues-and-comments/)
 will suffice. 
 


### PR DESCRIPTION
Added a note to check for the latest release before reporting bugs.

Although if they don't bother checking for existing issues, there's little chance they'll do this either.