### PR TITLE
fix(connect): keep spirc running after transient connection-id update failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] Fixed `--volume-ctrl fixed` not disabling volume control
 - [core] Fix default permissions on credentials file and warn user if file is world readable
 - [core] Try all resolved addresses for the dealer connection instead of failing after the first one.
+- [connect] Keep the Spirc running after a transient connection-id update failure instead of shutting it down, so the device no longer silently disappears from Spotify Connect until a manual restart.
 
 ## [0.8.0] - 2025-11-10
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -477,7 +477,6 @@ impl SpircTask {
                     connection_id_update,
                     match |connection_id| if let Err(why) = self.handle_connection_id_update(connection_id).await {
                         error!("failed handling connection id update: {why}");
-                        break;
                     }
                 },
                 // main dealer update of any remote device updates


### PR DESCRIPTION
## Problem

In `SpircTask::run`, the `connection_id_update` arm of the main `tokio::select!` loop is the **only** arm that treats a handler error as fatal — it `break`s out of the loop:

```rust
match |connection_id| if let Err(why) = self.handle_connection_id_update(connection_id).await {
    error!("failed handling connection id update: {why}");
    break;   // every other arm just logs and continues
}
```

Breaking leads straight to the `unexpected shutdown` path and terminates the spirc — but **the librespot process stays alive**. So process-level supervision (`Restart=on-failure`, etc.) never fires, and the device silently disappears from Spotify Connect until it is manually restarted.

The failure is usually transient: `handle_connection_id_update` issues the connect-state PUT (`notify_new_device_appeared`), which can race a dealer websocket reset and surface as `SpircError::FailedDealerSetup`.

## Fix

Drop the `break;` so the arm logs and continues, identical in shape to the seven sibling arms in the same `select!`. The connection_id is delivered through a long-lived dealer subscription to `hm://pusher/v1/connections/`, and the pusher re-sends a fresh connection_id on every dealer reconnect — so a transient failure is retried on the next update instead of taking down the whole controller.

## Real-world impact

A single transient `failed to put connect state for new device` left a `raspotify` instance wedged — process healthy, `systemctl` reporting the unit `active`, discovery socket still listening, but gone from Connect — for **13 days** before it was noticed and restarted.

## Notes

- Intentionally minimal and independent of the broader dealer-reconnect work in #1692 (which keeps the `break` and adds separate reconnect machinery). This can land as a small standalone robustness fix.
- `connect/src/spirc.rs` has no test coverage around `run()`, so there is no unit test to update; verified by reproducing the wedge against a live instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)