### PR TITLE
fix: add fallback for vergen git values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - [main] Fixed `--volume-ctrl fixed` not disabling volume control
+- [core] Fixed some version constants containing `VERGEN_IDEMPOTENT_OUTPUT`
 
 ## [0.8.0] - 2025-11-10
 

--- a/core/build.rs
+++ b/core/build.rs
@@ -8,23 +8,34 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .commit_date(true) // outputs 'VERGEN_GIT_COMMIT_DATE'
         .build()?;
 
+    if let Err(why) = Emitter::default()
+        .fail_on_error()
+        .add_instructions(&gitcl)
+        .and_then(|emitter| emitter.emit())
+    {
+        // if we are running into an error here, the git repo is most likely missing
+        // in that case we are probably a dependency and want to emit default values
+        println!("cargo:warning=emitting vergen-gitcl default values: {why}");
+        println!("cargo:rustc-env=VERGEN_GIT_SHA=stable");
+        println!("cargo:rustc-env=VERGEN_GIT_COMMIT_DATE=unknown");
+    }
+
     let build = BuildBuilder::default()
         .build_date(true) // outputs 'VERGEN_BUILD_DATE'
         .build()?;
 
     Emitter::default()
         .add_instructions(&build)?
-        .add_instructions(&gitcl)?
         .emit()
         .expect("Unable to generate the cargo keys!");
-    let build_id = match std::env::var("SOURCE_DATE_EPOCH") {
-        Ok(val) => val,
-        Err(_) => rand::rng()
+
+    let build_id = std::env::var("SOURCE_DATE_EPOCH").unwrap_or_else(|_| {
+        rand::rng()
             .sample_iter(Alphanumeric)
             .take(8)
             .map(char::from)
-            .collect(),
-    };
+            .collect()
+    });
 
     println!("cargo:rustc-env=LIBRESPOT_BUILD_ID={build_id}");
     Ok(())


### PR DESCRIPTION
Adds default values for the `vergen-gitcl` git values, when no `.git` folder is found for the dependency.

Fixes #1572