### PR TITLE
ci: build also on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest]
         toolchain:
           - "1.85" # MSRV (Minimum supported rust version)
           - stable


### PR DESCRIPTION
if you still have enough CI time; macOS count 10x Linux time