### PR TITLE
[codex] Fix stable clippy match lint

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -816,15 +816,12 @@ impl SpircTask {
                     SpircPlayStatus::Playing {
                         ref mut nominal_start_time,
                         ..
-                    } => {
-                        if (*nominal_start_time - new_nominal_start_time).abs() > 100 {
-                            *nominal_start_time = new_nominal_start_time;
-                            self.connect_state
-                                .update_position(position_ms, self.now_ms());
-                        } else {
-                            return Ok(());
-                        }
+                    } if (*nominal_start_time - new_nominal_start_time).abs() > 100 => {
+                        *nominal_start_time = new_nominal_start_time;
+                        self.connect_state
+                            .update_position(position_ms, self.now_ms());
                     }
+                    SpircPlayStatus::Playing { .. } => return Ok(()),
                     SpircPlayStatus::LoadingPlay { .. } | SpircPlayStatus::LoadingPause { .. } => {
                         self.connect_state
                             .update_position(position_ms, self.now_ms());


### PR DESCRIPTION
## Summary

This isolates the stable clippy fix for `connect/src/spirc.rs` into its own PR.

The change rewrites the relevant match arm into the shape stable clippy expects and includes the matching rustfmt layout update.

## Why

While validating #1708, stable clippy surfaced a repository-wide lint in `connect/src/spirc.rs` that was unrelated to the Avahi fix. Keeping this as a separate PR keeps the Avahi bugfix narrow and makes the lint cleanup easier to review.

## Validation

- `cargo clippy -p librespot-connect --lib -- -D warnings`
- `cargo fmt --check`
