### PR TITLE
Remove redundant closures

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -209,3 +209,9 @@ assets = [
     ["contrib/librespot.service", "lib/systemd/system/", "644"],
     ["contrib/librespot.user.service", "lib/systemd/user/", "644"],
 ]
+
+[workspace.lints]
+clippy.redundant_closure_for_method_calls = "warn"
+
+[lints]
+workspace = true

--- a/audio/Cargo.toml
+++ b/audio/Cargo.toml
@@ -31,3 +31,6 @@ log = "0.4"
 tempfile = "3"
 thiserror = "2"
 tokio = { version = "1", features = ["macros", "sync"] }
+
+[lints]
+workspace = true

--- a/audio/src/fetch/receive.rs
+++ b/audio/src/fetch/receive.rs
@@ -99,7 +99,7 @@ async fn receive_data(
         }
 
         let body = response.into_body();
-        let data = match body.collect().await.map(|b| b.to_bytes()) {
+        let data = match body.collect().await.map(http_body_util::Collected::to_bytes) {
             Ok(bytes) => bytes,
             Err(e) => break Err(e.into()),
         };

--- a/audio/src/fetch/receive.rs
+++ b/audio/src/fetch/receive.rs
@@ -99,7 +99,11 @@ async fn receive_data(
         }
 
         let body = response.into_body();
-        let data = match body.collect().await.map(http_body_util::Collected::to_bytes) {
+        let data = match body
+            .collect()
+            .await
+            .map(http_body_util::Collected::to_bytes)
+        {
             Ok(bytes) => bytes,
             Err(e) => break Err(e.into()),
         };

--- a/connect/Cargo.toml
+++ b/connect/Cargo.toml
@@ -31,3 +31,6 @@ thiserror = "2"
 tokio = { version = "1", features = ["macros", "sync"] }
 tokio-stream = { version = "0.1", default-features = false }
 uuid = { version = "1.18", default-features = false, features = ["v4"] }
+
+[lints]
+workspace = true

--- a/connect/src/context_resolver.rs
+++ b/connect/src/context_resolver.rs
@@ -142,7 +142,7 @@ impl ContextResolver {
         let last_try = self
             .unavailable_contexts
             .get(&resolve)
-            .map(|i| i.duration_since(Instant::now()));
+            .map(Instant::elapsed);
 
         let last_try = if matches!(last_try, Some(last_try) if last_try > RETRY_UNAVAILABLE) {
             let _ = self.unavailable_contexts.remove(&resolve);

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -118,3 +118,6 @@ vergen-gitcl = { version = "1.0", default-features = false, features = [
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }
+
+[lints]
+workspace = true

--- a/core/src/http_client.rs
+++ b/core/src/http_client.rs
@@ -242,7 +242,7 @@ impl HttpClient {
                 // strip the prefix from *.domain.tld (assume rate limit is per domain, not subdomain)
                 let mut parts = host
                     .split('.')
-                    .map(std::string::ToString::to_string)
+                    .map(ToString::to_string)
                     .collect::<Vec<String>>();
                 let n = parts.len().saturating_sub(2);
                 parts.drain(n..).collect()

--- a/core/src/http_client.rs
+++ b/core/src/http_client.rs
@@ -242,7 +242,7 @@ impl HttpClient {
                 // strip the prefix from *.domain.tld (assume rate limit is per domain, not subdomain)
                 let mut parts = host
                     .split('.')
-                    .map(|s| s.to_string())
+                    .map(std::string::ToString::to_string)
                     .collect::<Vec<String>>();
                 let n = parts.len().saturating_sub(2);
                 parts.drain(n..).collect()

--- a/core/src/http_client.rs
+++ b/core/src/http_client.rs
@@ -240,10 +240,7 @@ impl HttpClient {
         let domain = match req.uri().host() {
             Some(host) => {
                 // strip the prefix from *.domain.tld (assume rate limit is per domain, not subdomain)
-                let mut parts = host
-                    .split('.')
-                    .map(Into::into)
-                    .collect::<Vec<String>>();
+                let mut parts = host.split('.').map(Into::into).collect::<Vec<String>>();
                 let n = parts.len().saturating_sub(2);
                 parts.drain(n..).collect()
             }

--- a/core/src/http_client.rs
+++ b/core/src/http_client.rs
@@ -242,7 +242,7 @@ impl HttpClient {
                 // strip the prefix from *.domain.tld (assume rate limit is per domain, not subdomain)
                 let mut parts = host
                     .split('.')
-                    .map(ToString::to_string)
+                    .map(Into::into)
                     .collect::<Vec<String>>();
                 let n = parts.len().saturating_sub(2);
                 parts.drain(n..).collect()

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -422,7 +422,7 @@ impl SpClient {
         let mut headers = headers.unwrap_or_default();
         headers.insert(ACCEPT, HeaderValue::from_static("application/json"));
 
-        self.request(method, endpoint, Some(headers), body.map(|s| s.as_bytes()))
+        self.request(method, endpoint, Some(headers), body.map(str::as_bytes))
             .await
     }
 
@@ -749,7 +749,7 @@ impl SpClient {
 
         let previous_track_str = previous_tracks
             .iter()
-            .map(|track| track.to_base62())
+            .map(super::spotify_id::SpotifyId::to_base62)
             .collect::<Vec<_>>()
             .join(",");
         // better than checking `previous_tracks.len() > 0` because the `filter_map` could still return 0 items
@@ -952,7 +952,7 @@ impl SpClient {
             &Method::POST,
             &endpoint,
             None,
-            body.as_deref().map(|s| s.as_bytes()),
+            body.as_deref().map(str::as_bytes),
             &NO_METRICS_AND_SALT,
         )
         .await

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -749,7 +749,7 @@ impl SpClient {
 
         let previous_track_str = previous_tracks
             .iter()
-            .map(super::spotify_id::SpotifyId::to_base62)
+            .map(SpotifyId::to_base62)
             .collect::<Vec<_>>()
             .join(",");
         // better than checking `previous_tracks.len() > 0` because the `filter_map` could still return 0 items

--- a/discovery/Cargo.toml
+++ b/discovery/Cargo.toml
@@ -60,3 +60,6 @@ zbus = { version = "5", default-features = false, features = [
 futures = "0.3"
 hex = "0.4"
 tokio = { version = "1", features = ["macros", "rt"] }
+
+[lints]
+workspace = true

--- a/metadata/Cargo.toml
+++ b/metadata/Cargo.toml
@@ -29,3 +29,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2"
 uuid = { version = "1", default-features = false }
+
+[lints]
+workspace = true

--- a/metadata/src/image.rs
+++ b/metadata/src/image.rs
@@ -27,7 +27,7 @@ pub struct Images(pub Vec<Image>);
 
 impl From<&ImageGroup> for Images {
     fn from(image_group: &ImageGroup) -> Self {
-        Self(image_group.image.iter().map(std::convert::Into::into).collect())
+        Self(image_group.image.iter().map(Into::into).collect())
     }
 }
 

--- a/metadata/src/image.rs
+++ b/metadata/src/image.rs
@@ -27,7 +27,7 @@ pub struct Images(pub Vec<Image>);
 
 impl From<&ImageGroup> for Images {
     fn from(image_group: &ImageGroup) -> Self {
-        Self(image_group.image.iter().map(|i| i.into()).collect())
+        Self(image_group.image.iter().map(std::convert::Into::into).collect())
     }
 }
 

--- a/metadata/src/lyrics.rs
+++ b/metadata/src/lyrics.rs
@@ -24,7 +24,7 @@ impl TryFrom<&Bytes> for Lyrics {
     type Error = Error;
 
     fn try_from(lyrics: &Bytes) -> Result<Self, Self::Error> {
-        serde_json::from_slice(lyrics).map_err(std::convert::Into::into)
+        serde_json::from_slice(lyrics).map_err(Into::into)
     }
 }
 

--- a/metadata/src/lyrics.rs
+++ b/metadata/src/lyrics.rs
@@ -24,7 +24,7 @@ impl TryFrom<&Bytes> for Lyrics {
     type Error = Error;
 
     fn try_from(lyrics: &Bytes) -> Result<Self, Self::Error> {
-        serde_json::from_slice(lyrics).map_err(|err| err.into())
+        serde_json::from_slice(lyrics).map_err(std::convert::Into::into)
     }
 }
 

--- a/metadata/src/playlist/attribute.rs
+++ b/metadata/src/playlist/attribute.rs
@@ -144,7 +144,7 @@ impl TryFrom<&PlaylistPartialAttributesMessage> for PlaylistPartialAttributes {
             no_value: attributes
                 .no_value
                 .iter()
-                .map(|v| v.enum_value_or_default())
+                .map(protobuf::EnumOrUnknown::enum_value_or_default)
                 .collect::<Vec<PlaylistAttributeKind>>()
                 .as_slice()
                 .into(),
@@ -160,7 +160,7 @@ impl TryFrom<&PlaylistPartialItemAttributesMessage> for PlaylistPartialItemAttri
             no_value: attributes
                 .no_value
                 .iter()
-                .map(|v| v.enum_value_or_default())
+                .map(protobuf::EnumOrUnknown::enum_value_or_default)
                 .collect::<Vec<PlaylistItemAttributeKind>>()
                 .as_slice()
                 .into(),

--- a/metadata/src/playlist/list.rs
+++ b/metadata/src/playlist/list.rs
@@ -169,7 +169,7 @@ impl TryFrom<&<Playlist as Metadata>::Message> for SelectedListContent {
                 playlist
                     .resulting_revisions
                     .iter()
-                    .map(|p| p.try_into())
+                    .map(std::convert::TryInto::try_into)
                     .collect::<Result<Vec<SpotifyId>, Error>>()?,
             ),
             has_multiple_heads: playlist.multiple_heads(),
@@ -183,7 +183,7 @@ impl TryFrom<&<Playlist as Metadata>::Message> for SelectedListContent {
                 playlist
                     .geoblock
                     .iter()
-                    .map(|b| b.enum_value_or_default())
+                    .map(protobuf::EnumOrUnknown::enum_value_or_default)
                     .collect(),
             ),
         })

--- a/metadata/src/playlist/permission.rs
+++ b/metadata/src/playlist/permission.rs
@@ -33,7 +33,7 @@ impl From<&CapabilitiesMessage> for Capabilities {
                 playlist
                     .grantable_level
                     .iter()
-                    .map(|l| l.enum_value_or_default())
+                    .map(protobuf::EnumOrUnknown::enum_value_or_default)
                     .collect(),
             ),
             can_edit_metadata: playlist.can_edit_metadata(),

--- a/metadata/src/restriction.rs
+++ b/metadata/src/restriction.rs
@@ -35,7 +35,7 @@ impl Restriction {
     fn parse_country_codes(country_codes: &str) -> Vec<String> {
         country_codes
             .chunks(2)
-            .map(std::borrow::ToOwned::to_owned)
+            .map(ToOwned::to_owned)
             .collect()
     }
 }

--- a/metadata/src/restriction.rs
+++ b/metadata/src/restriction.rs
@@ -35,7 +35,7 @@ impl Restriction {
     fn parse_country_codes(country_codes: &str) -> Vec<String> {
         country_codes
             .chunks(2)
-            .map(|country_code| country_code.to_owned())
+            .map(std::borrow::ToOwned::to_owned)
             .collect()
     }
 }
@@ -58,7 +58,7 @@ impl From<&RestrictionMessage> for Restriction {
             catalogues: restriction
                 .catalogue
                 .iter()
-                .map(|c| c.enum_value_or_default())
+                .map(protobuf::EnumOrUnknown::enum_value_or_default)
                 .collect::<Vec<RestrictionCatalogue>>()
                 .as_slice()
                 .into(),

--- a/metadata/src/restriction.rs
+++ b/metadata/src/restriction.rs
@@ -35,7 +35,7 @@ impl Restriction {
     fn parse_country_codes(country_codes: &str) -> Vec<String> {
         country_codes
             .chunks(2)
-            .map(ToOwned::to_owned)
+            .map(Into::into)
             .collect()
     }
 }

--- a/metadata/src/restriction.rs
+++ b/metadata/src/restriction.rs
@@ -33,10 +33,7 @@ impl_deref_wrapped!(RestrictionCatalogues, Vec<RestrictionCatalogue>);
 
 impl Restriction {
     fn parse_country_codes(country_codes: &str) -> Vec<String> {
-        country_codes
-            .chunks(2)
-            .map(Into::into)
-            .collect()
+        country_codes.chunks(2).map(Into::into).collect()
     }
 }
 

--- a/oauth/Cargo.toml
+++ b/oauth/Cargo.toml
@@ -48,3 +48,6 @@ env_logger = { version = "0.11", default-features = false, features = [
     "auto-color",
 ] }
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
+
+[lints]
+workspace = true

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -493,7 +493,7 @@ pub fn get_access_token(
 
     let token_scopes: Vec<String> = match token.scopes() {
         Some(s) => s.iter().map(|s| s.to_string()).collect(),
-        _ => scopes.into_iter().map(|s| s.to_string()).collect(),
+        _ => scopes.into_iter().map(std::string::ToString::to_string).collect(),
     };
     let refresh_token = match token.refresh_token() {
         Some(t) => t.secret().to_string(),

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -493,7 +493,7 @@ pub fn get_access_token(
 
     let token_scopes: Vec<String> = match token.scopes() {
         Some(s) => s.iter().map(|s| s.to_string()).collect(),
-        _ => scopes.into_iter().map(std::string::ToString::to_string).collect(),
+        _ => scopes.into_iter().map(ToString::to_string).collect(),
     };
     let refresh_token = match token.refresh_token() {
         Some(t) => t.secret().to_string(),

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -493,7 +493,7 @@ pub fn get_access_token(
 
     let token_scopes: Vec<String> = match token.scopes() {
         Some(s) => s.iter().map(|s| s.to_string()).collect(),
-        _ => scopes.into_iter().map(ToString::to_string).collect(),
+        _ => scopes.into_iter().map(Into::into).collect(),
     };
     let refresh_token = match token.refresh_token() {
         Some(t) => t.secret().to_string(),

--- a/playback/Cargo.toml
+++ b/playback/Cargo.toml
@@ -97,3 +97,6 @@ rand_distr = "0.5"
 
 # Local file handling
 form_urlencoded = "1.2.2"
+
+[lints]
+workspace = true

--- a/playback/src/local_file.rs
+++ b/playback/src/local_file.rs
@@ -27,7 +27,7 @@ pub struct LocalFileLookup(HashMap<SpotifyUri, PathBuf>);
 
 impl LocalFileLookup {
     pub fn get(&self, uri: &SpotifyUri) -> Option<&Path> {
-        self.0.get(uri).map(|p| p.as_path())
+        self.0.get(uri).map(std::path::PathBuf::as_path)
     }
 }
 

--- a/playback/src/local_file.rs
+++ b/playback/src/local_file.rs
@@ -27,7 +27,7 @@ pub struct LocalFileLookup(HashMap<SpotifyUri, PathBuf>);
 
 impl LocalFileLookup {
     pub fn get(&self, uri: &SpotifyUri) -> Option<&Path> {
-        self.0.get(uri).map(std::path::PathBuf::as_path)
+        self.0.get(uri).map(PathBuf::as_path)
     }
 }
 

--- a/protocol/Cargo.toml
+++ b/protocol/Cargo.toml
@@ -14,3 +14,6 @@ protobuf = "3"
 
 [build-dependencies]
 protobuf-codegen = "3"
+
+[lints]
+workspace = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -1138,7 +1138,7 @@ async fn get_setup() -> Setup {
     let cache = {
         let volume_dir = opt_str(SYSTEM_CACHE)
             .or_else(|| opt_str(CACHE))
-            .map(|p| p.into());
+            .map(std::convert::Into::into);
 
         let cred_dir = if opt_present(DISABLE_CREDENTIAL_CACHE) {
             None

--- a/src/main.rs
+++ b/src/main.rs
@@ -1138,7 +1138,7 @@ async fn get_setup() -> Setup {
     let cache = {
         let volume_dir = opt_str(SYSTEM_CACHE)
             .or_else(|| opt_str(CACHE))
-            .map(std::convert::Into::into);
+            .map(Into::into);
 
         let cred_dir = if opt_present(DISABLE_CREDENTIAL_CACHE) {
             None


### PR DESCRIPTION
Checks for closures which only invoke a method on the closure argument and can be replaced by referencing the method directly.

https://rust-lang.github.io/rust-clippy/master/index.html#redundant_closure_for_method_calls