### PR TITLE
expose remote state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [connect] Add method `add_to_queue` to `Spirc` to add tracks, episodes, albums and playlists to the queue
+- [connect] Add broadcast/watch channels to `Spirc` for observing remote player, cluster, and queue state independent of whether this device is active
 - [playback] Add `SetQueue` player event, emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect). Gated behind `ConnectConfig::emit_set_queue_events`
 
 ### Changed

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -2379,12 +2379,17 @@ fn apply_local_activation(
     info: ClusterDeviceInfo,
     active: bool,
 ) {
-    if let Some(prev_id) = &state.active_device_id {
-        if let Some(prev) = state.devices.get_mut(prev_id) {
-            prev.is_active = false;
+    if active {
+        if let Some(prev_id) = &state.active_device_id {
+            if let Some(prev) = state.devices.get_mut(prev_id) {
+                prev.is_active = false;
+            }
         }
+        state.active_device_id = Some(device_id.clone());
+    } else if state.active_device_id.as_deref() == Some(device_id.as_str()) {
+        // don't relinquish if a remote update already moved active elsewhere
+        state.active_device_id = None;
     }
-    state.active_device_id = active.then(|| device_id.clone());
     state.devices.insert(device_id, info);
 }
 
@@ -2805,6 +2810,31 @@ mod tests {
         );
 
         assert_eq!(state.active_device_id, None);
+        assert!(!state.devices["me"].is_active);
+    }
+
+    #[test]
+    fn apply_local_activation_deactivation_does_not_clobber_newer_active_device() {
+        // a remote ClusterUpdate already made "other" active before our own
+        // deactivation got processed; we shouldn't stomp that back to None
+        let mut state = ClusterState {
+            devices: [
+                ("me".to_string(), device_info("me", false)),
+                ("other".to_string(), device_info("other", true)),
+            ]
+            .into(),
+            active_device_id: Some("other".to_string()),
+        };
+
+        apply_local_activation(
+            &mut state,
+            "me".to_string(),
+            device_info("me", false),
+            false,
+        );
+
+        assert_eq!(state.active_device_id.as_deref(), Some("other"));
+        assert!(state.devices["other"].is_active);
         assert!(!state.devices["me"].is_active);
     }
 }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1405,6 +1405,12 @@ impl SpircTask {
                             });
                         }
                     }
