### PR TITLE
Fix: parsing of SeekToCommand json with negative position values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] Fixed `--volume-ctrl fixed` not disabling volume control
 - [core] Fix default permissions on credentials file and warn user if file is world readable
 - [core] Try all resolved addresses for the dealer connection instead of failing after the first one.
+- [core] Allow parsing negative position values send in the `SeekToCommand` when seeking relative to current
 
 ## [0.8.0] - 2025-11-10
 

--- a/core/src/dealer/protocol/request.rs
+++ b/core/src/dealer/protocol/request.rs
@@ -108,7 +108,7 @@ pub struct PauseCommand {
 #[derive(Clone, Debug, Deserialize)]
 pub struct SeekToCommand {
     pub value: u32,
-    pub position: u32,
+    pub position: i32,
     pub logging_params: LoggingParams,
 }
 


### PR DESCRIPTION
### Fixed problem description:
When listening to a podcast episode the desktop and mobile applications offer buttons for skipping 15s forwards and backwards. The forward skipping button gets correctly handled but the backwards skipping comes back with an error message.

### Cause and fix of the problem:
The `SeekToCommand` struct expects a non-negative integer, but the Request-JSON contains a negative number when using the "-15s" buttons. Thus, I changed the type to allow for negative numbers, so the Request-JSON gets correctly parsed and afterwards successfully handled by the player. The player does not interpret the `position` field at all, so another option to fix this would be to simply remove the `position` field. It only uses the `value` field with seems to contain the absolute position to seek to.

```
websocket request: Object {
    "command": Object {
        "endpoint": String("seek_to"),
        "logging_params": Object {
            "device_identifier": String("<....>"),
        },
        "position": Number(-15000),
        "relative": String("current"),
        "value": Number(567682),
    },
    "message_id": Number(1334681861),
    "sent_by_device_id": String("<....>"),
    "target_alias_id": Null,
}
```