### PR TITLE
chore: pin vergen transitive dependency to 9.0.6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1908,6 +1908,7 @@ dependencies = [
  "tokio-util",
  "url",
  "uuid",
+ "vergen",
  "vergen-gitcl",
 ]
 

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -112,9 +112,11 @@ uuid = { version = "1", default-features = false, features = ["v4"] }
 [build-dependencies]
 rand = { version = "0.9", default-features = false, features = ["thread_rng"] }
 rand_distr = "0.5"
-vergen-gitcl = { version = "1.0", default-features = false, features = [
+vergen-gitcl = { version = "1.0.8", default-features = false, features = [
     "build",
 ] }
+# fix for https://github.com/rustyhorde/vergen/issues/478#issuecomment-3769340357
+vergen = "=9.0.6"
 
 [dev-dependencies]
 tokio = { version = "1", features = ["macros"] }


### PR DESCRIPTION
Fixes: #1681