+                } else {
+                    let queue_list = QueueList {
+                        prev_tracks: state.prev_tracks.iter().map(|t| t.uri.clone()).collect(),
+                        next_tracks: state.next_tracks.iter().map(|t| t.uri.clone()).collect(),
+                    };
+                    let _ = self.queue_list_sender.send(queue_list);
                 }
                 self.emit_player_update(Some(state.clone()), self.last_player_state.as_ref());
                 self.last_player_state = Some(state);

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -114,8 +114,10 @@ pub struct QueueList {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[non_exhaustive]
 pub enum ClusterUpdateReason {
-    /// Device list changed
-    DeviceListChanged,
+    /// A device joined the cluster
+    DeviceAppeared,
+    /// A device left the cluster
+    DeviceDisappeared,
     /// Active device switched
     ActiveDeviceChanged,
     /// Device state changed
@@ -1336,11 +1338,18 @@ impl SpircTask {
             if let Ok(reason_enum) = reason {
                 match reason_enum {
                     ServerClusterUpdateReason::DEVICE_NEW_CONNECTION
-                    | ServerClusterUpdateReason::NEW_DEVICE_APPEARED
-                    | ServerClusterUpdateReason::DEVICES_DISAPPEARED => {
+                    | ServerClusterUpdateReason::NEW_DEVICE_APPEARED => {
                         for device_id in &cluster_update.devices_that_changed {
                             self.emit_cluster_update(ClusterUpdateEvent {
-                                reason: ClusterUpdateReason::DeviceListChanged,
+                                reason: ClusterUpdateReason::DeviceAppeared,
+                                device_id: Some(device_id.clone()),
+                            });
+                        }
+                    }
+                    ServerClusterUpdateReason::DEVICES_DISAPPEARED => {
+                        for device_id in &cluster_update.devices_that_changed {
+                            self.emit_cluster_update(ClusterUpdateEvent {
+                                reason: ClusterUpdateReason::DeviceDisappeared,
                                 device_id: Some(device_id.clone()),
                             });
                         }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1219,101 +1219,7 @@ impl SpircTask {
         }
 
         let state = state.unwrap_or_else(|| self.connect_state.player().clone());
-
-        // Determine the reason for the update by diffing with last state
-        let reason = if let Some(last) = last_state {
-            // Check in priority order: track > play/pause > shuffle > repeat > seek
-            let new_track_uri = state
-                .track
-                .as_ref()
-                .map(|t| t.uri.clone())
-                .unwrap_or_default();
-            let old_track_uri = last
-                .track
-                .as_ref()
-                .map(|t| t.uri.clone())
-                .unwrap_or_default();
-            if new_track_uri != old_track_uri {
-                let _ = self.player_state_sender.send(Some(state));
-                let _ = self.player_update_sender.send(PlayerUpdateEvent {
-                    reason: PlayerUpdateReason::TrackChanged,
-                });
-                return;
-            }
-
-            let new_is_playing = state.is_playing && !state.is_paused;
-            let old_is_playing = last.is_playing && !last.is_paused;
-            if new_is_playing != old_is_playing {
-                let _ = self.player_state_sender.send(Some(state));
-                let _ = self.player_update_sender.send(PlayerUpdateEvent {
-                    reason: PlayerUpdateReason::PlayPauseChanged,
-                });
-                return;
-            }
-
-            let new_shuffle = state
-                .options
-                .as_ref()
-                .map(|o| o.shuffling_context)
-                .unwrap_or(false);
-            let old_shuffle = last
-                .options
-                .as_ref()
-                .map(|o| o.shuffling_context)
-                .unwrap_or(false);
-            if new_shuffle != old_shuffle {
-                let _ = self.player_state_sender.send(Some(state));
-                let _ = self.player_update_sender.send(PlayerUpdateEvent {
-                    reason: PlayerUpdateReason::ShuffleChanged,
-                });
-                return;
-            }
-
-            let new_repeat = state
-                .options
-                .as_ref()
-                .map(|o| (o.repeating_context, o.repeating_track));
-            let old_repeat = last
-                .options
-                .as_ref()
-                .map(|o| (o.repeating_context, o.repeating_track));
-            if new_repeat != old_repeat {
-                let _ = self.player_state_sender.send(Some(state));
-                let _ = self.player_update_sender.send(PlayerUpdateEvent {
-                    reason: PlayerUpdateReason::RepeatChanged,
-                });
-                return;
-            }
-
-            if state.context_uri != last.context_uri {
-                let _ = self.player_state_sender.send(Some(state));
-                let _ = self.player_update_sender.send(PlayerUpdateEvent {
-                    reason: PlayerUpdateReason::ContextChanged,
-                });
-                return;
-            }
-
-            // Detect seek: position jump (not just natural progress)
-            let time_diff = state.timestamp.saturating_sub(last.timestamp);
-            let expected_position = if state.is_playing {
-                // Account for natural progression if playing
-                last.position_as_of_timestamp + time_diff
-            } else {
-                // If paused, position shouldn't change
-                last.position_as_of_timestamp
-            };
-
-            let position_delta = (state.position_as_of_timestamp - expected_position).abs();
-            if position_delta > 5000 {
-                PlayerUpdateReason::SeekChanged
-            } else {
-                // No significant change detected
-                PlayerUpdateReason::Other
-            }
-        } else {
-            // No previous state (initial state)
-            PlayerUpdateReason::Other
-        };
+        let reason = classify_player_update_reason(&state, last_state);
 
         let _ = self.player_state_sender.send(Some(state));
         if let Err(why) = self.player_update_sender.send(PlayerUpdateEvent { reason }) {
@@ -2417,5 +2323,148 @@ impl SpircTask {
 impl Drop for SpircTask {
     fn drop(&mut self) {
         debug!("drop Spirc[{}]", self.spirc_id);
+    }
+}
+
+/// Classifies why a remote `PlayerState` snapshot differs from the last one seen
+fn classify_player_update_reason(
+    state: &PlayerState,
+    last_state: Option<&PlayerState>,
+) -> PlayerUpdateReason {
+    let Some(last) = last_state else {
+        return PlayerUpdateReason::Other;
+    };
+
+    let new_track_uri = state.track.as_ref().map(|t| t.uri.as_str());
+    let old_track_uri = last.track.as_ref().map(|t| t.uri.as_str());
+    if new_track_uri != old_track_uri {
+        return PlayerUpdateReason::TrackChanged;
+    }
+
+    let new_is_playing = state.is_playing && !state.is_paused;
+    let old_is_playing = last.is_playing && !last.is_paused;
+    if new_is_playing != old_is_playing {
+        return PlayerUpdateReason::PlayPauseChanged;
+    }
+
+    let shuffle = |s: &PlayerState| s.options.as_ref().map(|o| o.shuffling_context);
+    if shuffle(state) != shuffle(last) {
+        return PlayerUpdateReason::ShuffleChanged;
+    }
+
+    let repeat = |s: &PlayerState| {
+        s.options
+            .as_ref()
+            .map(|o| (o.repeating_context, o.repeating_track))
+    };
+    if repeat(state) != repeat(last) {
+        return PlayerUpdateReason::RepeatChanged;
+    }
+
+    if state.context_uri != last.context_uri {
+        return PlayerUpdateReason::ContextChanged;
+    }
+
+    // seek: a position jump beyond what natural playback progress would explain
+    let time_diff = state.timestamp.saturating_sub(last.timestamp);
+    let expected_position = if state.is_playing {
+        last.position_as_of_timestamp + time_diff
+    } else {
+        last.position_as_of_timestamp
+    };
+    let position_delta = (state.position_as_of_timestamp - expected_position).abs();
+
+    if position_delta > 5000 {
+        PlayerUpdateReason::SeekChanged
+    } else {
+        PlayerUpdateReason::Other
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn state_with(f: impl FnOnce(&mut PlayerState)) -> PlayerState {
+        let mut state = PlayerState::default();
+        f(&mut state);
+        state
+    }
+
+    fn track(uri: &str) -> ProvidedTrack {
+        let mut t = ProvidedTrack::new();
+        t.uri = uri.to_string();
+        t
+    }
+
+    #[test]
+    fn no_previous_state_is_other() {
+        let state = PlayerState::default();
+        assert_eq!(
+            classify_player_update_reason(&state, None),
+            PlayerUpdateReason::Other
+        );
+    }
+
+    #[test]
+    fn track_change_wins_over_everything_else() {
+        let last = state_with(|s| {
+            s.track = MessageField::some(track("spotify:track:a"));
+            s.is_playing = true;
+        });
+        let next = state_with(|s| {
+            s.track = MessageField::some(track("spotify:track:b"));
+            s.is_playing = false;
+        });
+        assert_eq!(
+            classify_player_update_reason(&next, Some(&last)),
+            PlayerUpdateReason::TrackChanged
+        );
+    }
+
+    #[test]
+    fn play_pause_change_detected() {
+        let last = state_with(|s| s.is_playing = false);
+        let next = state_with(|s| s.is_playing = true);
+        assert_eq!(
+            classify_player_update_reason(&next, Some(&last)),
+            PlayerUpdateReason::PlayPauseChanged
+        );
+    }
+
+    #[test]
+    fn seek_detected_beyond_natural_progress() {
+        let last = state_with(|s| {
+            s.is_playing = true;
+            s.timestamp = 1_000;
+            s.position_as_of_timestamp = 10_000;
+        });
+        let next = state_with(|s| {
+            s.is_playing = true;
+            s.timestamp = 2_000;
+            s.position_as_of_timestamp = 50_000;
+        });
+        assert_eq!(
+            classify_player_update_reason(&next, Some(&last)),
+            PlayerUpdateReason::SeekChanged
+        );
+    }
+
+    #[test]
+    fn natural_progress_is_not_a_seek() {
+        let last = state_with(|s| {
+            s.is_playing = true;
+            s.timestamp = 1_000;
+            s.position_as_of_timestamp = 10_000;
+        });
+        let next = state_with(|s| {
+            s.is_playing = true;
+            s.timestamp = 2_000;
+            s.position_as_of_timestamp = 11_000;
+        });
+        assert_eq!(
+            classify_player_update_reason(&next, Some(&last)),
+            PlayerUpdateReason::Other
+        );
     }
 }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -271,6 +271,9 @@ const UPDATE_STATE_DELAY: Duration = Duration::from_millis(200);
 // changing at once) with no await point in between for a receiver to drain the channel,
 // so capacity 1 would silently drop all but the last one
 const UPDATE_EVENT_CHANNEL_CAPACITY: usize = 16;
+// position drift beyond this is treated as a user seek rather than natural playback
+// progress or network jitter in the timestamp/position reporting
+const SEEK_THRESHOLD_MS: i64 = 5_000;
 
 /// The spotify connect handle
 pub struct Spirc {
@@ -2446,7 +2449,19 @@ fn build_cluster_state(cluster: &Cluster) -> ClusterState {
     }
 }
 
-/// Every way a remote `PlayerState` snapshot differs from the last one seen
+/// Position drift beyond `SEEK_THRESHOLD_MS` relative to natural playback progress
+fn is_seek(state: &PlayerState, last: &PlayerState) -> bool {
+    let time_diff = state.timestamp.saturating_sub(last.timestamp);
+    let expected_position = if state.is_playing {
+        last.position_as_of_timestamp + time_diff
+    } else {
+        last.position_as_of_timestamp
+    };
+    (state.position_as_of_timestamp - expected_position).abs() > SEEK_THRESHOLD_MS
+}
+
+/// Every way a remote `PlayerState` snapshot differs from the last one seen.
+/// Adding a new kind of change to track is a single entry in `checks` below.
 fn classify_player_update_reasons(
     state: &PlayerState,
     last_state: Option<&PlayerState>,
@@ -2455,53 +2470,48 @@ fn classify_player_update_reasons(
         return vec![PlayerUpdateReason::Other];
     };
 
-    let mut reasons = Vec::new();
-
-    let new_track_uri = state.track.as_ref().map(|t| t.uri.as_str());
-    let old_track_uri = last.track.as_ref().map(|t| t.uri.as_str());
-    let track_changed = new_track_uri != old_track_uri;
-    if track_changed {
-        reasons.push(PlayerUpdateReason::TrackChanged);
+    fn track_uri(s: &PlayerState) -> Option<&str> {
+        s.track.as_ref().map(|t| t.uri.as_str())
     }
-
-    let new_is_playing = state.is_playing && !state.is_paused;
-    let old_is_playing = last.is_playing && !last.is_paused;
-    if new_is_playing != old_is_playing {
-        reasons.push(PlayerUpdateReason::PlayPauseChanged);
-    }
-
+    let is_playing = |s: &PlayerState| s.is_playing && !s.is_paused;
     let shuffle = |s: &PlayerState| s.options.as_ref().map(|o| o.shuffling_context);
-    if shuffle(state) != shuffle(last) {
-        reasons.push(PlayerUpdateReason::ShuffleChanged);
-    }
-
     let repeat = |s: &PlayerState| {
         s.options
             .as_ref()
             .map(|o| (o.repeating_context, o.repeating_track))
     };
-    if repeat(state) != repeat(last) {
-        reasons.push(PlayerUpdateReason::RepeatChanged);
-    }
 
-    if state.context_uri != last.context_uri {
-        reasons.push(PlayerUpdateReason::ContextChanged);
-    }
+    let track_changed = track_uri(state) != track_uri(last);
 
-    // seek doesn't apply across a track change: position naturally resets then
-    if !track_changed {
-        let time_diff = state.timestamp.saturating_sub(last.timestamp);
-        let expected_position = if state.is_playing {
-            last.position_as_of_timestamp + time_diff
-        } else {
-            last.position_as_of_timestamp
-        };
-        let position_delta = (state.position_as_of_timestamp - expected_position).abs();
+    let checks = [
+        (track_changed, PlayerUpdateReason::TrackChanged),
+        (
+            is_playing(state) != is_playing(last),
+            PlayerUpdateReason::PlayPauseChanged,
+        ),
+        (
+            shuffle(state) != shuffle(last),
+            PlayerUpdateReason::ShuffleChanged,
+        ),
+        (
+            repeat(state) != repeat(last),
+            PlayerUpdateReason::RepeatChanged,
+        ),
+        (
+            state.context_uri != last.context_uri,
+            PlayerUpdateReason::ContextChanged,
+        ),
+        // seek doesn't apply across a track change: position naturally resets then
+        (
+            !track_changed && is_seek(state, last),
+            PlayerUpdateReason::SeekChanged,
+        ),
+    ];
 
-        if position_delta > 5000 {
-            reasons.push(PlayerUpdateReason::SeekChanged);
-        }
-    }
+    let mut reasons: Vec<_> = checks
+        .into_iter()
+        .filter_map(|(changed, reason)| changed.then_some(reason))
+        .collect();
 
     if reasons.is_empty() {
         reasons.push(PlayerUpdateReason::Other);

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -2298,6 +2298,24 @@ impl SpircTask {
             if self.connect_state.is_active() {
                 self.player.emit_volume_changed_event(volume);
             }
+
+            // reflect locally now; the server only echoes this back on its own schedule
+            let device_id = self.session.device_id().to_string();
+            let device_info = self.connect_state.device_info();
+            let info = DeviceInfo {
+                device_id: device_id.clone(),
+                device_alias: device_info.name.clone(),
+                device_type: device_info.device_type.enum_value_or_default(),
+                volume: new_volume,
+                is_active: self.connect_state.is_active(),
+            };
+            self.cluster_state_sender.send_modify(|state| {
+                state.devices.insert(device_id.clone(), info);
+            });
+            self.emit_cluster_update(ClusterUpdateEvent {
+                reason: ClusterUpdateReason::DeviceInfoChanged,
+                device_id,
+            });
         }
     }
 }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1327,6 +1327,12 @@ impl SpircTask {
         );
 
         if let Some(mut cluster) = cluster_update.cluster.take() {
+            // published before any broadcast below, so a receiver woken by one of those
+            // events can trust watch_cluster_state() already reflects it
+            let _ = self
+                .cluster_state_sender
+                .send(build_cluster_state(&cluster));
+
             if let Ok(reason_enum) = reason {
                 match reason_enum {
                     ServerClusterUpdateReason::DEVICE_NEW_CONNECTION
@@ -1373,11 +1379,6 @@ impl SpircTask {
                 });
                 self.last_active_device_id = new_active_device_id;
             }
-
-            // Sync device state to cluster_state_sender (after emitting events)
-            let _ = self
-                .cluster_state_sender
-                .send(build_cluster_state(&cluster));
 
             let became_inactive = self.connect_state.is_active()
                 && cluster.active_device_id != self.session.device_id();

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1291,6 +1291,12 @@ impl SpircTask {
     }
 
     fn publish_queue_snapshot(&mut self, player_state: &PlayerState) {
+        if self.queue_list_sender.receiver_count() == 0
+            && self.queue_update_sender.receiver_count() == 0
+        {
+            return;
+        }
+
         let queue_list = Self::queue_list_from_player_state(player_state);
         let prev_queue_list = std::mem::replace(&mut self.last_queue_list, queue_list.clone());
 
@@ -1313,6 +1319,14 @@ impl SpircTask {
     }
 
     fn publish_active_state(&mut self, reason: Option<PlayerUpdateReason>) {
+        let has_subscribers = self.player_update_sender.receiver_count() > 0
+            || self.player_state_sender.receiver_count() > 0
+            || self.queue_list_sender.receiver_count() > 0
+            || self.queue_update_sender.receiver_count() > 0;
+        if !has_subscribers {
+            return;
+        }
+
         let player_state = self.connect_state.player().clone();
         let _ = self.player_state_sender.send(Some(player_state.clone()));
         self.publish_queue_snapshot(&player_state);

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1276,7 +1276,7 @@ impl SpircTask {
             };
 
             let position_delta =
-                (state.position_as_of_timestamp as i64 - expected_position as i64).abs();
+                (state.position_as_of_timestamp - expected_position).abs();
             if position_delta > 5000 {
                 PlayerUpdateReason::SeekChanged
             } else {
@@ -1377,13 +1377,13 @@ impl SpircTask {
             // Sync device state to cluster_state_sender (after emitting events)
             let devices: HashMap<String, DeviceInfo> = cluster
                 .device
-                .iter()
-                .map(|(_, device)| {
+                .values()
+                .map(|device| {
                     let info = DeviceInfo {
                         device_id: device.device_id.clone(),
                         device_alias: device.name.clone(),
                         device_type: format!("{:?}", device.device_type),
-                        volume: device.volume as u32,
+                        volume: device.volume,
                         is_active: device.device_id == cluster.active_device_id,
                     };
                     (info.device_id.clone(), info)

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -17,7 +17,10 @@ use crate::{
         player::{Player, PlayerEvent, PlayerEventChannel, QueueTrack},
     },
     protocol::{
-        connect::{Cluster, ClusterUpdate, LogoutCommand, SetVolumeCommand},
+        connect::{
+            Cluster, ClusterUpdate, ClusterUpdateReason as ServerClusterUpdateReason,
+            LogoutCommand, SetVolumeCommand,
+        },
         context::Context,
         explicit_content_pubsub::UserAttributesUpdate,
         player::ProvidedTrack,
@@ -36,6 +39,7 @@ use crate::{
 use futures_util::StreamExt;
 use protobuf::MessageField;
 use std::{
+    collections::HashMap,
     future::Future,
     sync::Arc,
     sync::atomic::{AtomicUsize, Ordering},
@@ -43,7 +47,7 @@ use std::{
 };
 use thiserror::Error;
 use tokio::{
-    sync::{broadcast, mpsc},
+    sync::{broadcast, mpsc, watch},
     time::sleep,
 };
 
@@ -70,6 +74,103 @@ impl From<SpircError> for Error {
             UnknownEndpoint(_) => Error::unimplemented(err),
         }
     }
+}
+
+/// Information about a device in the cluster
+#[derive(Debug, Clone)]
+pub struct DeviceInfo {
+    /// Unique device identifier
+    pub device_id: String,
+    /// Human-readable device name
+    pub device_alias: String,
+    /// Device type (e.g., "Speaker", "Phone")
+    pub device_type: String,
+    /// Volume level 0-100
+    pub volume: u32,
+    /// Whether this is the currently active device
+    pub is_active: bool,
+}
+
+/// Current state of the device cluster (all known devices)
+#[derive(Debug, Clone)]
+pub struct ClusterState {
+    /// Map of all known devices by device_id
+    pub devices: HashMap<String, DeviceInfo>,
+    /// Currently active device ID (if any)
+    pub active_device_id: Option<String>,
+}
+
+/// Queue information (previous and next tracks)
+#[derive(Debug, Clone)]
+pub struct QueueList {
+    /// Previous tracks in the queue (as URIs)
+    pub prev_tracks: Vec<String>,
+    /// Next tracks in the queue (as URIs)
+    pub next_tracks: Vec<String>,
+}
+
+/// Semantic reason for cluster updates
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClusterUpdateReason {
+    /// Device list changed
+    DeviceListChanged,
+    /// Active device switched
+    ActiveDeviceChanged,
+    /// Device state changed
+    DeviceStateChanged,
+    /// Device info changed
+    DeviceInfoChanged,
+}
+
+/// Event emitted when cluster state changes
+#[derive(Debug, Clone)]
+pub struct ClusterUpdateEvent {
+    /// Device ID that changed
+    pub device_id: String,
+    /// Reason for the update
+    pub reason: ClusterUpdateReason,
+}
+
+/// Semantic reasons for queue updates
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueueUpdateReason {
+    /// Previous tracks changed
+    PrevTracksChanged,
+    /// Next tracks changed
+    NextTracksChanged,
+}
+
+/// Event emitted when queue changes
+#[derive(Debug, Clone)]
+pub struct QueueUpdateEvent {
+    /// Reason for the queue update
+    pub reason: QueueUpdateReason,
+}
+
+/// Semantic reasons for player state updates
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlayerUpdateReason {
+    /// Track changed
+    TrackChanged,
+    /// Position changed
+    PositionChanged,
+    /// Play/pause state changed
+    PlayPauseChanged,
+    /// Shuffle mode changed
+    ShuffleChanged,
+    /// Repeat mode changed
+    RepeatChanged,
+    /// Context changed
+    ContextChanged,
+    /// Other state change
+    Other,
+}
+
+/// Emitted when player state changes
+#[derive(Debug, Clone)]
+pub struct PlayerUpdateEvent {
+    /// Reason for the player update
+    pub reason: PlayerUpdateReason,
 }
 
 struct SpircTask {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1221,8 +1221,8 @@ impl SpircTask {
         }
     }
 
-    /// Remote snapshots carry no event metadata, so the reason is inferred by diffing here.
-    /// Local updates get it directly from the originating `PlayerEvent` instead.
+    /// Remote snapshots carry no event metadata, so reasons are inferred by diffing here.
+    /// Local updates get theirs directly from the originating `PlayerEvent` instead.
     fn emit_player_update(&self, state: Option<PlayerState>, last_state: Option<&PlayerState>) {
         if self.player_update_sender.receiver_count() == 0
             && self.player_state_sender.receiver_count() == 0
@@ -1231,10 +1231,12 @@ impl SpircTask {
         }
 
         let state = state.unwrap_or_else(|| self.connect_state.player().clone());
-        let reason = classify_player_update_reason(&state, last_state);
+        let reasons = classify_player_update_reasons(&state, last_state);
 
         let _ = self.player_state_sender.send(Some(state));
-        self.emit_player_update_event(PlayerUpdateEvent { reason });
+        for reason in reasons {
+            self.emit_player_update_event(PlayerUpdateEvent { reason });
+        }
     }
 
     /// No-op without subscribers, so local playback doesn't warn when nobody's listening
@@ -2387,30 +2389,33 @@ fn build_cluster_state(cluster: &Cluster) -> ClusterState {
     }
 }
 
-/// Classifies why a remote `PlayerState` snapshot differs from the last one seen
-fn classify_player_update_reason(
+/// Every way a remote `PlayerState` snapshot differs from the last one seen
+fn classify_player_update_reasons(
     state: &PlayerState,
     last_state: Option<&PlayerState>,
-) -> PlayerUpdateReason {
+) -> Vec<PlayerUpdateReason> {
     let Some(last) = last_state else {
-        return PlayerUpdateReason::Other;
+        return vec![PlayerUpdateReason::Other];
     };
+
+    let mut reasons = Vec::new();
 
     let new_track_uri = state.track.as_ref().map(|t| t.uri.as_str());
     let old_track_uri = last.track.as_ref().map(|t| t.uri.as_str());
-    if new_track_uri != old_track_uri {
-        return PlayerUpdateReason::TrackChanged;
+    let track_changed = new_track_uri != old_track_uri;
+    if track_changed {
+        reasons.push(PlayerUpdateReason::TrackChanged);
     }
 
     let new_is_playing = state.is_playing && !state.is_paused;
     let old_is_playing = last.is_playing && !last.is_paused;
     if new_is_playing != old_is_playing {
-        return PlayerUpdateReason::PlayPauseChanged;
+        reasons.push(PlayerUpdateReason::PlayPauseChanged);
     }
 
     let shuffle = |s: &PlayerState| s.options.as_ref().map(|o| o.shuffling_context);
     if shuffle(state) != shuffle(last) {
-        return PlayerUpdateReason::ShuffleChanged;
+        reasons.push(PlayerUpdateReason::ShuffleChanged);
     }
 
     let repeat = |s: &PlayerState| {
@@ -2419,27 +2424,33 @@ fn classify_player_update_reason(
             .map(|o| (o.repeating_context, o.repeating_track))
     };
     if repeat(state) != repeat(last) {
-        return PlayerUpdateReason::RepeatChanged;
+        reasons.push(PlayerUpdateReason::RepeatChanged);
     }
 
     if state.context_uri != last.context_uri {
-        return PlayerUpdateReason::ContextChanged;
+        reasons.push(PlayerUpdateReason::ContextChanged);
     }
 
-    // seek: a position jump beyond what natural playback progress would explain
-    let time_diff = state.timestamp.saturating_sub(last.timestamp);
-    let expected_position = if state.is_playing {
-        last.position_as_of_timestamp + time_diff
-    } else {
-        last.position_as_of_timestamp
-    };
-    let position_delta = (state.position_as_of_timestamp - expected_position).abs();
+    // seek doesn't apply across a track change: position naturally resets then
+    if !track_changed {
+        let time_diff = state.timestamp.saturating_sub(last.timestamp);
+        let expected_position = if state.is_playing {
+            last.position_as_of_timestamp + time_diff
+        } else {
+            last.position_as_of_timestamp
+        };
+        let position_delta = (state.position_as_of_timestamp - expected_position).abs();
 
-    if position_delta > 5000 {
-        PlayerUpdateReason::SeekChanged
-    } else {
-        PlayerUpdateReason::Other
+        if position_delta > 5000 {
+            reasons.push(PlayerUpdateReason::SeekChanged);
+        }
     }
+
+    if reasons.is_empty() {
+        reasons.push(PlayerUpdateReason::Other);
+    }
+
+    reasons
 }
 
 #[cfg(test)]
@@ -2462,13 +2473,29 @@ mod tests {
     fn no_previous_state_is_other() {
         let state = PlayerState::default();
         assert_eq!(
-            classify_player_update_reason(&state, None),
-            PlayerUpdateReason::Other
+            classify_player_update_reasons(&state, None),
+            vec![PlayerUpdateReason::Other]
         );
     }
 
     #[test]
-    fn track_change_wins_over_everything_else() {
+    fn track_change_alone() {
+        let last = state_with(|s| {
+            s.track = MessageField::some(track("spotify:track:a"));
+            s.is_playing = true;
+        });
+        let next = state_with(|s| {
+            s.track = MessageField::some(track("spotify:track:b"));
+            s.is_playing = true;
+        });
+        assert_eq!(
+            classify_player_update_reasons(&next, Some(&last)),
+            vec![PlayerUpdateReason::TrackChanged]
+        );
+    }
+
+    #[test]
+    fn track_and_play_pause_both_reported() {
         let last = state_with(|s| {
             s.track = MessageField::some(track("spotify:track:a"));
             s.is_playing = true;
@@ -2478,8 +2505,11 @@ mod tests {
             s.is_playing = false;
         });
         assert_eq!(
-            classify_player_update_reason(&next, Some(&last)),
-            PlayerUpdateReason::TrackChanged
+            classify_player_update_reasons(&next, Some(&last)),
+            vec![
+                PlayerUpdateReason::TrackChanged,
+                PlayerUpdateReason::PlayPauseChanged,
+            ]
         );
     }
 
@@ -2488,8 +2518,8 @@ mod tests {
         let last = state_with(|s| s.is_playing = false);
         let next = state_with(|s| s.is_playing = true);
         assert_eq!(
-            classify_player_update_reason(&next, Some(&last)),
-            PlayerUpdateReason::PlayPauseChanged
+            classify_player_update_reasons(&next, Some(&last)),
+            vec![PlayerUpdateReason::PlayPauseChanged]
         );
     }
 
@@ -2506,8 +2536,8 @@ mod tests {
             s.position_as_of_timestamp = 50_000;
         });
         assert_eq!(
-            classify_player_update_reason(&next, Some(&last)),
-            PlayerUpdateReason::SeekChanged
+            classify_player_update_reasons(&next, Some(&last)),
+            vec![PlayerUpdateReason::SeekChanged]
         );
     }
 
@@ -2524,8 +2554,29 @@ mod tests {
             s.position_as_of_timestamp = 11_000;
         });
         assert_eq!(
-            classify_player_update_reason(&next, Some(&last)),
-            PlayerUpdateReason::Other
+            classify_player_update_reasons(&next, Some(&last)),
+            vec![PlayerUpdateReason::Other]
+        );
+    }
+
+    #[test]
+    fn track_change_suppresses_seek() {
+        // position naturally resets on a track change; that's not a seek
+        let last = state_with(|s| {
+            s.track = MessageField::some(track("spotify:track:a"));
+            s.is_playing = true;
+            s.timestamp = 1_000;
+            s.position_as_of_timestamp = 100_000;
+        });
+        let next = state_with(|s| {
+            s.track = MessageField::some(track("spotify:track:b"));
+            s.is_playing = true;
+            s.timestamp = 2_000;
+            s.position_as_of_timestamp = 0;
+        });
+        assert_eq!(
+            classify_player_update_reasons(&next, Some(&last)),
+            vec![PlayerUpdateReason::TrackChanged]
         );
     }
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -77,9 +77,10 @@ impl From<SpircError> for Error {
     }
 }
 
-/// Information about a device in the cluster
+/// Information about a device in the cluster. Named to avoid colliding with
+/// `librespot_protocol::connect::DeviceInfo` under a wildcard import.
 #[derive(Debug, Clone)]
-pub struct DeviceInfo {
+pub struct ClusterDeviceInfo {
     /// Unique device identifier
     pub device_id: String,
     /// Human-readable device name
@@ -96,7 +97,7 @@ pub struct DeviceInfo {
 #[derive(Debug, Clone)]
 pub struct ClusterState {
     /// Map of all known devices by device_id
-    pub devices: HashMap<String, DeviceInfo>,
+    pub devices: HashMap<String, ClusterDeviceInfo>,
     /// Currently active device ID (if any)
     pub active_device_id: Option<String>,
 }
@@ -2342,10 +2343,10 @@ impl SpircTask {
         }
     }
 
-    fn own_device_info(&self, is_active: bool) -> (String, DeviceInfo) {
+    fn own_device_info(&self, is_active: bool) -> (String, ClusterDeviceInfo) {
         let device_id = self.session.device_id().to_string();
         let device_info = self.connect_state.device_info();
-        let info = DeviceInfo {
+        let info = ClusterDeviceInfo {
             device_id: device_id.clone(),
             device_alias: device_info.name.clone(),
             device_type: device_info.device_type.enum_value_or_default(),
@@ -2392,7 +2393,7 @@ fn queue_lists_changed(prev: &QueueList, next: &QueueList) -> (bool, bool) {
 fn apply_local_activation(
     state: &mut ClusterState,
     device_id: String,
-    info: DeviceInfo,
+    info: ClusterDeviceInfo,
     active: bool,
 ) {
     if let Some(prev_id) = &state.active_device_id {
@@ -2410,7 +2411,7 @@ fn build_cluster_state(cluster: &Cluster) -> ClusterState {
         .device
         .values()
         .map(|device| {
-            let info = DeviceInfo {
+            let info = ClusterDeviceInfo {
                 device_id: device.device_id.clone(),
                 device_alias: device.name.clone(),
                 device_type: device.device_type.enum_value_or_default(),
@@ -2703,8 +2704,8 @@ mod tests {
         assert!(state.devices.is_empty());
     }
 
-    fn device_info(device_id: &str, is_active: bool) -> DeviceInfo {
-        DeviceInfo {
+    fn device_info(device_id: &str, is_active: bool) -> ClusterDeviceInfo {
+        ClusterDeviceInfo {
             device_id: device_id.to_string(),
             device_alias: "test device".to_string(),
             device_type: DeviceType::COMPUTER,

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -215,7 +215,14 @@ struct SpircTask {
     /// when no other future resolves, otherwise resets the delay
     update_state: bool,
 
-    state_sender: broadcast::Sender<PlayerState>,
+    player_update_sender: broadcast::Sender<PlayerUpdateEvent>,
+    cluster_update_sender: broadcast::Sender<ClusterUpdateEvent>,
+    queue_update_sender: broadcast::Sender<QueueUpdateEvent>,
+    player_state_sender: watch::Sender<Option<PlayerState>>,
+    cluster_state_sender: watch::Sender<ClusterState>,
+    queue_list_sender: watch::Sender<QueueList>,
+    last_active_device_id: Option<String>,
+    last_player_state: Option<PlayerState>,
 
     spirc_id: usize,
 }
@@ -254,7 +261,12 @@ const UPDATE_STATE_DELAY: Duration = Duration::from_millis(200);
 /// The spotify connect handle
 pub struct Spirc {
     commands: mpsc::UnboundedSender<SpircCommand>,
-    state_sender: broadcast::Sender<PlayerState>,
+    player_update_sender: broadcast::Sender<PlayerUpdateEvent>,
+    cluster_update_sender: broadcast::Sender<ClusterUpdateEvent>,
+    queue_update_sender: broadcast::Sender<QueueUpdateEvent>,
+    player_state_sender: watch::Sender<Option<PlayerState>>,
+    cluster_state_sender: watch::Sender<ClusterState>,
+    queue_list_sender: watch::Sender<QueueList>,
 }
 
 impl Spirc {
@@ -332,7 +344,18 @@ impl Spirc {
         let _ = session.login5().auth_token().await?;
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
-        let (state_tx, _) = broadcast::channel(1);
+        let (player_update_sender_tx, _) = broadcast::channel(1);
+        let (cluster_update_sender_tx, _) = broadcast::channel(1);
+        let (queue_update_sender_tx, _) = broadcast::channel(1);
+        let (player_state_sender_tx, _) = watch::channel(None);
+        let (cluster_state_sender_tx, _) = watch::channel(ClusterState {
+            devices: HashMap::new(),
+            active_device_id: None,
+        });
+        let (queue_list_sender_tx, _) = watch::channel(QueueList {
+            prev_tracks: Vec::new(),
+            next_tracks: Vec::new(),
+        });
 
         let player_events = player.get_player_event_channel();
 
@@ -369,14 +392,26 @@ impl Spirc {
             update_volume: false,
             update_state: false,
 
-            state_sender: state_tx.clone(),
+            player_update_sender: player_update_tx.clone(),
+            cluster_update_sender: cluster_update_tx.clone(),
+            queue_update_sender: queue_update_tx.clone(),
+            player_state_sender: player_state_sender_tx.clone(),
+            cluster_state_sender: cluster_state_sender_tx.clone(),
+            queue_list_sender: queue_list_sender_tx.clone(),
+            last_active_device_id: None,
+            last_player_state: None,
 
             spirc_id,
         };
 
         let spirc = Spirc {
             commands: cmd_tx,
-            state_sender: state_tx,
+            player_update_sender: player_update_tx,
+            cluster_update_sender: cluster_update_tx,
+            queue_update_sender: queue_update_tx,
+            player_state_sender: player_state_sender_tx,
+            cluster_state_sender: cluster_state_sender_tx,
+            queue_list_sender: queue_list_sender_tx,
         };
 
         let initial_volume = task.connect_state.device_info().volume;
@@ -549,12 +584,34 @@ impl Spirc {
             .send(SpircCommand::Transfer(transfer_request))?)
     }
 
-    /// Get a channel which sends the [PlayerState] whenever it changes.
-    ///
-    /// Forwards the internal [PlayerState] when we are the active device. When we are only
-    /// a spectator, forwards any [PlayerState] update from the active player.
-    pub fn get_state_update_channel(&self) -> broadcast::Receiver<PlayerState> {
-        self.state_sender.subscribe()
+    /// Get a channel which sends lightweight playback state updates.
+    pub fn get_player_update_channel(&self) -> broadcast::Receiver<PlayerUpdateEvent> {
+        self.player_update_sender.subscribe()
+    }
+
+    /// Get a channel which sends device topology changes (devices appearing/disappearing, active device changes).
+    pub fn get_cluster_update_channel(&self) -> broadcast::Receiver<ClusterUpdateEvent> {
+        self.cluster_update_sender.subscribe()
+    }
+
+    /// Get a channel which sends queue change events when prev/next tracks differ.
+    pub fn get_queue_update_channel(&self) -> broadcast::Receiver<QueueUpdateEvent> {
+        self.queue_update_sender.subscribe()
+    }
+
+    /// Watch the current player state (full PlayerState)
+    pub fn watch_player_state(&self) -> watch::Receiver<Option<PlayerState>> {
+        self.player_state_sender.subscribe()
+    }
+
+    /// Watch the current cluster state (all devices and active device)
+    pub fn watch_cluster_state(&self) -> watch::Receiver<ClusterState> {
+        self.cluster_state_sender.subscribe()
+    }
+
+    /// Watch the current queue list (previous and next tracks)
+    pub fn watch_queue_list(&self) -> watch::Receiver<QueueList> {
+        self.queue_list_sender.subscribe()
     }
 }
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1356,43 +1356,12 @@ impl SpircTask {
                 .cluster_state_sender
                 .send(build_cluster_state(&cluster));
 
-            if let Ok(reason_enum) = reason {
-                match reason_enum {
-                    ServerClusterUpdateReason::DEVICE_NEW_CONNECTION
-                    | ServerClusterUpdateReason::NEW_DEVICE_APPEARED => {
-                        for device_id in &cluster_update.devices_that_changed {
-                            self.emit_cluster_update(ClusterUpdateEvent {
-                                reason: ClusterUpdateReason::DeviceAppeared,
-                                device_id: Some(device_id.clone()),
-                            });
-                        }
-                    }
-                    ServerClusterUpdateReason::DEVICES_DISAPPEARED => {
-                        for device_id in &cluster_update.devices_that_changed {
-                            self.emit_cluster_update(ClusterUpdateEvent {
-                                reason: ClusterUpdateReason::DeviceDisappeared,
-                                device_id: Some(device_id.clone()),
-                            });
-                        }
-                    }
-                    ServerClusterUpdateReason::DEVICE_ALIAS_CHANGED
-                    | ServerClusterUpdateReason::DEVICE_VOLUME_CHANGED => {
-                        for device_id in &cluster_update.devices_that_changed {
-                            self.emit_cluster_update(ClusterUpdateEvent {
-                                reason: ClusterUpdateReason::DeviceInfoChanged,
-                                device_id: Some(device_id.clone()),
-                            });
-                        }
-                    }
-                    ServerClusterUpdateReason::DEVICE_STATE_CHANGED => {
-                        for device_id in &cluster_update.devices_that_changed {
-                            self.emit_cluster_update(ClusterUpdateEvent {
-                                reason: ClusterUpdateReason::DeviceStateChanged,
-                                device_id: Some(device_id.clone()),
-                            });
-                        }
-                    }
-                    _ => {}
+            if let Some(mapped_reason) = reason.ok().and_then(map_server_cluster_update_reason) {
+                for device_id in &cluster_update.devices_that_changed {
+                    self.emit_cluster_update(ClusterUpdateEvent {
+                        reason: mapped_reason,
+                        device_id: Some(device_id.clone()),
+                    });
                 }
             }
 
@@ -2419,6 +2388,30 @@ fn apply_local_activation(
     state.devices.insert(device_id, info);
 }
 
+/// Maps the server's cluster update reason to ours; `None` for reasons we don't
+/// broadcast a per-device event for (e.g. the active device change, handled separately)
+fn map_server_cluster_update_reason(
+    reason: ServerClusterUpdateReason,
+) -> Option<ClusterUpdateReason> {
+    match reason {
+        ServerClusterUpdateReason::DEVICE_NEW_CONNECTION
+        | ServerClusterUpdateReason::NEW_DEVICE_APPEARED => {
+            Some(ClusterUpdateReason::DeviceAppeared)
+        }
+        ServerClusterUpdateReason::DEVICES_DISAPPEARED => {
+            Some(ClusterUpdateReason::DeviceDisappeared)
+        }
+        ServerClusterUpdateReason::DEVICE_ALIAS_CHANGED
+        | ServerClusterUpdateReason::DEVICE_VOLUME_CHANGED => {
+            Some(ClusterUpdateReason::DeviceInfoChanged)
+        }
+        ServerClusterUpdateReason::DEVICE_STATE_CHANGED => {
+            Some(ClusterUpdateReason::DeviceStateChanged)
+        }
+        _ => None,
+    }
+}
+
 /// Builds the device map and active device id from a server `Cluster` snapshot
 fn build_cluster_state(cluster: &Cluster) -> ClusterState {
     let devices = cluster
@@ -2716,6 +2709,56 @@ mod tests {
         let state = build_cluster_state(&cluster);
         assert_eq!(state.active_device_id, None);
         assert!(state.devices.is_empty());
+    }
+
+    #[test]
+    fn maps_new_device_reasons_to_appeared() {
+        assert_eq!(
+            map_server_cluster_update_reason(ServerClusterUpdateReason::DEVICE_NEW_CONNECTION),
+            Some(ClusterUpdateReason::DeviceAppeared)
+        );
+        assert_eq!(
+            map_server_cluster_update_reason(ServerClusterUpdateReason::NEW_DEVICE_APPEARED),
+            Some(ClusterUpdateReason::DeviceAppeared)
+        );
+    }
+
+    #[test]
+    fn maps_disappeared_reason() {
+        assert_eq!(
+            map_server_cluster_update_reason(ServerClusterUpdateReason::DEVICES_DISAPPEARED),
+            Some(ClusterUpdateReason::DeviceDisappeared)
+        );
+    }
+
+    #[test]
+    fn maps_alias_and_volume_to_device_info_changed() {
+        assert_eq!(
+            map_server_cluster_update_reason(ServerClusterUpdateReason::DEVICE_ALIAS_CHANGED),
+            Some(ClusterUpdateReason::DeviceInfoChanged)
+        );
+        assert_eq!(
+            map_server_cluster_update_reason(ServerClusterUpdateReason::DEVICE_VOLUME_CHANGED),
+            Some(ClusterUpdateReason::DeviceInfoChanged)
+        );
+    }
+
+    #[test]
+    fn maps_state_changed_reason() {
+        assert_eq!(
+            map_server_cluster_update_reason(ServerClusterUpdateReason::DEVICE_STATE_CHANGED),
+            Some(ClusterUpdateReason::DeviceStateChanged)
+        );
+    }
+
+    #[test]
+    fn unknown_reason_has_no_per_device_event() {
+        assert_eq!(
+            map_server_cluster_update_reason(
+                ServerClusterUpdateReason::UNKNOWN_CLUSTER_UPDATE_REASON
+            ),
+            None
+        );
     }
 
     fn device_info(device_id: &str, is_active: bool) -> ClusterDeviceInfo {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1135,7 +1135,7 @@ impl SpircTask {
         trace!("Received connection ID update: {connection_id:?}");
         self.session.set_connection_id(&connection_id);
 
-        let cluster = match self
+        let mut cluster = match self
             .connect_state
             .notify_new_device_appeared(&self.session)
             .await
@@ -1154,6 +1154,7 @@ impl SpircTask {
         );
 
         self.connect_established = true;
+        self.sync_cluster_state(&cluster);
 
         let same_session = cluster.player_state.session_id == self.session.session_id()
             || cluster.player_state.session_id.is_empty();
@@ -1162,6 +1163,9 @@ impl SpircTask {
                 "active device is <{}> with session <{}>",
                 cluster.active_device_id, cluster.player_state.session_id
             );
+            if let Some(state) = cluster.player_state.take() {
+                self.publish_remote_player_state(state);
+            }
             return Ok(());
         } else if cluster.transfer_data.is_empty() {
             debug!("got empty transfer state, do nothing");
@@ -1256,6 +1260,30 @@ impl SpircTask {
         if let Err(why) = self.player_update_sender.send(event) {
             warn!("couldn't emit player update because: {why}")
         }
+    }
+
+    /// Shared by connect-time hydration and ongoing dealer updates so neither forgets it
+    fn sync_cluster_state(&mut self, cluster: &Cluster) {
+        let _ = self.cluster_state_sender.send(build_cluster_state(cluster));
+
+        let new_active_device_id = if cluster.active_device_id.is_empty() {
+            None
+        } else {
+            Some(cluster.active_device_id.clone())
+        };
+        if new_active_device_id != self.last_active_device_id {
+            self.emit_cluster_update(ClusterUpdateEvent {
+                reason: ClusterUpdateReason::ActiveDeviceChanged,
+                device_id: new_active_device_id.clone(),
+            });
+            self.last_active_device_id = new_active_device_id;
+        }
+    }
+
+    fn publish_remote_player_state(&mut self, state: PlayerState) {
+        self.publish_queue_snapshot(&state);
+        self.emit_player_update(Some(state.clone()), self.last_player_state.as_ref());
+        self.last_player_state = Some(state);
     }
 
     fn emit_cluster_update(&self, event: ClusterUpdateEvent) {
@@ -1355,9 +1383,7 @@ impl SpircTask {
         if let Some(mut cluster) = cluster_update.cluster.take() {
             // published before any broadcast below, so a receiver woken by one of those
             // events can trust watch_cluster_state() already reflects it
-            let _ = self
-                .cluster_state_sender
-                .send(build_cluster_state(&cluster));
+            self.sync_cluster_state(&cluster);
 
             if let Some(mapped_reason) = reason.ok().and_then(map_server_cluster_update_reason) {
                 for device_id in &cluster_update.devices_that_changed {
@@ -1366,20 +1392,6 @@ impl SpircTask {
                         device_id: Some(device_id.clone()),
                     });
                 }
-            }
-
-            // Check for active device changes
-            let new_active_device_id = if cluster.active_device_id.is_empty() {
-                None
-            } else {
-                Some(cluster.active_device_id.clone())
-            };
-            if new_active_device_id != self.last_active_device_id {
-                self.emit_cluster_update(ClusterUpdateEvent {
-                    reason: ClusterUpdateReason::ActiveDeviceChanged,
-                    device_id: new_active_device_id.clone(),
-                });
-                self.last_active_device_id = new_active_device_id;
             }
 
             let became_inactive = self.connect_state.is_active()
@@ -1394,9 +1406,7 @@ impl SpircTask {
                 //  tried: providing session_id, playback_id, track-metadata "track_player"
                 self.update_state = true;
             } else if let Some(state) = cluster.player_state.take() {
-                self.publish_queue_snapshot(&state);
-                self.emit_player_update(Some(state.clone()), self.last_player_state.as_ref());
-                self.last_player_state = Some(state);
+                self.publish_remote_player_state(state);
             }
         } else if self.connect_state.is_active() {
             self.connect_state.became_inactive(&self.session).await?;

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -22,6 +22,7 @@ use crate::{
             LogoutCommand, SetVolumeCommand,
         },
         context::Context,
+        devices::DeviceType,
         explicit_content_pubsub::UserAttributesUpdate,
         player::ProvidedTrack,
         playlist4_external::PlaylistModificationInfo,
@@ -83,8 +84,8 @@ pub struct DeviceInfo {
     pub device_id: String,
     /// Human-readable device name
     pub device_alias: String,
-    /// Device type (e.g., "Speaker", "Phone")
-    pub device_type: String,
+    /// Device type (e.g., speaker, phone)
+    pub device_type: DeviceType,
     /// Volume level 0-100
     pub volume: u32,
     /// Whether this is the currently active device
@@ -1266,8 +1267,7 @@ impl SpircTask {
         let queue_list = Self::queue_list_from_player_state(player_state);
         let prev_queue_list = std::mem::replace(&mut self.last_queue_list, queue_list.clone());
 
-        let prev_changed = prev_queue_list.prev_tracks != queue_list.prev_tracks;
-        let next_changed = prev_queue_list.next_tracks != queue_list.next_tracks;
+        let (prev_changed, next_changed) = queue_lists_changed(&prev_queue_list, &queue_list);
 
         if prev_changed || next_changed {
             let _ = self.queue_list_sender.send(queue_list);
@@ -1359,29 +1359,9 @@ impl SpircTask {
             }
 
             // Sync device state to cluster_state_sender (after emitting events)
-            let devices: HashMap<String, DeviceInfo> = cluster
-                .device
-                .values()
-                .map(|device| {
-                    let info = DeviceInfo {
-                        device_id: device.device_id.clone(),
-                        device_alias: device.name.clone(),
-                        device_type: format!("{:?}", device.device_type),
-                        volume: device.volume,
-                        is_active: device.device_id == cluster.active_device_id,
-                    };
-                    (info.device_id.clone(), info)
-                })
-                .collect();
-
-            let _ = self.cluster_state_sender.send(ClusterState {
-                devices,
-                active_device_id: if cluster.active_device_id.is_empty() {
-                    None
-                } else {
-                    Some(cluster.active_device_id.clone())
-                },
-            });
+            let _ = self
+                .cluster_state_sender
+                .send(build_cluster_state(&cluster));
 
             let became_inactive = self.connect_state.is_active()
                 && cluster.active_device_id != self.session.device_id();
@@ -2326,6 +2306,43 @@ impl Drop for SpircTask {
     }
 }
 
+/// Returns whether the prev/next track lists differ between two `QueueList`s
+fn queue_lists_changed(prev: &QueueList, next: &QueueList) -> (bool, bool) {
+    (
+        prev.prev_tracks != next.prev_tracks,
+        prev.next_tracks != next.next_tracks,
+    )
+}
+
+/// Builds the device map and active device id from a server `Cluster` snapshot
+fn build_cluster_state(cluster: &Cluster) -> ClusterState {
+    let devices = cluster
+        .device
+        .values()
+        .map(|device| {
+            let info = DeviceInfo {
+                device_id: device.device_id.clone(),
+                device_alias: device.name.clone(),
+                device_type: device.device_type.enum_value_or_default(),
+                volume: device.volume,
+                is_active: device.device_id == cluster.active_device_id,
+            };
+            (info.device_id.clone(), info)
+        })
+        .collect();
+
+    let active_device_id = if cluster.active_device_id.is_empty() {
+        None
+    } else {
+        Some(cluster.active_device_id.clone())
+    };
+
+    ClusterState {
+        devices,
+        active_device_id,
+    }
+}
+
 /// Classifies why a remote `PlayerState` snapshot differs from the last one seen
 fn classify_player_update_reason(
     state: &PlayerState,
@@ -2466,5 +2483,84 @@ mod tests {
             classify_player_update_reason(&next, Some(&last)),
             PlayerUpdateReason::Other
         );
+    }
+
+    fn queue_list(prev: &[&str], next: &[&str]) -> QueueList {
+        QueueList {
+            prev_tracks: prev.iter().map(ToString::to_string).collect(),
+            next_tracks: next.iter().map(ToString::to_string).collect(),
+        }
+    }
+
+    #[test]
+    fn queue_lists_changed_detects_no_change() {
+        let a = queue_list(&["a"], &["b"]);
+        let b = queue_list(&["a"], &["b"]);
+        assert_eq!(queue_lists_changed(&a, &b), (false, false));
+    }
+
+    #[test]
+    fn queue_lists_changed_detects_prev_and_next_independently() {
+        let a = queue_list(&["a"], &["b"]);
+        assert_eq!(
+            queue_lists_changed(&a, &queue_list(&["z"], &["b"])),
+            (true, false)
+        );
+        assert_eq!(
+            queue_lists_changed(&a, &queue_list(&["a"], &["z"])),
+            (false, true)
+        );
+        assert_eq!(
+            queue_lists_changed(&a, &queue_list(&["z"], &["z"])),
+            (true, true)
+        );
+    }
+
+    fn device(
+        id: &str,
+        name: &str,
+        volume: u32,
+        device_type: DeviceType,
+    ) -> crate::protocol::connect::DeviceInfo {
+        let mut d = crate::protocol::connect::DeviceInfo::new();
+        d.device_id = id.to_string();
+        d.name = name.to_string();
+        d.volume = volume;
+        d.device_type = ::protobuf::EnumOrUnknown::new(device_type);
+        d
+    }
+
+    #[test]
+    fn build_cluster_state_maps_devices_and_marks_active() {
+        let mut cluster = Cluster::new();
+        cluster.active_device_id = "device-1".to_string();
+        cluster.device.insert(
+            "device-1".to_string(),
+            device("device-1", "Kitchen", 50, DeviceType::SPEAKER),
+        );
+        cluster.device.insert(
+            "device-2".to_string(),
+            device("device-2", "Phone", 80, DeviceType::SMARTPHONE),
+        );
+
+        let state = build_cluster_state(&cluster);
+
+        assert_eq!(state.active_device_id.as_deref(), Some("device-1"));
+        assert_eq!(state.devices.len(), 2);
+        assert!(state.devices["device-1"].is_active);
+        assert!(!state.devices["device-2"].is_active);
+        assert_eq!(state.devices["device-2"].volume, 80);
+        assert_eq!(
+            state.devices["device-2"].device_type,
+            DeviceType::SMARTPHONE
+        );
+    }
+
+    #[test]
+    fn build_cluster_state_no_active_device_is_none() {
+        let cluster = Cluster::new();
+        let state = build_cluster_state(&cluster);
+        assert_eq!(state.active_device_id, None);
+        assert!(state.devices.is_empty());
     }
 }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1161,14 +1161,126 @@ impl SpircTask {
         }
     }
 
-    fn emit_state_update(&self, state: Option<PlayerState>) {
-        if self.state_sender.receiver_count() == 0 {
+    fn emit_player_update(&self, state: Option<PlayerState>, last_state: Option<&PlayerState>) {
+        if self.player_update_sender.receiver_count() == 0
+            && self.player_state_sender.receiver_count() == 0
+        {
             return;
         }
 
         let state = state.unwrap_or_else(|| self.connect_state.player().clone());
-        if let Err(why) = self.state_sender.send(state) {
-            warn!("couldn't emit state because: {why}")
+
+        // Determine the reason for the update by diffing with last state
+        let reason = if let Some(last) = last_state {
+            // Check in priority order: track > play/pause > shuffle > repeat > seek
+            let new_track_uri = state
+                .track
+                .as_ref()
+                .map(|t| t.uri.clone())
+                .unwrap_or_default();
+            let old_track_uri = last
+                .track
+                .as_ref()
+                .map(|t| t.uri.clone())
+                .unwrap_or_default();
+            if new_track_uri != old_track_uri {
+                let _ = self.player_state_sender.send(Some(state));
+                let _ = self.player_update_sender.send(PlayerUpdateEvent {
+                    reason: PlayerUpdateReason::TrackChanged,
+                });
+                return;
+            }
+
+            let new_is_playing = state.is_playing && !state.is_paused;
+            let old_is_playing = last.is_playing && !last.is_paused;
+            if new_is_playing != old_is_playing {
+                let _ = self.player_state_sender.send(Some(state));
+                let _ = self.player_update_sender.send(PlayerUpdateEvent {
+                    reason: PlayerUpdateReason::PlayPauseChanged,
+                });
+                return;
+            }
+
+            let new_shuffle = state
+                .options
+                .as_ref()
+                .map(|o| o.shuffling_context)
+                .unwrap_or(false);
+            let old_shuffle = last
+                .options
+                .as_ref()
+                .map(|o| o.shuffling_context)
+                .unwrap_or(false);
+            if new_shuffle != old_shuffle {
+                let _ = self.player_state_sender.send(Some(state));
+                let _ = self.player_update_sender.send(PlayerUpdateEvent {
+                    reason: PlayerUpdateReason::ShuffleChanged,
+                });
+                return;
+            }
+
+            let new_repeat = state
+                .options
+                .as_ref()
+                .map(|o| (o.repeating_context, o.repeating_track));
+            let old_repeat = last
+                .options
+                .as_ref()
+                .map(|o| (o.repeating_context, o.repeating_track));
+            if new_repeat != old_repeat {
+                let _ = self.player_state_sender.send(Some(state));
+                let _ = self.player_update_sender.send(PlayerUpdateEvent {
+                    reason: PlayerUpdateReason::RepeatChanged,
+                });
+                return;
+            }
+
+            if state.context_uri != last.context_uri {
+                let _ = self.player_state_sender.send(Some(state));
+                let _ = self.player_update_sender.send(PlayerUpdateEvent {
+                    reason: PlayerUpdateReason::ContextChanged,
+                });
+                return;
+            }
+
+            // Detect seek: position jump (not just natural progress)
+            let position_diff =
+                (state.position_as_of_timestamp - last.position_as_of_timestamp).abs();
+            if position_diff > 5000 {
+                // threshold: 5 seconds
+                PlayerUpdateReason::PositionChanged
+            } else {
+                // No significant change detected
+                PlayerUpdateReason::Other
+            }
+        } else {
+            // No previous state (initial state)
+            PlayerUpdateReason::Other
+        };
+
+        let _ = self.player_state_sender.send(Some(state));
+        if let Err(why) = self.player_update_sender.send(PlayerUpdateEvent { reason }) {
+            warn!("couldn't emit player update because: {why}")
+        }
+    }
+
+    fn emit_cluster_update(&self, event: ClusterUpdateEvent) {
+        if self.cluster_update_sender.receiver_count() == 0 {
+            return;
+        }
+
+        if let Err(why) = self.cluster_update_sender.send(event) {
+            warn!("couldn't emit cluster transition because: {why}")
+        }
+    }
+
+    fn emit_queue_update(&self, event: QueueUpdateEvent) {
+        if self.queue_update_sender.receiver_count() == 0 {
+            return;
+        }
+
+        if let Err(why) = self.queue_update_sender.send(event) {
+            warn!("couldn't emit queue update because: {why}")
         }
     }
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1297,6 +1297,74 @@ impl SpircTask {
         );
 
         if let Some(mut cluster) = cluster_update.cluster.take() {
+            if let Ok(reason_enum) = reason {
+                match reason_enum {
+                    ServerClusterUpdateReason::DEVICE_NEW_CONNECTION
+                    | ServerClusterUpdateReason::NEW_DEVICE_APPEARED
+                    | ServerClusterUpdateReason::DEVICES_DISAPPEARED => {
+                        for device_id in &cluster_update.devices_that_changed {
+                            self.emit_cluster_update(ClusterUpdateEvent {
+                                reason: crate::spirc::ClusterUpdateReason::DeviceListChanged,
+                                device_id: device_id.clone(),
+                            });
+                        }
+                    }
+                    ServerClusterUpdateReason::DEVICE_ALIAS_CHANGED
+                    | ServerClusterUpdateReason::DEVICE_VOLUME_CHANGED => {
+                        for device_id in &cluster_update.devices_that_changed {
+                            self.emit_cluster_update(ClusterUpdateEvent {
+                                reason: crate::spirc::ClusterUpdateReason::DeviceInfoChanged,
+                                device_id: device_id.clone(),
+                            });
+                        }
+                    }
+                    ServerClusterUpdateReason::DEVICE_STATE_CHANGED => {
+                        for device_id in &cluster_update.devices_that_changed {
+                            self.emit_cluster_update(ClusterUpdateEvent {
+                                reason: crate::spirc::ClusterUpdateReason::DeviceStateChanged,
+                                device_id: device_id.clone(),
+                            });
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            // Check for active device changes
+            let new_active_device_id = cluster.active_device_id.clone();
+            if Some(new_active_device_id.clone()) != self.last_active_device_id {
+                self.emit_cluster_update(ClusterUpdateEvent {
+                    reason: crate::spirc::ClusterUpdateReason::ActiveDeviceChanged,
+                    device_id: new_active_device_id.clone(),
+                });
+                self.last_active_device_id = Some(new_active_device_id);
+            }
+
+            // Sync device state to cluster_state_sender (after emitting events)
+            let devices: HashMap<String, DeviceInfo> = cluster
+                .device
+                .iter()
+                .map(|(_, device)| {
+                    let info = DeviceInfo {
+                        device_id: device.device_id.clone(),
+                        device_alias: device.name.clone(),
+                        device_type: format!("{:?}", device.device_type),
+                        volume: device.volume as u32,
+                        is_active: device.device_id == cluster.active_device_id,
+                    };
+                    (info.device_id.clone(), info)
+                })
+                .collect();
+
+            let _ = self.cluster_state_sender.send(ClusterState {
+                devices,
+                active_device_id: if cluster.active_device_id.is_empty() {
+                    None
+                } else {
+                    Some(cluster.active_device_id.clone())
+                },
+            });
+
             let became_inactive = self.connect_state.is_active()
                 && cluster.active_device_id != self.session.device_id();
             if became_inactive {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -789,6 +789,7 @@ impl SpircTask {
             if let Err(why) = self.handle_disconnect().await {
                 error!("error during disconnecting: {why}")
             }
+            self.publish_local_activation(false);
         }
 
         // this should clear the active session id, leaving an empty state
@@ -898,6 +899,7 @@ impl SpircTask {
                 trace!("Received SpircCommand::Shutdown");
                 self.handle_pause();
                 self.handle_disconnect().await?;
+                self.publish_local_activation(false);
                 self.shutdown = true;
                 if let Some(rx) = self.commands.as_mut() {
                     rx.close()
@@ -926,7 +928,9 @@ impl SpircTask {
                 if pause {
                     self.handle_pause()
                 }
-                return self.handle_disconnect().await;
+                let result = self.handle_disconnect().await;
+                self.publish_local_activation(false);
+                return result;
             }
             SpircCommand::Play => self.handle_play(),
             SpircCommand::PlayPause => self.handle_play_pause(),
@@ -1713,6 +1717,7 @@ impl SpircTask {
 
     fn handle_activate(&mut self) {
         self.connect_state.set_active(true);
+        self.publish_local_activation(true);
         self.player
             .emit_session_connected_event(self.session.connection_id(), self.session.username());
         self.player.emit_session_client_changed_event(
@@ -2326,21 +2331,43 @@ impl SpircTask {
             }
 
             // reflect locally now; the server only echoes this back on its own schedule
-            let device_id = self.session.device_id().to_string();
-            let device_info = self.connect_state.device_info();
-            let info = DeviceInfo {
-                device_id: device_id.clone(),
-                device_alias: device_info.name.clone(),
-                device_type: device_info.device_type.enum_value_or_default(),
-                volume: new_volume,
-                is_active: self.connect_state.is_active(),
-            };
+            let (device_id, info) = self.own_device_info(self.connect_state.is_active());
             self.cluster_state_sender.send_modify(|state| {
                 state.devices.insert(device_id.clone(), info);
             });
             self.emit_cluster_update(ClusterUpdateEvent {
                 reason: ClusterUpdateReason::DeviceInfoChanged,
                 device_id: Some(device_id),
+            });
+        }
+    }
+
+    fn own_device_info(&self, is_active: bool) -> (String, DeviceInfo) {
+        let device_id = self.session.device_id().to_string();
+        let device_info = self.connect_state.device_info();
+        let info = DeviceInfo {
+            device_id: device_id.clone(),
+            device_alias: device_info.name.clone(),
+            device_type: device_info.device_type.enum_value_or_default(),
+            volume: device_info.volume,
+            is_active,
+        };
+        (device_id, info)
+    }
+
+    /// Local echo of an activation change, same rationale as `set_volume`'s
+    fn publish_local_activation(&mut self, active: bool) {
+        let (device_id, info) = self.own_device_info(active);
+        let new_active_device_id = active.then(|| device_id.clone());
+
+        self.cluster_state_sender
+            .send_modify(|state| apply_local_activation(state, device_id, info, active));
+
+        if new_active_device_id != self.last_active_device_id {
+            self.last_active_device_id = new_active_device_id.clone();
+            self.emit_cluster_update(ClusterUpdateEvent {
+                reason: ClusterUpdateReason::ActiveDeviceChanged,
+                device_id: new_active_device_id,
             });
         }
     }
@@ -2358,6 +2385,23 @@ fn queue_lists_changed(prev: &QueueList, next: &QueueList) -> (bool, bool) {
         prev.prev_tracks != next.prev_tracks,
         prev.next_tracks != next.next_tracks,
     )
+}
+
+/// Upserts one device's entry into a `ClusterState`, clearing `is_active` on whichever
+/// device previously held it
+fn apply_local_activation(
+    state: &mut ClusterState,
+    device_id: String,
+    info: DeviceInfo,
+    active: bool,
+) {
+    if let Some(prev_id) = &state.active_device_id {
+        if let Some(prev) = state.devices.get_mut(prev_id) {
+            prev.is_active = false;
+        }
+    }
+    state.active_device_id = active.then(|| device_id.clone());
+    state.devices.insert(device_id, info);
 }
 
 /// Builds the device map and active device id from a server `Cluster` snapshot
@@ -2657,5 +2701,52 @@ mod tests {
         let state = build_cluster_state(&cluster);
         assert_eq!(state.active_device_id, None);
         assert!(state.devices.is_empty());
+    }
+
+    fn device_info(device_id: &str, is_active: bool) -> DeviceInfo {
+        DeviceInfo {
+            device_id: device_id.to_string(),
+            device_alias: "test device".to_string(),
+            device_type: DeviceType::COMPUTER,
+            volume: 50,
+            is_active,
+        }
+    }
+
+    #[test]
+    fn apply_local_activation_marks_device_active_and_clears_previous() {
+        let mut state = ClusterState {
+            devices: [("old".to_string(), device_info("old", true))].into(),
+            active_device_id: Some("old".to_string()),
+        };
+
+        apply_local_activation(
+            &mut state,
+            "new".to_string(),
+            device_info("new", true),
+            true,
+        );
+
+        assert_eq!(state.active_device_id.as_deref(), Some("new"));
+        assert!(!state.devices["old"].is_active);
+        assert!(state.devices["new"].is_active);
+    }
+
+    #[test]
+    fn apply_local_activation_deactivation_clears_active_device_id() {
+        let mut state = ClusterState {
+            devices: [("me".to_string(), device_info("me", true))].into(),
+            active_device_id: Some("me".to_string()),
+        };
+
+        apply_local_activation(
+            &mut state,
+            "me".to_string(),
+            device_info("me", false),
+            false,
+        );
+
+        assert_eq!(state.active_device_id, None);
+        assert!(!state.devices["me"].is_active);
     }
 }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1338,13 +1338,17 @@ impl SpircTask {
             }
 
             // Check for active device changes
-            let new_active_device_id = cluster.active_device_id.clone();
-            if Some(new_active_device_id.clone()) != self.last_active_device_id {
+            let new_active_device_id = if cluster.active_device_id.is_empty() {
+                None
+            } else {
+                Some(cluster.active_device_id.clone())
+            };
+            if new_active_device_id != self.last_active_device_id {
                 self.emit_cluster_update(ClusterUpdateEvent {
                     reason: crate::spirc::ClusterUpdateReason::ActiveDeviceChanged,
-                    device_id: new_active_device_id.clone(),
+                    device_id: new_active_device_id.clone().unwrap_or_default(),
                 });
-                self.last_active_device_id = Some(new_active_device_id);
+                self.last_active_device_id = new_active_device_id;
             }
 
             // Sync device state to cluster_state_sender (after emitting events)

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -392,9 +392,9 @@ impl Spirc {
             update_volume: false,
             update_state: false,
 
-            player_update_sender: player_update_tx.clone(),
-            cluster_update_sender: cluster_update_tx.clone(),
-            queue_update_sender: queue_update_tx.clone(),
+            player_update_sender: player_update_sender_tx.clone(),
+            cluster_update_sender: cluster_update_sender_tx.clone(),
+            queue_update_sender: queue_update_sender_tx.clone(),
             player_state_sender: player_state_sender_tx.clone(),
             cluster_state_sender: cluster_state_sender_tx.clone(),
             queue_list_sender: queue_list_sender_tx.clone(),
@@ -406,9 +406,9 @@ impl Spirc {
 
         let spirc = Spirc {
             commands: cmd_tx,
-            player_update_sender: player_update_tx,
-            cluster_update_sender: cluster_update_tx,
-            queue_update_sender: queue_update_tx,
+            player_update_sender: player_update_sender_tx,
+            cluster_update_sender: cluster_update_sender_tx,
+            queue_update_sender: queue_update_sender_tx,
             player_state_sender: player_state_sender_tx,
             cluster_state_sender: cluster_state_sender_tx,
             queue_list_sender: queue_list_sender_tx,

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1377,7 +1377,30 @@ impl SpircTask {
                 //  tried: providing session_id, playback_id, track-metadata "track_player"
                 self.update_state = true;
             } else if let Some(state) = cluster.player_state.take() {
-                self.emit_state_update(Some(state))
+                if let Some(last_state) = &self.last_player_state {
+                    let prev_changed = state.prev_tracks != last_state.prev_tracks;
+                    let next_changed = state.next_tracks != last_state.next_tracks;
+                    if prev_changed || next_changed {
+                        let queue_list = QueueList {
+                            prev_tracks: state.prev_tracks.iter().map(|t| t.uri.clone()).collect(),
+                            next_tracks: state.next_tracks.iter().map(|t| t.uri.clone()).collect(),
+                        };
+                        let _ = self.queue_list_sender.send(queue_list);
+
+                        if prev_changed {
+                            self.emit_queue_update(QueueUpdateEvent {
+                                reason: QueueUpdateReason::PrevTracksChanged,
+                            });
+                        }
+                        if next_changed {
+                            self.emit_queue_update(QueueUpdateEvent {
+                                reason: QueueUpdateReason::NextTracksChanged,
+                            });
+                        }
+                    }
+                }
+                self.emit_player_update(Some(state.clone()), self.last_player_state.as_ref());
+                self.last_player_state = Some(state);
             }
         } else if self.connect_state.is_active() {
             self.connect_state.became_inactive(&self.session).await?;

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -101,7 +101,7 @@ pub struct ClusterState {
 }
 
 /// Queue information (previous and next tracks)
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct QueueList {
     /// Previous tracks in the queue (as URIs)
     pub prev_tracks: Vec<String>,
@@ -222,6 +222,7 @@ struct SpircTask {
     cluster_state_sender: watch::Sender<ClusterState>,
     queue_list_sender: watch::Sender<QueueList>,
     last_active_device_id: Option<String>,
+    last_queue_list: QueueList,
     last_player_state: Option<PlayerState>,
 
     spirc_id: usize,
@@ -399,6 +400,10 @@ impl Spirc {
             cluster_state_sender: cluster_state_sender_tx.clone(),
             queue_list_sender: queue_list_sender_tx.clone(),
             last_active_device_id: None,
+            last_queue_list: QueueList {
+                prev_tracks: Vec::new(),
+                next_tracks: Vec::new(),
+            },
             last_player_state: None,
 
             spirc_id,
@@ -931,10 +936,23 @@ impl SpircTask {
     }
 
     fn handle_player_event(&mut self, event: PlayerEvent) -> Result<(), Error> {
-        if let PlayerEvent::TrackChanged { audio_item } = event {
+        let player_update_reason = match &event {
+            PlayerEvent::TrackChanged { .. } => Some(PlayerUpdateReason::TrackChanged),
+            PlayerEvent::Playing { .. }
+            | PlayerEvent::Paused { .. }
+            | PlayerEvent::Stopped { .. } => Some(PlayerUpdateReason::PlayPauseChanged),
+            PlayerEvent::Seeked { .. } | PlayerEvent::PositionCorrection { .. } => {
+                Some(PlayerUpdateReason::SeekChanged)
+            }
+            PlayerEvent::ShuffleChanged { .. } => Some(PlayerUpdateReason::ShuffleChanged),
+            PlayerEvent::RepeatChanged { .. } => Some(PlayerUpdateReason::RepeatChanged),
+            PlayerEvent::SetQueue { .. } => Some(PlayerUpdateReason::ContextChanged),
+            _ => None,
+        };
+
+        if let PlayerEvent::TrackChanged { audio_item } = &event {
             self.connect_state.update_duration(audio_item.duration_ms);
             self.update_state = true;
-            return Ok(());
         }
 
         // update play_request_id
@@ -943,16 +961,29 @@ impl SpircTask {
             return Ok(());
         }
 
-        let is_current_track = matches! {
-            (event.get_play_request_id(), self.play_request_id),
-            (Some(event_id), Some(current_id)) if event_id == current_id
-        };
+        let should_gate_by_play_request_id = matches!(
+            event,
+            PlayerEvent::Loading { .. }
+                | PlayerEvent::Seeked { .. }
+                | PlayerEvent::PositionCorrection { .. }
+                | PlayerEvent::Playing { .. }
+                | PlayerEvent::Paused { .. }
+                | PlayerEvent::Stopped { .. }
+                | PlayerEvent::TimeToPreloadNextTrack { .. }
+                | PlayerEvent::EndOfTrack { .. }
+                | PlayerEvent::Unavailable { .. }
+        );
 
         // we only process events if the play_request_id matches. If it doesn't, it is
         // an event that belongs to a previous track and only arrives now due to a race
         // condition. In this case we have updated the state already and don't want to
         // mess with it.
-        if !is_current_track {
+        if should_gate_by_play_request_id
+            && !matches! {
+                (event.get_play_request_id(), self.play_request_id),
+                (Some(event_id), Some(current_id)) if event_id == current_id
+            }
+        {
             return Ok(());
         }
 
@@ -1050,6 +1081,16 @@ impl SpircTask {
                 self.handle_preload_next_track();
                 return Ok(());
             }
+            PlayerEvent::TrackChanged { .. }
+            | PlayerEvent::ShuffleChanged { .. }
+            | PlayerEvent::RepeatChanged { .. }
+            | PlayerEvent::SetQueue { .. } => {}
+            PlayerEvent::VolumeChanged { .. }
+            | PlayerEvent::SessionConnected { .. }
+            | PlayerEvent::SessionDisconnected { .. }
+            | PlayerEvent::SessionClientChanged { .. }
+            | PlayerEvent::AutoPlayChanged { .. }
+            | PlayerEvent::FilterExplicitContentChanged { .. } => return Ok(()),
             PlayerEvent::Unavailable { track_id, .. } => {
                 self.handle_unavailable(&track_id)?;
                 if self.connect_state.current_track(|t| &t.uri) == &track_id.to_uri() {
@@ -1061,25 +1102,10 @@ impl SpircTask {
 
         self.update_state = true;
 
-        // Emit local player state to watch channels if this device is active
         if self.connect_state.is_active() {
-            let player_state = self.connect_state.player().clone();
-            let _ = self.player_state_sender.send(Some(player_state.clone()));
-
-            // Also update queue list from local state
-            let queue_list = QueueList {
-                prev_tracks: player_state
-                    .prev_tracks
-                    .iter()
-                    .map(|t| t.uri.clone())
-                    .collect(),
-                next_tracks: player_state
-                    .next_tracks
-                    .iter()
-                    .map(|t| t.uri.clone())
-                    .collect(),
-            };
-            let _ = self.queue_list_sender.send(queue_list);
+            // sync play_status now instead of waiting on the debounced notify()
+            self.connect_state.set_status(&self.play_status);
+            self.publish_active_state(player_update_reason);
         }
 
         Ok(())
@@ -1275,8 +1301,7 @@ impl SpircTask {
                 last.position_as_of_timestamp
             };
 
-            let position_delta =
-                (state.position_as_of_timestamp - expected_position).abs();
+            let position_delta = (state.position_as_of_timestamp - expected_position).abs();
             if position_delta > 5000 {
                 PlayerUpdateReason::SeekChanged
             } else {
@@ -1311,6 +1336,57 @@ impl SpircTask {
 
         if let Err(why) = self.queue_update_sender.send(event) {
             warn!("couldn't emit queue update because: {why}")
+        }
+    }
+
+    fn queue_list_from_player_state(player_state: &PlayerState) -> QueueList {
+        QueueList {
+            prev_tracks: player_state
+                .prev_tracks
+                .iter()
+                .map(|t| t.uri.clone())
+                .collect(),
+            next_tracks: player_state
+                .next_tracks
+                .iter()
+                .map(|t| t.uri.clone())
+                .collect(),
+        }
+    }
+
+    fn publish_queue_snapshot(&mut self, player_state: &PlayerState) {
+        let queue_list = Self::queue_list_from_player_state(player_state);
+        let prev_queue_list = std::mem::replace(&mut self.last_queue_list, queue_list.clone());
+
+        let prev_changed = prev_queue_list.prev_tracks != queue_list.prev_tracks;
+        let next_changed = prev_queue_list.next_tracks != queue_list.next_tracks;
+
+        if prev_changed || next_changed {
+            let _ = self.queue_list_sender.send(queue_list);
+
+            if prev_changed {
+                self.emit_queue_update(QueueUpdateEvent {
+                    reason: QueueUpdateReason::PrevTracksChanged,
+                });
+            }
+            if next_changed {
+                self.emit_queue_update(QueueUpdateEvent {
+                    reason: QueueUpdateReason::NextTracksChanged,
+                });
+            }
+        }
+    }
+
+    fn publish_active_state(&mut self, reason: Option<PlayerUpdateReason>) {
+        let player_state = self.connect_state.player().clone();
+        let _ = self.player_state_sender.send(Some(player_state.clone()));
+        self.publish_queue_snapshot(&player_state);
+        self.last_player_state = Some(player_state);
+
+        if let Some(reason) = reason {
+            if let Err(why) = self.player_update_sender.send(PlayerUpdateEvent { reason }) {
+                warn!("couldn't emit player update because: {why}")
+            }
         }
     }
 
@@ -1411,34 +1487,7 @@ impl SpircTask {
                 //  tried: providing session_id, playback_id, track-metadata "track_player"
                 self.update_state = true;
             } else if let Some(state) = cluster.player_state.take() {
-                if let Some(last_state) = &self.last_player_state {
-                    let prev_changed = state.prev_tracks != last_state.prev_tracks;
-                    let next_changed = state.next_tracks != last_state.next_tracks;
-                    if prev_changed || next_changed {
-                        let queue_list = QueueList {
-                            prev_tracks: state.prev_tracks.iter().map(|t| t.uri.clone()).collect(),
-                            next_tracks: state.next_tracks.iter().map(|t| t.uri.clone()).collect(),
-                        };
-                        let _ = self.queue_list_sender.send(queue_list);
-
-                        if prev_changed {
-                            self.emit_queue_update(QueueUpdateEvent {
-                                reason: QueueUpdateReason::PrevTracksChanged,
-                            });
-                        }
-                        if next_changed {
-                            self.emit_queue_update(QueueUpdateEvent {
-                                reason: QueueUpdateReason::NextTracksChanged,
-                            });
-                        }
-                    }
-                } else {
-                    let queue_list = QueueList {
-                        prev_tracks: state.prev_tracks.iter().map(|t| t.uri.clone()).collect(),
-                        next_tracks: state.next_tracks.iter().map(|t| t.uri.clone()).collect(),
-                    };
-                    let _ = self.queue_list_sender.send(queue_list);
-                }
+                self.publish_queue_snapshot(&state);
                 self.emit_player_update(Some(state.clone()), self.last_player_state.as_ref());
                 self.last_player_state = Some(state);
             }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1275,7 +1275,8 @@ impl SpircTask {
                 last.position_as_of_timestamp
             };
 
-            let position_delta = (state.position_as_of_timestamp as i64 - expected_position as i64).abs();
+            let position_delta =
+                (state.position_as_of_timestamp as i64 - expected_position as i64).abs();
             if position_delta > 5000 {
                 PlayerUpdateReason::SeekChanged
             } else {

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -2297,7 +2297,6 @@ impl SpircTask {
 
         self.connect_state.set_now(self.now_ms() as u64);
 
-        self.emit_state_update(None);
 
         self.connect_state
             .send_state(&self.session)

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -152,8 +152,6 @@ pub struct QueueUpdateEvent {
 pub enum PlayerUpdateReason {
     /// Track changed
     TrackChanged,
-    /// Position changed
-    PositionChanged,
     /// Play/pause state changed
     PlayPauseChanged,
     /// Shuffle mode changed
@@ -162,6 +160,8 @@ pub enum PlayerUpdateReason {
     RepeatChanged,
     /// Context changed
     ContextChanged,
+    /// Seek detected
+    SeekChanged,
     /// Other state change
     Other,
 }
@@ -1244,11 +1244,18 @@ impl SpircTask {
             }
 
             // Detect seek: position jump (not just natural progress)
-            let position_diff =
-                (state.position_as_of_timestamp - last.position_as_of_timestamp).abs();
-            if position_diff > 5000 {
-                // threshold: 5 seconds
-                PlayerUpdateReason::PositionChanged
+            let time_diff = state.timestamp.saturating_sub(last.timestamp);
+            let expected_position = if state.is_playing {
+                // Account for natural progression if playing
+                last.position_as_of_timestamp + time_diff
+            } else {
+                // If paused, position shouldn't change
+                last.position_as_of_timestamp
+            };
+
+            let position_delta = (state.position_as_of_timestamp as i64 - expected_position as i64).abs();
+            if position_delta > 5000 {
+                PlayerUpdateReason::SeekChanged
             } else {
                 // No significant change detected
                 PlayerUpdateReason::Other

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -261,6 +261,10 @@ const CONTEXT_FETCH_THRESHOLD: usize = 2;
 const VOLUME_UPDATE_DELAY: Duration = Duration::from_millis(500);
 // to reduce updates to remote, we group some request by waiting for a set amount of time
 const UPDATE_STATE_DELAY: Duration = Duration::from_millis(200);
+// a single cluster update can emit several of these back-to-back (e.g. multiple devices
+// changing at once) with no await point in between for a receiver to drain the channel,
+// so capacity 1 would silently drop all but the last one
+const UPDATE_EVENT_CHANNEL_CAPACITY: usize = 16;
 
 /// The spotify connect handle
 pub struct Spirc {
@@ -348,9 +352,9 @@ impl Spirc {
         let _ = session.login5().auth_token().await?;
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
-        let (player_update_sender_tx, _) = broadcast::channel(1);
-        let (cluster_update_sender_tx, _) = broadcast::channel(1);
-        let (queue_update_sender_tx, _) = broadcast::channel(1);
+        let (player_update_sender_tx, _) = broadcast::channel(UPDATE_EVENT_CHANNEL_CAPACITY);
+        let (cluster_update_sender_tx, _) = broadcast::channel(UPDATE_EVENT_CHANNEL_CAPACITY);
+        let (queue_update_sender_tx, _) = broadcast::channel(UPDATE_EVENT_CHANNEL_CAPACITY);
         let (player_state_sender_tx, _) = watch::channel(None);
         let (cluster_state_sender_tx, _) = watch::channel(ClusterState {
             devices: HashMap::new(),
@@ -1225,7 +1229,16 @@ impl SpircTask {
         let reason = classify_player_update_reason(&state, last_state);
 
         let _ = self.player_state_sender.send(Some(state));
-        if let Err(why) = self.player_update_sender.send(PlayerUpdateEvent { reason }) {
+        self.emit_player_update_event(PlayerUpdateEvent { reason });
+    }
+
+    /// No-op without subscribers, so local playback doesn't warn when nobody's listening
+    fn emit_player_update_event(&self, event: PlayerUpdateEvent) {
+        if self.player_update_sender.receiver_count() == 0 {
+            return;
+        }
+
+        if let Err(why) = self.player_update_sender.send(event) {
             warn!("couldn't emit player update because: {why}")
         }
     }
@@ -1294,9 +1307,7 @@ impl SpircTask {
         self.last_player_state = Some(player_state);
 
         if let Some(reason) = reason {
-            if let Err(why) = self.player_update_sender.send(PlayerUpdateEvent { reason }) {
-                warn!("couldn't emit player update because: {why}")
-            }
+            self.emit_player_update_event(PlayerUpdateEvent { reason });
         }
     }
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1209,6 +1209,8 @@ impl SpircTask {
         }
     }
 
+    /// Remote snapshots carry no event metadata, so the reason is inferred by diffing here.
+    /// Local updates get it directly from the originating `PlayerEvent` instead.
     fn emit_player_update(&self, state: Option<PlayerState>, last_state: Option<&PlayerState>) {
         if self.player_update_sender.receiver_count() == 0
             && self.player_state_sender.receiver_count() == 0
@@ -1410,7 +1412,7 @@ impl SpircTask {
                     | ServerClusterUpdateReason::DEVICES_DISAPPEARED => {
                         for device_id in &cluster_update.devices_that_changed {
                             self.emit_cluster_update(ClusterUpdateEvent {
-                                reason: crate::spirc::ClusterUpdateReason::DeviceListChanged,
+                                reason: ClusterUpdateReason::DeviceListChanged,
                                 device_id: device_id.clone(),
                             });
                         }
@@ -1419,7 +1421,7 @@ impl SpircTask {
                     | ServerClusterUpdateReason::DEVICE_VOLUME_CHANGED => {
                         for device_id in &cluster_update.devices_that_changed {
                             self.emit_cluster_update(ClusterUpdateEvent {
-                                reason: crate::spirc::ClusterUpdateReason::DeviceInfoChanged,
+                                reason: ClusterUpdateReason::DeviceInfoChanged,
                                 device_id: device_id.clone(),
                             });
                         }
@@ -1427,7 +1429,7 @@ impl SpircTask {
                     ServerClusterUpdateReason::DEVICE_STATE_CHANGED => {
                         for device_id in &cluster_update.devices_that_changed {
                             self.emit_cluster_update(ClusterUpdateEvent {
-                                reason: crate::spirc::ClusterUpdateReason::DeviceStateChanged,
+                                reason: ClusterUpdateReason::DeviceStateChanged,
                                 device_id: device_id.clone(),
                             });
                         }
@@ -1444,7 +1446,7 @@ impl SpircTask {
             };
             if new_active_device_id != self.last_active_device_id {
                 self.emit_cluster_update(ClusterUpdateEvent {
-                    reason: crate::spirc::ClusterUpdateReason::ActiveDeviceChanged,
+                    reason: ClusterUpdateReason::ActiveDeviceChanged,
                     device_id: new_active_device_id.clone().unwrap_or_default(),
                 });
                 self.last_active_device_id = new_active_device_id;

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1060,6 +1060,28 @@ impl SpircTask {
         }
 
         self.update_state = true;
+
+        // Emit local player state to watch channels if this device is active
+        if self.connect_state.is_active() {
+            let player_state = self.connect_state.player().clone();
+            let _ = self.player_state_sender.send(Some(player_state.clone()));
+
+            // Also update queue list from local state
+            let queue_list = QueueList {
+                prev_tracks: player_state
+                    .prev_tracks
+                    .iter()
+                    .map(|t| t.uri.clone())
+                    .collect(),
+                next_tracks: player_state
+                    .next_tracks
+                    .iter()
+                    .map(|t| t.uri.clone())
+                    .collect(),
+            };
+            let _ = self.queue_list_sender.send(queue_list);
+        }
+
         Ok(())
     }
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -25,6 +25,7 @@ use crate::{
         social_connect_v2::SessionUpdate,
         transfer_state::TransferState,
         user_attributes::UserAttributesMutation,
+        {context_page::ContextPage, player::PlayerState},
     },
     state::{
         context::{ContextType, ResetContext},
@@ -33,7 +34,6 @@ use crate::{
     },
 };
 use futures_util::StreamExt;
-use librespot_protocol::context_page::ContextPage;
 use protobuf::MessageField;
 use std::{
     future::Future,
@@ -42,7 +42,10 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
-use tokio::{sync::mpsc, time::sleep};
+use tokio::{
+    sync::{broadcast, mpsc},
+    time::sleep,
+};
 
 #[derive(Debug, Error)]
 enum SpircError {
@@ -111,6 +114,8 @@ struct SpircTask {
     /// when no other future resolves, otherwise resets the delay
     update_state: bool,
 
+    state_sender: broadcast::Sender<PlayerState>,
+
     spirc_id: usize,
 }
 
@@ -148,6 +153,7 @@ const UPDATE_STATE_DELAY: Duration = Duration::from_millis(200);
 /// The spotify connect handle
 pub struct Spirc {
     commands: mpsc::UnboundedSender<SpircCommand>,
+    state_sender: broadcast::Sender<PlayerState>,
 }
 
 impl Spirc {
@@ -225,6 +231,7 @@ impl Spirc {
         let _ = session.login5().auth_token().await?;
 
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
+        let (state_tx, _) = broadcast::channel(1);
 
         let player_events = player.get_player_event_channel();
 
@@ -261,10 +268,15 @@ impl Spirc {
             update_volume: false,
             update_state: false,
 
+            state_sender: state_tx.clone(),
+
             spirc_id,
         };
 
-        let spirc = Spirc { commands: cmd_tx };
+        let spirc = Spirc {
+            commands: cmd_tx,
+            state_sender: state_tx,
+        };
 
         let initial_volume = task.connect_state.device_info().volume;
         task.connect_state.set_volume(0);
@@ -434,6 +446,14 @@ impl Spirc {
         Ok(self
             .commands
             .send(SpircCommand::Transfer(transfer_request))?)
+    }
+
+    /// Get a channel which sends the [PlayerState] whenever it changes.
+    ///
+    /// Forwards the internal [PlayerState] when we are the active device. When we are only
+    /// a spectator, forwards any [PlayerState] update from the active player.
+    pub fn get_state_update_channel(&self) -> broadcast::Receiver<PlayerState> {
+        self.state_sender.subscribe()
     }
 }
 
@@ -983,6 +1003,17 @@ impl SpircTask {
         }
     }
 
+    fn emit_state_update(&self, state: Option<PlayerState>) {
+        if self.state_sender.receiver_count() == 0 {
+            return;
+        }
+
+        let state = state.unwrap_or_else(|| self.connect_state.player().clone());
+        if let Err(why) = self.state_sender.send(state) {
+            warn!("couldn't emit state because: {why}")
+        }
+    }
+
     async fn handle_cluster_update(
         &mut self,
         mut cluster_update: ClusterUpdate,
@@ -995,7 +1026,7 @@ impl SpircTask {
             cluster_update.cluster.active_device_id
         );
 
-        if let Some(cluster) = cluster_update.cluster.take() {
+        if let Some(mut cluster) = cluster_update.cluster.take() {
             let became_inactive = self.connect_state.is_active()
                 && cluster.active_device_id != self.session.device_id();
             if became_inactive {
@@ -1007,6 +1038,8 @@ impl SpircTask {
                 //  background: when another device sends a connect-state update, some player's position de-syncs
                 //  tried: providing session_id, playback_id, track-metadata "track_player"
                 self.update_state = true;
+            } else if let Some(state) = cluster.player_state.take() {
+                self.emit_state_update(Some(state))
             }
         } else if self.connect_state.is_active() {
             self.connect_state.became_inactive(&self.session).await?;
@@ -1902,6 +1935,8 @@ impl SpircTask {
         }
 
         self.connect_state.set_now(self.now_ms() as u64);
+
+        self.emit_state_update(None);
 
         self.connect_state
             .send_state(&self.session)

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -2297,7 +2297,6 @@ impl SpircTask {
 
         self.connect_state.set_now(self.now_ms() as u64);
 
-
         self.connect_state
             .send_state(&self.session)
             .await

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -112,6 +112,7 @@ pub struct QueueList {
 
 /// Semantic reason for cluster updates
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum ClusterUpdateReason {
     /// Device list changed
     DeviceListChanged,
@@ -126,14 +127,15 @@ pub enum ClusterUpdateReason {
 /// Event emitted when cluster state changes
 #[derive(Debug, Clone)]
 pub struct ClusterUpdateEvent {
-    /// Device ID that changed
-    pub device_id: String,
+    /// Device that changed, or `None` if `ActiveDeviceChanged` means nothing is active
+    pub device_id: Option<String>,
     /// Reason for the update
     pub reason: ClusterUpdateReason,
 }
 
 /// Semantic reasons for queue updates
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum QueueUpdateReason {
     /// Previous tracks changed
     PrevTracksChanged,
@@ -150,6 +152,7 @@ pub struct QueueUpdateEvent {
 
 /// Semantic reasons for player state updates
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum PlayerUpdateReason {
     /// Track changed
     TrackChanged,
@@ -1332,7 +1335,7 @@ impl SpircTask {
                         for device_id in &cluster_update.devices_that_changed {
                             self.emit_cluster_update(ClusterUpdateEvent {
                                 reason: ClusterUpdateReason::DeviceListChanged,
-                                device_id: device_id.clone(),
+                                device_id: Some(device_id.clone()),
                             });
                         }
                     }
@@ -1341,7 +1344,7 @@ impl SpircTask {
                         for device_id in &cluster_update.devices_that_changed {
                             self.emit_cluster_update(ClusterUpdateEvent {
                                 reason: ClusterUpdateReason::DeviceInfoChanged,
-                                device_id: device_id.clone(),
+                                device_id: Some(device_id.clone()),
                             });
                         }
                     }
@@ -1349,7 +1352,7 @@ impl SpircTask {
                         for device_id in &cluster_update.devices_that_changed {
                             self.emit_cluster_update(ClusterUpdateEvent {
                                 reason: ClusterUpdateReason::DeviceStateChanged,
-                                device_id: device_id.clone(),
+                                device_id: Some(device_id.clone()),
                             });
                         }
                     }
@@ -1366,7 +1369,7 @@ impl SpircTask {
             if new_active_device_id != self.last_active_device_id {
                 self.emit_cluster_update(ClusterUpdateEvent {
                     reason: ClusterUpdateReason::ActiveDeviceChanged,
-                    device_id: new_active_device_id.clone().unwrap_or_default(),
+                    device_id: new_active_device_id.clone(),
                 });
                 self.last_active_device_id = new_active_device_id;
             }
@@ -2325,7 +2328,7 @@ impl SpircTask {
             });
             self.emit_cluster_update(ClusterUpdateEvent {
                 reason: ClusterUpdateReason::DeviceInfoChanged,
-                device_id,
+                device_id: Some(device_id),
             });
         }
     }

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -161,6 +161,8 @@ pub enum PlayerUpdateReason {
     RepeatChanged,
     /// Context changed
     ContextChanged,
+    /// Queue was set or reloaded
+    QueueChanged,
     /// Seek detected
     SeekChanged,
     /// Other state change
@@ -947,7 +949,7 @@ impl SpircTask {
             }
             PlayerEvent::ShuffleChanged { .. } => Some(PlayerUpdateReason::ShuffleChanged),
             PlayerEvent::RepeatChanged { .. } => Some(PlayerUpdateReason::RepeatChanged),
-            PlayerEvent::SetQueue { .. } => Some(PlayerUpdateReason::ContextChanged),
+            PlayerEvent::SetQueue { .. } => Some(PlayerUpdateReason::QueueChanged),
             _ => None,
         };
 

--- a/examples/watch_remote_state.rs
+++ b/examples/watch_remote_state.rs
@@ -1,0 +1,124 @@
+//! Demonstrates observing Spotify Connect playback/device state from `Spirc`,
+//! independent of whether this device is the one actively playing. This is the
+//! pattern an MPRIS bridge (e.g. spotifyd) would use: watch channels give you
+//! the current snapshot, broadcast channels tell you when something changed
+//! and why.
+
+use librespot::{
+    connect::{ConnectConfig, Spirc},
+    core::{authentication::Credentials, cache::Cache, config::SessionConfig, session::Session},
+    playback::mixer::MixerConfig,
+    playback::{
+        audio_backend,
+        config::{AudioFormat, PlayerConfig},
+        mixer,
+        player::Player,
+    },
+};
+
+use log::LevelFilter;
+
+const CACHE: &str = ".cache";
+const CACHE_FILES: &str = ".cache/files";
+
+#[tokio::main]
+async fn main() -> Result<(), librespot::core::Error> {
+    env_logger::builder()
+        .filter_module("librespot", LevelFilter::Info)
+        .init();
+
+    let session_config = SessionConfig::default();
+    let player_config = PlayerConfig::default();
+    let audio_format = AudioFormat::default();
+    let connect_config = ConnectConfig::default();
+    let mixer_config = MixerConfig::default();
+
+    let sink_builder = audio_backend::find(None).unwrap();
+    let mixer_builder = mixer::find(None).unwrap();
+
+    let cache = Cache::new(Some(CACHE), Some(CACHE), Some(CACHE_FILES), None)?;
+    let credentials = cache
+        .credentials()
+        .ok_or(librespot::core::Error::unavailable(
+            "credentials not cached",
+        ))
+        .or_else(|_| {
+            librespot_oauth::OAuthClientBuilder::new(
+                &session_config.client_id,
+                "http://127.0.0.1:8898/login",
+                vec!["streaming"],
+            )
+            .open_in_browser()
+            .build()?
+            .get_access_token()
+            .map(|t| Credentials::with_access_token(t.access_token))
+        })?;
+
+    let session = Session::new(session_config, Some(cache));
+    let mixer = mixer_builder(mixer_config)?;
+
+    let player = Player::new(
+        player_config,
+        session.clone(),
+        mixer.get_soft_volume(),
+        move || sink_builder(None, audio_format),
+    );
+
+    let (spirc, spirc_task) =
+        Spirc::new(connect_config, session.clone(), credentials, player, mixer).await?;
+
+    // watch channels: current state snapshots
+    let mut cluster_state = spirc.watch_cluster_state();
+    let mut player_state = spirc.watch_player_state();
+    let mut queue_list = spirc.watch_queue_list();
+
+    // broadcast channels: lightweight "something changed, here's why" notifications
+    let mut cluster_updates = spirc.get_cluster_update_channel();
+    let mut player_updates = spirc.get_player_update_channel();
+    let mut queue_updates = spirc.get_queue_update_channel();
+
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                Ok(()) = cluster_state.changed() => {
+                    let state = cluster_state.borrow_and_update();
+                    println!(
+                        "cluster snapshot: {} device(s), active={:?}",
+                        state.devices.len(),
+                        state.active_device_id
+                    );
+                }
+                Ok(event) = cluster_updates.recv() => {
+                    println!("cluster update: {event:?}");
+                }
+                Ok(()) = player_state.changed() => {
+                    let state = player_state.borrow_and_update();
+                    if let Some(state) = state.as_ref() {
+                        let track = state.track.as_ref().map(|t| t.uri.as_str()).unwrap_or("<none>");
+                        println!("player snapshot: track={track} playing={}", state.is_playing);
+                    }
+                }
+                Ok(event) = player_updates.recv() => {
+                    println!("player update: {event:?}");
+                }
+                Ok(()) = queue_list.changed() => {
+                    let queue = queue_list.borrow_and_update();
+                    println!(
+                        "queue snapshot: {} prev, {} next",
+                        queue.prev_tracks.len(),
+                        queue.next_tracks.len()
+                    );
+                }
+                Ok(event) = queue_updates.recv() => {
+                    println!("queue update: {event:?}");
+                }
+                else => break,
+            }
+        }
+    });
+
+    // this device stays passive; it only observes remote Connect state
+    spirc_task.await;
+
+    Ok(())
+}


### PR DESCRIPTION
expose 3 broadcast/watch channel pairs to observe remote playback and other states. pattern-wise, broadcast channels (lightweight) emit only update (or state change) events with semantic reasons. watch channels (stateful) emit complete state snapshots

- cluster
  - broadcast when device list (dis/appeared, active device) or info (volume, alias) changes
  - watch current ClusterState with all device info and active device id
  - use case: mpris lifecycle, device picker ui
- player
  - broadcast when track, play/pause, position, shuffle, repeat or context changes
  - watch current PlayerState snapshot
  - use: remote playback ui, track changes, pause/resume
- queue
  - broadcast when when prev or next track queue changes
  - watch current QueueList snapshot
  - use: queue ui refresh, skip detection, upcoming track preview

partially closes #1448

also fixed

- `ShuffleChanged`/`RepeatChanged`/`SetQueue` player events never carried a `play_request_id` so the pre-existing gate in `handle_player_event` silently dropped them before `update_state` was set. this pr narrows the gate to only the events that actually carry one


