### PR TITLE
chore: update crypto-common to v0.1.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -434,9 +434,9 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
@@ -861,9 +861,9 @@ dependencies = [
 
 [[package]]
 name = "generic-array"
-version = "0.14.9"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",

--- a/core/src/authentication.rs
+++ b/core/src/authentication.rs
@@ -66,7 +66,6 @@ impl Credentials {
         }
     }
 
-    #[expect(deprecated)]
     pub fn with_blob(
         username: impl Into<String>,
         encrypted_blob: impl AsRef<[u8]>,


### PR DESCRIPTION
fixes generic-array deperecation warnings

Related issues: https://github.com/RustCrypto/traits/issues/2036, https://github.com/fizyk20/generic-array/issues/158