### PR TITLE
try all resolved socket addrs for connection

### DIFF
--- a/core/src/socket.rs
+++ b/core/src/socket.rs
@@ -1,4 +1,4 @@
-use std::{io, net::ToSocketAddrs};
+use std::io;
 
 use tokio::net::TcpStream;
 use url::Url;
@@ -6,29 +6,14 @@ use url::Url;
 use crate::proxytunnel;
 
 pub async fn connect(host: &str, port: u16, proxy: Option<&Url>) -> io::Result<TcpStream> {
-    let socket = if let Some(proxy_url) = proxy {
+    if let Some(proxy_url) = proxy {
         info!("Using proxy \"{proxy_url}\"");
 
-        let socket_addr = proxy_url.socket_addrs(|| None).and_then(|addrs| {
-            addrs.into_iter().next().ok_or_else(|| {
-                io::Error::new(
-                    io::ErrorKind::NotFound,
-                    "Can't resolve proxy server address",
-                )
-            })
-        })?;
-        let socket = TcpStream::connect(&socket_addr).await?;
+        let socket_addrs = proxy_url.socket_addrs(|| None)?;
+        let socket = TcpStream::connect(&*socket_addrs).await?;
 
-        proxytunnel::proxy_connect(socket, host, &port.to_string()).await?
+        proxytunnel::proxy_connect(socket, host, &port.to_string()).await
     } else {
-        let socket_addr = (host, port).to_socket_addrs()?.next().ok_or_else(|| {
-            io::Error::new(
-                io::ErrorKind::NotFound,
-                "Can't resolve access point address",
-            )
-        })?;
-
-        TcpStream::connect(&socket_addr).await?
-    };
-    Ok(socket)
+        TcpStream::connect((host, port)).await
+    }
 }


### PR DESCRIPTION
For the dealer connection, we currently only try the first socket address that we resolved. In some cases, for example when using a VPN, which blocks IPv6 traffic, this might fail due to being an IPv6 address. The other options are never considered, and thus starting the Dealer fails.

Instead of doing the address resolution ourselves, we can just rely on [`TcpStream::connect`](https://docs.rs/tokio/latest/tokio/net/struct.TcpStream.html#method.connect) to do it, which will try all options until one is successful, so this seems to be common practice.

See also Spotifyd/spotifyd#1382