### PR TITLE
fix: credential file shouldn't be world readable

### DIFF
--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -321,7 +321,7 @@ impl Cache {
             #[cfg(unix)]
             if file.metadata()?.mode() & 0o004 != 0 {
                 warn!(
-                    "credential file {location:?} is currently world readable, consider using  chmod 600 {location:?}  to fix this"
+                    "credential file {location:?} is currently world readable, consider using  chmod 600 {location:?} to fix this"
                 )
             }
             Ok(serde_json::from_reader(file)?)

--- a/core/src/cache.rs
+++ b/core/src/cache.rs
@@ -1,3 +1,5 @@
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
 use std::{
     cmp::Reverse,
     collections::HashMap,
@@ -315,10 +317,14 @@ impl Cache {
 
         // This closure is just convencience to enable the question mark operator
         let read = || -> Result<Credentials, Error> {
-            let mut file = File::open(location)?;
-            let mut contents = String::new();
-            file.read_to_string(&mut contents)?;
-            Ok(serde_json::from_str(&contents)?)
+            let file = File::open(location)?;
+            #[cfg(unix)]
+            if file.metadata()?.mode() & 0o004 != 0 {
+                warn!(
+                    "credential file {location:?} is currently world readable, consider using  chmod 600 {location:?}  to fix this"
+                )
+            }
+            Ok(serde_json::from_reader(file)?)
         };
 
         match read() {
@@ -336,10 +342,15 @@ impl Cache {
 
     pub fn save_credentials(&self, cred: &Credentials) {
         if let Some(location) = &self.credentials_location {
-            let result = File::create(location).and_then(|mut file| {
-                let data = serde_json::to_string(cred)?;
-                write!(file, "{data}")
-            });
+            let mut file = File::options();
+            #[cfg(unix)]
+            let file = file.mode(0o600);
+            let result = file
+                .create(true)
+                .write(true)
+                .truncate(true)
+                .open(location)
+                .and_then(|file| Ok(serde_json::to_writer(file, cred)?));
 
             if let Err(e) = result {
                 warn!("Cannot save credentials to cache: {e}")


### PR DESCRIPTION
As has been raised in https://github.com/Spotifyd/spotifyd/issues/1349 some time ago, the credential files in cache should probably not be world readable, as this allows for example other users on a multi-user system to use the Spotify account of another user.

This changes the default permissions for the file and suggests changing the permissions, if the file is world readable. One could of course just change the permissions instead of asking the user to do it, but this might be a little intrusive. If you think that the permissions should also be changed on other files / directories, let me know.

Note that this only works on Unix systems, I don't know anything about how Windows handles permissions, so didn't change anything there.