### PR TITLE
chore(deps): update rust crate quinn-proto to v0.11.15

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2789,9 +2789,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
Fix https://github.com/librespot-org/librespot/issues/1697 (RUSTSEC-2026-0037: Denial of service in Quinn endpoints)