### PR TITLE
fix: num-bigint-dig future incompatibilities

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2200,9 +2200,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
  "lazy_static",
  "libm",


### PR DESCRIPTION
```log
librespot-org-librespot % cargo report future-incompatibilities --id 1 --package num-bigint-dig@0.8.5
The following warnings were discovered during the build. These warnings are an
indication that the packages contain code that will become an error in a
future release of Rust. These warnings typically cover changes to close
soundness problems, unintended or undocumented behavior, or critical problems
that cannot be fixed in a backwards-compatible fashion, and are not expected
to be in wide use.

Each warning should contain a link for more information on what the warning
means and how to resolve it.


To solve this problem, you can try the following approaches:


- Some affected dependencies have newer versions available.
You may want to consider updating them to a newer version to see if the issue has been fixed.

num-bigint-dig v0.8.5 has the following newer versions available: 0.8.6, 0.9.0, 0.9.1

- If the issue is not solved by updating the dependencies, a fix has to be
implemented by those dependencies. You can help with that by notifying the
maintainers of this problem (e.g. by creating a bug report) or by proposing a
fix to the maintainers (e.g. by creating a pull request):

  - num-bigint-dig@0.8.5
  - Repository: https://github.com/dignifiedquire/num-bigint
  - Detailed warning command: `cargo report future-incompatibilities --id 1 --package num-bigint-dig@0.8.5`

- If waiting for an upstream fix is not an option, you can use the `[patch]`
section in `Cargo.toml` to use your own version of the dependency. For more
information, see:
https://doc.rust-lang.org/cargo/reference/overriding-dependencies.html#the-patch-section
```