### PR TITLE
[codex] Fix stable clippy sort lint

### DIFF
--- a/metadata/src/audio/item.rs
+++ b/metadata/src/audio/item.rs
@@ -194,7 +194,7 @@ impl AudioItem {
 fn get_covers(covers: Images, image_url: String) -> Vec<CoverImage> {
     let mut covers = covers;
 
-    covers.sort_by(|a, b| b.width.cmp(&a.width));
+    covers.sort_by_key(|cover| std::cmp::Reverse(cover.width));
 
     covers
         .iter()


### PR DESCRIPTION
## Summary

This isolates the stable clippy fix for `metadata/src/audio/item.rs` into its own PR.

The change replaces a `sort_by` call with `sort_by_key(Reverse(...))` to satisfy `clippy::unnecessary_sort_by` on the stable toolchain without changing behavior.

## Why

While validating #1708, stable clippy surfaced a repository-wide lint in `metadata/src/audio/item.rs` that was unrelated to the Avahi fix. Keeping this as a separate PR keeps the Avahi bugfix narrow and makes the lint cleanup easier to review.

## Validation

- `cargo clippy -p librespot-metadata --lib -- -D warnings`
- `cargo fmt --check`
