### PR TITLE
Emit `SetQueue` event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [connect] Add method `add_to_queue` to `Spirc` to add tracks, episodes, albums and playlists to the queue
-- [playback] Add `AddedToQueue` player event, emitting when a track was added to the queue with `Spirc::add_to_queue`
+- [playback] Add `SetQueue` player event, emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [connect] Add method `add_to_queue` to `Spirc` to add tracks, episodes, albums and playlists to the queue
-- [playback] Add `SetQueue` player event, emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect)
+- [playback] Add `SetQueue` player event (opt-in), emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [connect] Add method `add_to_queue` to `Spirc` to add tracks, episodes, albums and playlists to the queue
-- [playback] Add `SetQueue` player event (opt-in), emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect)
+- [playback] Add `SetQueue` player event, emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect). Gated behind `ConnectConfig::emit_set_queue_events`
 
 ### Changed
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -14,7 +14,7 @@ use crate::{
     model::{LoadRequest, PlayingTrack, SpircPlayStatus},
     playback::{
         mixer::Mixer,
-        player::{Player, PlayerEvent, PlayerEventChannel},
+        player::{Player, PlayerEvent, PlayerEventChannel, QueueTrack},
     },
     protocol::{
         connect::{Cluster, ClusterUpdate, LogoutCommand, SetVolumeCommand},
@@ -650,21 +650,27 @@ impl SpircTask {
         let context_uri = self.connect_state.context_uri().clone();
         let state_player = self.connect_state.player();
 
-        let current_track = state_player
-            .track
-            .as_ref()
-            .map(|t| (t.uri.clone(), t.provider.clone()));
+        let current_track = state_player.track.as_ref().map(|t| QueueTrack {
+            uri: t.uri.clone(),
+            provider: t.provider.clone(),
+        });
 
         let next_tracks: Vec<_> = state_player
             .next_tracks
             .iter()
-            .map(|t| (t.uri.clone(), t.provider.clone()))
+            .map(|t| QueueTrack {
+                uri: t.uri.clone(),
+                provider: t.provider.clone(),
+            })
             .collect();
 
         let prev_tracks: Vec<_> = state_player
             .prev_tracks
             .iter()
-            .map(|t| (t.uri.clone(), t.provider.clone()))
+            .map(|t| QueueTrack {
+                uri: t.uri.clone(),
+                provider: t.provider.clone(),
+            })
             .collect();
 
         self.player

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -95,6 +95,8 @@ struct SpircTask {
 
     context_resolver: ContextResolver,
 
+    emit_set_queue_events: bool,
+
     shutdown: bool,
     session: Session,
 
@@ -173,6 +175,7 @@ impl Spirc {
         let spirc_id = SPIRC_COUNTER.fetch_add(1, Ordering::AcqRel);
         debug!("new Spirc[{spirc_id}]");
 
+        let emit_set_queue_events = config.emit_set_queue_events;
         let connect_state = ConnectState::new(config, &session);
 
         let connection_id_update = session
@@ -248,6 +251,8 @@ impl Spirc {
             player_events: Some(player_events),
 
             context_resolver: ContextResolver::new(session.clone()),
+
+            emit_set_queue_events,
 
             shutdown: false,
             session,
@@ -647,6 +652,10 @@ impl SpircTask {
 
     /// Emit set queue event via PlayerEvent
     fn emit_set_queue_event(&self) {
+        if !self.emit_set_queue_events {
+            return;
+        }
+
         let context_uri = self.connect_state.context_uri().clone();
         let state_player = self.connect_state.player();
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1657,8 +1657,8 @@ impl SpircTask {
                 ..Default::default()
             };
             self.connect_state.add_to_queue(track, true);
-            self.emit_set_queue_event();
         }
+        self.emit_set_queue_event();
     }
 
     fn handle_preload_next_track(&mut self) {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1119,34 +1119,8 @@ impl SpircTask {
                 self.emit_set_queue_event();
             }
             SetQueue(set_queue) => {
-                // Extract current state and new queue data for the event before updating the state
-                let context_uri = self.connect_state.context_uri().clone();
-                let state_player = self.connect_state.player();
-
-                let current_track = state_player
-                    .track
-                    .as_ref()
-                    .map(|t| (t.uri.clone(), t.provider.clone()));
-
-                let next_tracks: Vec<(String, String)> = set_queue
-                    .next_tracks
-                    .iter()
-                    .map(|t| (t.uri.clone(), t.provider.clone()))
-                    .collect();
-
-                let prev_tracks: Vec<(String, String)> = set_queue
-                    .prev_tracks
-                    .iter()
-                    .map(|t| (t.uri.clone(), t.provider.clone()))
-                    .collect();
-
                 self.connect_state.handle_set_queue(set_queue);
-                self.player.emit_set_queue_event(
-                    context_uri,
-                    current_track,
-                    next_tracks,
-                    prev_tracks,
-                );
+                self.emit_set_queue_event();
             }
             SetOptions(set_options) => {
                 if let Some(repeat_context) = set_options.repeating_context {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -656,7 +656,6 @@ impl SpircTask {
             return;
         }
 
-        let context_uri = self.connect_state.context_uri().clone();
         let state_player = self.connect_state.player();
 
         let current_track = state_player.track.as_ref().map(|t| QueueTrack {
@@ -681,6 +680,8 @@ impl SpircTask {
                 provider: t.provider.clone(),
             })
             .collect();
+
+        let context_uri = self.connect_state.context_uri().clone();
 
         self.player
             .emit_set_queue_event(context_uri, current_track, next_tracks, prev_tracks);

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1119,7 +1119,7 @@ impl SpircTask {
                 self.emit_set_queue_event();
             }
             SetQueue(set_queue) => {
-                // Extract track data before consuming set_queue
+                // Extract current state and new queue data for the event before updating the state
                 let context_uri = self.connect_state.context_uri().clone();
                 let state_player = self.connect_state.player();
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -636,8 +636,39 @@ impl SpircTask {
             false
         };
 
+        // Fire set queue event if context was successfully loaded
+        if update_state {
+            self.emit_set_queue_event();
+        }
+
         self.context_resolver.remove_used_and_invalid();
         update_state
+    }
+
+    /// Emit set queue event via PlayerEvent
+    fn emit_set_queue_event(&self) {
+        let context_uri = self.connect_state.context_uri().clone();
+        let state_player = self.connect_state.player();
+
+        let current_track = state_player
+            .track
+            .as_ref()
+            .map(|t| (t.uri.clone(), t.provider.clone()));
+
+        let next_tracks: Vec<_> = state_player
+            .next_tracks
+            .iter()
+            .map(|t| (t.uri.clone(), t.provider.clone()))
+            .collect();
+
+        let prev_tracks: Vec<_> = state_player
+            .prev_tracks
+            .iter()
+            .map(|t| (t.uri.clone(), t.provider.clone()))
+            .collect();
+
+        self.player
+            .emit_set_queue_event(context_uri, current_track, next_tracks, prev_tracks);
     }
 
     // todo: is the time_delta still necessary?
@@ -1090,7 +1121,36 @@ impl SpircTask {
                     self.player.emit_added_to_queue_event(uri);
                 }
             }
-            SetQueue(set_queue) => self.connect_state.handle_set_queue(set_queue),
+            SetQueue(set_queue) => {
+                // Extract track data before consuming set_queue
+                let context_uri = self.connect_state.context_uri().clone();
+                let state_player = self.connect_state.player();
+
+                let current_track = state_player
+                    .track
+                    .as_ref()
+                    .map(|t| (t.uri.clone(), t.provider.clone()));
+
+                let next_tracks: Vec<(String, String)> = set_queue
+                    .next_tracks
+                    .iter()
+                    .map(|t| (t.uri.clone(), t.provider.clone()))
+                    .collect();
+
+                let prev_tracks: Vec<(String, String)> = set_queue
+                    .prev_tracks
+                    .iter()
+                    .map(|t| (t.uri.clone(), t.provider.clone()))
+                    .collect();
+
+                self.connect_state.handle_set_queue(set_queue);
+                self.player.emit_set_queue_event(
+                    context_uri,
+                    current_track,
+                    next_tracks,
+                    prev_tracks,
+                );
+            }
             SetOptions(set_options) => {
                 if let Some(repeat_context) = set_options.repeating_context {
                     self.handle_repeat_context(repeat_context)?
@@ -1459,6 +1519,8 @@ impl SpircTask {
         let _ = self
             .connect_state
             .update_context(ctx, ContextType::Default)?;
+
+        self.emit_set_queue_event();
 
         Ok(())
     }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1115,11 +1115,8 @@ impl SpircTask {
             }
             SetRepeatingTrack(repeat_track) => self.handle_repeat_track(repeat_track.value),
             AddToQueue(add_to_queue) => {
-                let track = add_to_queue.track.clone();
                 self.connect_state.add_to_queue(add_to_queue.track, true);
-                if let Ok(uri) = SpotifyUri::from_uri(&track.uri) {
-                    self.player.emit_added_to_queue_event(uri);
-                }
+                self.emit_set_queue_event();
             }
             SetQueue(set_queue) => {
                 // Extract track data before consuming set_queue
@@ -1660,10 +1657,7 @@ impl SpircTask {
                 ..Default::default()
             };
             self.connect_state.add_to_queue(track, true);
-
-            if let Ok(uri) = SpotifyUri::from_uri(&track_uri) {
-                self.player.emit_added_to_queue_event(uri);
-            }
+            self.emit_set_queue_event();
         }
     }
 

--- a/connect/src/state.rs
+++ b/connect/src/state.rs
@@ -90,6 +90,8 @@ pub struct ConnectConfig {
     pub disable_volume: bool,
     /// Number of incremental steps (default: 64)
     pub volume_steps: u16,
+    /// Emit `SetQueue` player events when the queue changes (default: false)
+    pub emit_set_queue_events: bool,
 }
 
 impl Default for ConnectConfig {
@@ -101,6 +103,7 @@ impl Default for ConnectConfig {
             initial_volume: u16::MAX / 2,
             disable_volume: false,
             volume_steps: 64,
+            emit_set_queue_events: false,
         }
     }
 }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -140,10 +140,17 @@ enum PlayerCommand {
     EmitAutoPlayChangedEvent(bool),
     EmitSetQueueEvent {
         context_uri: String,
-        current_track: Option<(String, String)>, // (uri, provider)
-        next_tracks: Vec<(String, String)>,      // (uri, provider)
-        prev_tracks: Vec<(String, String)>,      // (uri, provider)
+        current_track: Option<QueueTrack>,
+        next_tracks: Vec<QueueTrack>,
+        prev_tracks: Vec<QueueTrack>,
     },
+}
+
+/// Represents a track in the queue with its URI and provider.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct QueueTrack {
+    pub uri: String,
+    pub provider: String,
 }
 
 #[derive(Debug, Clone)]
@@ -257,9 +264,9 @@ pub enum PlayerEvent {
     /// Fired when the queue is set or context is loaded with its track list.
     SetQueue {
         context_uri: String,
-        current_track: Option<(String, String)>, // (uri, provider)
-        next_tracks: Vec<(String, String)>,      // (uri, provider)
-        prev_tracks: Vec<(String, String)>,      // (uri, provider)
+        current_track: Option<QueueTrack>,
+        next_tracks: Vec<QueueTrack>,
+        prev_tracks: Vec<QueueTrack>,
     },
 }
 
@@ -664,9 +671,9 @@ impl Player {
     pub fn emit_set_queue_event(
         &self,
         context_uri: String,
-        current_track: Option<(String, String)>,
-        next_tracks: Vec<(String, String)>,
-        prev_tracks: Vec<(String, String)>,
+        current_track: Option<QueueTrack>,
+        next_tracks: Vec<QueueTrack>,
+        prev_tracks: Vec<QueueTrack>,
     ) {
         self.command(PlayerCommand::EmitSetQueueEvent {
             context_uri,

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -139,6 +139,12 @@ enum PlayerCommand {
     },
     EmitAutoPlayChangedEvent(bool),
     EmitAddedToQueueEvent(SpotifyUri),
+    EmitSetQueueEvent {
+        context_uri: String,
+        current_track: Option<(String, String)>, // (uri, provider)
+        next_tracks: Vec<(String, String)>,      // (uri, provider)
+        prev_tracks: Vec<(String, String)>,      // (uri, provider)
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -251,6 +257,13 @@ pub enum PlayerEvent {
     },
     FilterExplicitContentChanged {
         filter: bool,
+    },
+    /// Fired when the queue is set or context is loaded with its track list.
+    SetQueue {
+        context_uri: String,
+        current_track: Option<(String, String)>, // (uri, provider)
+        next_tracks: Vec<(String, String)>,      // (uri, provider)
+        prev_tracks: Vec<(String, String)>,      // (uri, provider)
     },
 }
 
@@ -654,6 +667,21 @@ impl Player {
 
     pub fn emit_added_to_queue_event(&self, track_id: SpotifyUri) {
         self.command(PlayerCommand::EmitAddedToQueueEvent(track_id));
+    }
+
+    pub fn emit_set_queue_event(
+        &self,
+        context_uri: String,
+        current_track: Option<(String, String)>,
+        next_tracks: Vec<(String, String)>,
+        prev_tracks: Vec<(String, String)>,
+    ) {
+        self.command(PlayerCommand::EmitSetQueueEvent {
+            context_uri,
+            current_track,
+            next_tracks,
+            prev_tracks,
+        });
     }
 }
 
@@ -2347,6 +2375,18 @@ impl PlayerInternal {
                 self.send_event(PlayerEvent::AddedToQueue { track_id })
             }
 
+            PlayerCommand::EmitSetQueueEvent {
+                context_uri,
+                current_track,
+                next_tracks,
+                prev_tracks,
+            } => self.send_event(PlayerEvent::SetQueue {
+                context_uri,
+                current_track,
+                next_tracks,
+                prev_tracks,
+            }),
+
             PlayerCommand::EmitFilterExplicitContentChangedEvent(filter) => {
                 self.send_event(PlayerEvent::FilterExplicitContentChanged { filter });
 
@@ -2551,6 +2591,17 @@ impl fmt::Debug for PlayerCommand {
             PlayerCommand::EmitAddedToQueueEvent(track_id) => f
                 .debug_tuple("EmitAddedToQueueEvent")
                 .field(&track_id)
+                .finish(),
+            PlayerCommand::EmitSetQueueEvent {
+                context_uri,
+                next_tracks,
+                prev_tracks,
+                ..
+            } => f
+                .debug_tuple("EmitSetQueueEvent")
+                .field(&context_uri)
+                .field(&next_tracks.len())
+                .field(&prev_tracks.len())
                 .finish(),
         }
     }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -138,7 +138,6 @@ enum PlayerCommand {
         track: bool,
     },
     EmitAutoPlayChangedEvent(bool),
-    EmitAddedToQueueEvent(SpotifyUri),
     EmitSetQueueEvent {
         context_uri: String,
         current_track: Option<(String, String)>, // (uri, provider)
@@ -152,9 +151,6 @@ pub enum PlayerEvent {
     // Play request id changed
     PlayRequestIdChanged {
         play_request_id: u64,
-    },
-    AddedToQueue {
-        track_id: SpotifyUri,
     },
     // Fired when the player is stopped (e.g. by issuing a "stop" command to the player).
     Stopped {
@@ -663,10 +659,6 @@ impl Player {
 
     pub fn emit_auto_play_changed_event(&self, auto_play: bool) {
         self.command(PlayerCommand::EmitAutoPlayChangedEvent(auto_play));
-    }
-
-    pub fn emit_added_to_queue_event(&self, track_id: SpotifyUri) {
-        self.command(PlayerCommand::EmitAddedToQueueEvent(track_id));
     }
 
     pub fn emit_set_queue_event(
@@ -2371,10 +2363,6 @@ impl PlayerInternal {
                 self.auto_normalise_as_album = setting
             }
 
-            PlayerCommand::EmitAddedToQueueEvent(track_id) => {
-                self.send_event(PlayerEvent::AddedToQueue { track_id })
-            }
-
             PlayerCommand::EmitSetQueueEvent {
                 context_uri,
                 current_track,
@@ -2587,10 +2575,6 @@ impl fmt::Debug for PlayerCommand {
             PlayerCommand::EmitAutoPlayChangedEvent(auto_play) => f
                 .debug_tuple("EmitAutoPlayChangedEvent")
                 .field(&auto_play)
-                .finish(),
-            PlayerCommand::EmitAddedToQueueEvent(track_id) => f
-                .debug_tuple("EmitAddedToQueueEvent")
-                .field(&track_id)
                 .finish(),
             PlayerCommand::EmitSetQueueEvent {
                 context_uri,

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -80,7 +80,7 @@ struct PlayerInternal {
     sink_status: SinkStatus,
     sink_event_callback: Option<SinkEventCallback>,
     volume_getter: Box<dyn VolumeGetter + Send>,
-    event_senders: Vec<EventSubscriber>,
+    event_senders: Vec<mpsc::UnboundedSender<PlayerEvent>>,
     converter: Converter,
 
     normalisation_integrators: [f64; 2],
@@ -113,10 +113,7 @@ enum PlayerCommand {
     Stop,
     Seek(u32),
     SetSession(Session),
-    AddEventSender {
-        sender: mpsc::UnboundedSender<PlayerEvent>,
-        opt_in_events: OptInPlayerEvents,
-    },
+    AddEventSender(mpsc::UnboundedSender<PlayerEvent>),
     SetSinkEventCallback(Option<SinkEventCallback>),
     EmitVolumeChangedEvent(u16),
     SetAutoNormaliseAsAlbum(bool),
@@ -154,20 +151,6 @@ enum PlayerCommand {
 pub struct QueueTrack {
     pub uri: String,
     pub provider: String,
-}
-
-/// Opt-in player events that are not delivered to subscribers by default.
-///
-/// Use [`Player::get_player_event_channel_with`] to subscribe to these.
-#[derive(Clone, Copy, Debug, Default)]
-pub struct OptInPlayerEvents {
-    /// Subscribe to [`PlayerEvent::SetQueue`] events.
-    pub set_queue: bool,
-}
-
-struct EventSubscriber {
-    sender: mpsc::UnboundedSender<PlayerEvent>,
-    opt_in_events: OptInPlayerEvents,
 }
 
 #[derive(Debug, Clone)]
@@ -319,14 +302,6 @@ impl PlayerEvent {
                 play_request_id, ..
             } => Some(*play_request_id),
             _ => None,
-        }
-    }
-
-    /// Whether this event should be sent to a subscriber with the given opt-in events.
-    fn should_send(&self, opt_in: &OptInPlayerEvents) -> bool {
-        match self {
-            PlayerEvent::SetQueue { .. } => opt_in.set_queue,
-            _ => true,
         }
     }
 }
@@ -619,18 +594,8 @@ impl Player {
     }
 
     pub fn get_player_event_channel(&self) -> PlayerEventChannel {
-        self.get_player_event_channel_with(OptInPlayerEvents::default())
-    }
-
-    pub fn get_player_event_channel_with(
-        &self,
-        opt_in_events: OptInPlayerEvents,
-    ) -> PlayerEventChannel {
         let (event_sender, event_receiver) = mpsc::unbounded_channel();
-        self.command(PlayerCommand::AddEventSender {
-            sender: event_sender,
-            opt_in_events,
-        });
+        self.command(PlayerCommand::AddEventSender(event_sender));
         event_receiver
     }
 
@@ -2353,15 +2318,7 @@ impl PlayerInternal {
 
             PlayerCommand::SetSession(session) => self.session = session,
 
-            PlayerCommand::AddEventSender {
-                sender,
-                opt_in_events,
-            } => {
-                self.event_senders.push(EventSubscriber {
-                    sender,
-                    opt_in_events,
-                });
-            }
+            PlayerCommand::AddEventSender(sender) => self.event_senders.push(sender),
 
             PlayerCommand::SetSinkEventCallback(callback) => self.sink_event_callback = callback,
 
@@ -2462,12 +2419,8 @@ impl PlayerInternal {
     }
 
     fn send_event(&mut self, event: PlayerEvent) {
-        self.event_senders.retain(|sub| {
-            if !event.should_send(&sub.opt_in_events) {
-                return true; // keep subscriber, skip this event
-            }
-            sub.sender.send(event.clone()).is_ok()
-        });
+        self.event_senders
+            .retain(|sender| sender.send(event.clone()).is_ok());
     }
 
     fn load_track(
@@ -2573,7 +2526,7 @@ impl fmt::Debug for PlayerCommand {
             PlayerCommand::Stop => f.debug_tuple("Stop").finish(),
             PlayerCommand::Seek(position) => f.debug_tuple("Seek").field(&position).finish(),
             PlayerCommand::SetSession(_) => f.debug_tuple("SetSession").finish(),
-            PlayerCommand::AddEventSender { .. } => f.debug_tuple("AddEventSender").finish(),
+            PlayerCommand::AddEventSender(_) => f.debug_tuple("AddEventSender").finish(),
             PlayerCommand::SetSinkEventCallback(_) => {
                 f.debug_tuple("SetSinkEventCallback").finish()
             }

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -80,7 +80,7 @@ struct PlayerInternal {
     sink_status: SinkStatus,
     sink_event_callback: Option<SinkEventCallback>,
     volume_getter: Box<dyn VolumeGetter + Send>,
-    event_senders: Vec<mpsc::UnboundedSender<PlayerEvent>>,
+    event_senders: Vec<EventSubscriber>,
     converter: Converter,
 
     normalisation_integrators: [f64; 2],
@@ -113,7 +113,10 @@ enum PlayerCommand {
     Stop,
     Seek(u32),
     SetSession(Session),
-    AddEventSender(mpsc::UnboundedSender<PlayerEvent>),
+    AddEventSender {
+        sender: mpsc::UnboundedSender<PlayerEvent>,
+        opt_in_events: OptInPlayerEvents,
+    },
     SetSinkEventCallback(Option<SinkEventCallback>),
     EmitVolumeChangedEvent(u16),
     SetAutoNormaliseAsAlbum(bool),
@@ -151,6 +154,20 @@ enum PlayerCommand {
 pub struct QueueTrack {
     pub uri: String,
     pub provider: String,
+}
+
+/// Opt-in player events that are not delivered to subscribers by default.
+///
+/// Use [`Player::get_player_event_channel_with`] to subscribe to these.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct OptInPlayerEvents {
+    /// Subscribe to [`PlayerEvent::SetQueue`] events.
+    pub set_queue: bool,
+}
+
+struct EventSubscriber {
+    sender: mpsc::UnboundedSender<PlayerEvent>,
+    opt_in_events: OptInPlayerEvents,
 }
 
 #[derive(Debug, Clone)]
@@ -302,6 +319,14 @@ impl PlayerEvent {
                 play_request_id, ..
             } => Some(*play_request_id),
             _ => None,
+        }
+    }
+
+    /// Whether this event should be sent to a subscriber with the given opt-in events.
+    fn should_send(&self, opt_in: &OptInPlayerEvents) -> bool {
+        match self {
+            PlayerEvent::SetQueue { .. } => opt_in.set_queue,
+            _ => true,
         }
     }
 }
@@ -594,8 +619,18 @@ impl Player {
     }
 
     pub fn get_player_event_channel(&self) -> PlayerEventChannel {
+        self.get_player_event_channel_with(OptInPlayerEvents::default())
+    }
+
+    pub fn get_player_event_channel_with(
+        &self,
+        opt_in_events: OptInPlayerEvents,
+    ) -> PlayerEventChannel {
         let (event_sender, event_receiver) = mpsc::unbounded_channel();
-        self.command(PlayerCommand::AddEventSender(event_sender));
+        self.command(PlayerCommand::AddEventSender {
+            sender: event_sender,
+            opt_in_events,
+        });
         event_receiver
     }
 
@@ -2318,7 +2353,15 @@ impl PlayerInternal {
 
             PlayerCommand::SetSession(session) => self.session = session,
 
-            PlayerCommand::AddEventSender(sender) => self.event_senders.push(sender),
+            PlayerCommand::AddEventSender {
+                sender,
+                opt_in_events,
+            } => {
+                self.event_senders.push(EventSubscriber {
+                    sender,
+                    opt_in_events,
+                });
+            }
 
             PlayerCommand::SetSinkEventCallback(callback) => self.sink_event_callback = callback,
 
@@ -2419,8 +2462,12 @@ impl PlayerInternal {
     }
 
     fn send_event(&mut self, event: PlayerEvent) {
-        self.event_senders
-            .retain(|sender| sender.send(event.clone()).is_ok());
+        self.event_senders.retain(|sub| {
+            if !event.should_send(&sub.opt_in_events) {
+                return true; // keep subscriber, skip this event
+            }
+            sub.sender.send(event.clone()).is_ok()
+        });
     }
 
     fn load_track(
@@ -2526,7 +2573,7 @@ impl fmt::Debug for PlayerCommand {
             PlayerCommand::Stop => f.debug_tuple("Stop").finish(),
             PlayerCommand::Seek(position) => f.debug_tuple("Seek").field(&position).finish(),
             PlayerCommand::SetSession(_) => f.debug_tuple("SetSession").finish(),
-            PlayerCommand::AddEventSender(_) => f.debug_tuple("AddEventSender").finish(),
+            PlayerCommand::AddEventSender { .. } => f.debug_tuple("AddEventSender").finish(),
             PlayerCommand::SetSinkEventCallback(_) => {
                 f.debug_tuple("SetSinkEventCallback").finish()
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1534,7 +1534,7 @@ async fn get_setup() -> Setup {
             initial_volume,
             disable_volume,
             volume_steps,
-            emit_set_queue_events: false
+            emit_set_queue_events: false,
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1534,7 +1534,7 @@ async fn get_setup() -> Setup {
             initial_volume,
             disable_volume,
             volume_steps,
-            ..ConnectConfig::default()
+            emit_set_queue_events: false
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use librespot::{
         },
         dither,
         mixer::{self, MixerConfig, MixerFn},
-        player::{Player, coefficient_to_duration, duration_to_coefficient},
+        player::{OptInPlayerEvents, Player, coefficient_to_duration, duration_to_coefficient},
     },
 };
 use librespot_oauth::OAuthClientBuilder;
@@ -1994,8 +1994,9 @@ async fn main() {
     });
 
     if let Some(player_event_program) = setup.player_event_program.clone() {
+        let opt_in_events = OptInPlayerEvents { set_queue: true };
         _event_handler = Some(EventHandler::new(
-            player.get_player_event_channel(),
+            player.get_player_event_channel_with(opt_in_events),
             &player_event_program,
         ));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use librespot::{
         },
         dither,
         mixer::{self, MixerConfig, MixerFn},
-        player::{OptInPlayerEvents, Player, coefficient_to_duration, duration_to_coefficient},
+        player::{Player, coefficient_to_duration, duration_to_coefficient},
     },
 };
 use librespot_oauth::OAuthClientBuilder;
@@ -1534,6 +1534,7 @@ async fn get_setup() -> Setup {
             initial_volume,
             disable_volume,
             volume_steps,
+            ..ConnectConfig::default()
         }
     };
 
@@ -1994,9 +1995,8 @@ async fn main() {
     });
 
     if let Some(player_event_program) = setup.player_event_program.clone() {
-        let opt_in_events = OptInPlayerEvents { set_queue: true };
         _event_handler = Some(EventHandler::new(
-            player.get_player_event_channel_with(opt_in_events),
+            player.get_player_event_channel(),
             &player_event_program,
         ));
 

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -27,10 +27,6 @@ impl EventHandler {
                                     .insert("PLAYER_EVENT", "play_request_id_changed".to_string());
                                 env_vars.insert("PLAY_REQUEST_ID", play_request_id.to_string());
                             }
-                            PlayerEvent::AddedToQueue { track_id } => {
-                                env_vars.insert("PLAYER_EVENT", "added_to_queue".to_string());
-                                env_vars.insert("TRACK_ID", track_id.to_id());
-                            }
                             PlayerEvent::TrackChanged { audio_item } => {
                                 let id = audio_item.track_id.to_id();
                                 env_vars.insert("PLAYER_EVENT", "track_changed".to_string());

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -238,14 +238,17 @@ impl EventHandler {
                             } => {
                                 env_vars.insert("PLAYER_EVENT", "set_queue".to_string());
                                 env_vars.insert("CONTEXT_URI", context_uri);
-                                if let Some((uri, provider)) = current_track {
-                                    env_vars.insert("CURRENT_TRACK", format!("{uri}\t{provider}"));
+                                if let Some(track) = current_track {
+                                    env_vars.insert(
+                                        "CURRENT_TRACK",
+                                        format!("{}\t{}", track.uri, track.provider),
+                                    );
                                 }
                                 env_vars.insert(
                                     "NEXT_TRACKS",
                                     next_tracks
                                         .into_iter()
-                                        .map(|(uri, provider)| format!("{uri}\t{provider}"))
+                                        .map(|t| format!("{}\t{}", t.uri, t.provider))
                                         .collect::<Vec<String>>()
                                         .join("\n"),
                                 );
@@ -253,7 +256,7 @@ impl EventHandler {
                                     "PREV_TRACKS",
                                     prev_tracks
                                         .into_iter()
-                                        .map(|(uri, provider)| format!("{uri}\t{provider}"))
+                                        .map(|t| format!("{}\t{}", t.uri, t.provider))
                                         .collect::<Vec<String>>()
                                         .join("\n"),
                                 );

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -234,6 +234,35 @@ impl EventHandler {
                                 );
                                 env_vars.insert("FILTER", filter.to_string());
                             }
+                            PlayerEvent::SetQueue {
+                                context_uri,
+                                current_track,
+                                next_tracks,
+                                prev_tracks,
+                            } => {
+                                env_vars.insert("PLAYER_EVENT", "set_queue".to_string());
+                                env_vars.insert("CONTEXT_URI", context_uri);
+                                if let Some((uri, provider)) = current_track {
+                                    env_vars
+                                        .insert("CURRENT_TRACK", format!("{uri}\t{provider}"));
+                                }
+                                env_vars.insert(
+                                    "NEXT_TRACKS",
+                                    next_tracks
+                                        .into_iter()
+                                        .map(|(uri, provider)| format!("{uri}\t{provider}"))
+                                        .collect::<Vec<String>>()
+                                        .join("\n"),
+                                );
+                                env_vars.insert(
+                                    "PREV_TRACKS",
+                                    prev_tracks
+                                        .into_iter()
+                                        .map(|(uri, provider)| format!("{uri}\t{provider}"))
+                                        .collect::<Vec<String>>()
+                                        .join("\n"),
+                                );
+                            }
                             // Ignore event irrelevant for standalone binary like PositionChanged
                             _ => {}
                         }

--- a/src/player_event_handler.rs
+++ b/src/player_event_handler.rs
@@ -239,8 +239,7 @@ impl EventHandler {
                                 env_vars.insert("PLAYER_EVENT", "set_queue".to_string());
                                 env_vars.insert("CONTEXT_URI", context_uri);
                                 if let Some((uri, provider)) = current_track {
-                                    env_vars
-                                        .insert("CURRENT_TRACK", format!("{uri}\t{provider}"));
+                                    env_vars.insert("CURRENT_TRACK", format!("{uri}\t{provider}"));
                                 }
                                 env_vars.insert(
                                     "NEXT_TRACKS",


### PR DESCRIPTION
## What does this do?

This emits a new universal `Player::SetQueue` event.

### Background info: How is the Spotify Connect queue organised?

The Spotify connect queue basically has the following data structure:

```
context_uri: SpotifyUri
current_track: Track
prev_tracks: []Track
next_tracks: []Track
```

Each Track has at least a track URI and a provider which can be `autoplay`, `context`, `queue` or `unavailable`.

* `autoplay`: Added by Spotify to keep playing
* `context`: part of the current context identified by `context_uri`
* `queue`: manually queued while a context was loaded
* `unavailable`: self explanatory 

Here you can see an example of a queue:

![539394739-65d47a85-9dd3-4b21-9343-da1503151c20](https://github.com/user-attachments/assets/b8beb9f5-8ab6-42f1-aaa5-27f3d000e3b1)


### Why is this event "universal"?

There are multiple actions that manipulate the queue in different ways. Examples:

* Loading a new context: manipulates `context_uri`, `current_track`, `prev_tracks`, `next_tracks`
* Queuing a new track/album/playlist while a context is loaded: manipulates `next_tracks`
* Reordering tracks in the queue: `next_tracks`
* Removing tracks from the queue: `next_tracks`

If a GUI application wants to adjust its state when any of these actions are performed remote or local, it just needs to listen to this one universal event. The queue displayed in the GUI is always correct and always up to date.

### Why does this remove AddToQueue that was just added in 87d37c3e18e7c712618cd04fad8303e4da9b9c7a ?

`AddToQueue` is a special case of `SetQueue`, and `SetQueue` covers all cases of `AddToQueue` usage. Also, it's less error prone for app developers. Say a GUI developer wants to display the current queue from Spirc, and the queue looks like this:

```
`context` Track 1 <- currently playing
`context` Track 2
`context` Track 3
`context` Track 4
```

When another track is queued, it will be placed after the currently playing track:

```
`context` Track 1 <- currently playing
`queue` Track 1
`context` Track 2
`context` Track 3
`context` Track 4
```

In this case, `AddToQueue` will be emitted for Track 1, and the GUI developer will be responsible to add it in the right position of the app's state.

When yet another track (or collection of tracks, e.g. an album with 2 tracks) is queued, those will be placed after the currently playing track AND after all the other `queue` tracks:

```
`context` Track 1 <- currently playing
`queue` Track 1
`queue` Track 2
`queue` Track 3
`context` Track 2
`context` Track 3
`context` Track 4
```

In this case, `AddToQueue` will be emitted with Track 2, then with Track 3. Again, the developer of the consuming app is responsible for placing the new tracks in the right position.

In contrast to this, `SetQueue` always emits the whole queue with the tracks in the right order, so the developer of the consuming app cannot place the tracks in the wrong position.

Also, `AddToQueue` was never in a release, so removing it is ok imho.


### Are there downsides?

As we're emitting ALL THE QUEUE FIELDS \o/ with every change, we do sometimes emit more than necessary. But we have to emit `next_tracks` most of the time, and the remaining queue fields are not that large compared to `next_tracks`.  `current_track` and `context_uri` is negligible, and `prev_tracks` is capped at 20 tracks.


### How to go from here?

I'd love to hear your input on this. Do you think a universal `SetQueue` event is a good thing? Or would you rather have more fine grained events emitting less data, e.g. one for `prev_tracks`, one for `next_tracks` one for `current_track` and `current_track`? Or should we keep the universal `SetQueue` for actions that manipulate all of `next_tracks`, but keep `AddToTrack` when adding tracks to the queue, manipulating only small parts of `next_tracks`?

The current approach works well for me and my reactive SwiftUI app, and makes updating the queue incredibly easy. But I'm still pretty new to this and there might be use cases that I didn't think of.