### PR TITLE
Add Sleep Timer support (set_sleep_timer endpoint)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [connect] Add method `add_to_queue` to `Spirc` to add tracks, episodes, albums and playlists to the queue
+- [connect] Add support for the `set_sleep_timer` Spotify Connect endpoint, pausing playback when the timer expires
+- [core] Add `SetSleepTimer` variant to the `Command` enum, along with the `SetSleepTimerCommand` and `SleepTimer` types (breaking)
 - [playback] Add `SetQueue` player event, emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect). Gated behind `ConnectConfig::emit_set_queue_events`
 
 ### Changed

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -6,7 +6,7 @@ use crate::{
         authentication::Credentials,
         dealer::{
             manager::{BoxedStream, BoxedStreamResult, Reply, RequestReply},
-            protocol::{Command, FallbackWrapper, Message, Request},
+            protocol::{Command, FallbackWrapper, Message, Request, SetSleepTimerCommand},
         },
         session::UserAttributes,
         spclient::TransferRequest,
@@ -42,7 +42,10 @@ use std::{
     time::{Duration, SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
-use tokio::{sync::mpsc, time::sleep};
+use tokio::{
+    sync::mpsc,
+    time::{Instant, sleep, sleep_until},
+};
 
 #[derive(Debug, Error)]
 enum SpircError {
@@ -110,6 +113,10 @@ struct SpircTask {
     /// when set to true, it will update the volume after [UPDATE_STATE_DELAY],
     /// when no other future resolves, otherwise resets the delay
     update_state: bool,
+
+    /// absolute deadline at which the sleep timer pauses playback, or `None`
+    /// when no timer is armed. Set via the `set_sleep_timer` endpoint.
+    sleep_timer_deadline: Option<Instant>,
 
     spirc_id: usize,
 }
@@ -260,6 +267,7 @@ impl Spirc {
             transfer_state: None,
             update_volume: false,
             update_state: false,
+            sleep_timer_deadline: None,
 
             spirc_id,
         };
@@ -558,6 +566,15 @@ impl SpircTask {
                     if let Err(why) = self.notify().await {
                         error!("error updating connect state for volume update: {why}")
                     }
+                },
+                // the sleep timer fires once when its deadline is reached, pausing playback.
+                // `sleep_until` targets an absolute instant, so recreating the future on every
+                // loop iteration does not push the deadline back.
+                _ = async { sleep_until(self.sleep_timer_deadline.unwrap()).await }, if self.sleep_timer_deadline.is_some() => {
+                    info!("sleep timer expired, pausing playback");
+                    self.sleep_timer_deadline = None;
+                    self.handle_pause();
+                    self.update_state = true;
                 },
                 // context resolver handling, the idea/reason behind it the following:
                 //
@@ -1158,6 +1175,7 @@ impl SpircTask {
                 self.load_track(true, 0)?
             }
             Resume(_) => self.handle_play(),
+            SetSleepTimer(command) => self.handle_set_sleep_timer(command),
         }
 
         self.update_state = true;
@@ -1572,6 +1590,41 @@ impl SpircTask {
             }
             _ => (),
         }
+    }
+
+    fn handle_set_sleep_timer(&mut self, command: SetSleepTimerCommand) {
+        let timer = command.timer_type;
+        self.sleep_timer_deadline = match timer.kind.as_str() {
+            "duration" => match timer.duration_s {
+                // a zero or missing duration is interpreted as a cancellation/disarm
+                Some(0) | None => {
+                    info!("sleep timer cancelled");
+                    None
+                }
+                Some(duration_s) => {
+                    info!("sleep timer armed for {duration_s}s");
+                    Some(Instant::now() + Duration::from_secs(duration_s))
+                }
+            },
+            "timestamp" => match timer.timestamp {
+                Some(timestamp_ms) => {
+                    // an absolute Unix time in ms; convert it to a relative delay against
+                    // our Spotify-corrected clock. A past deadline pauses on the next
+                    // loop iteration.
+                    let remaining_ms = (timestamp_ms - self.now_ms()).max(0) as u64;
+                    info!("sleep timer armed for {remaining_ms}ms (timestamp {timestamp_ms})");
+                    Some(Instant::now() + Duration::from_millis(remaining_ms))
+                }
+                None => {
+                    warn!("set_sleep_timer of type \"timestamp\" without a usable value, ignoring");
+                    return;
+                }
+            },
+            other => {
+                warn!("unsupported sleep timer type \"{other}\", ignoring");
+                return;
+            }
+        };
     }
 
     fn handle_seek(&mut self, position_ms: u32) {

--- a/core/src/dealer/protocol/request.rs
+++ b/core/src/dealer/protocol/request.rs
@@ -39,6 +39,7 @@ pub enum Command {
     // commands that don't send any context (at least not usually...)
     SkipPrev(GenericCommand),
     Resume(GenericCommand),
+    SetSleepTimer(SetSleepTimerCommand),
     // catch unknown commands, so that we can implement them later
     #[serde(untagged)]
     Unknown(Value),
@@ -69,6 +70,7 @@ impl Display for Command {
                 SkipNext(_) => "skip_next",
                 SkipPrev(_) => "skip_prev",
                 Resume(_) => "resume",
+                SetSleepTimer(_) => "set_sleep_timer",
                 Unknown(json) => {
                     json.as_object()
                         .and_then(|obj| obj.get("endpoint").map(|v| v.as_str()))
@@ -163,6 +165,32 @@ pub struct UpdateContextCommand {
 #[derive(Clone, Debug, Deserialize)]
 pub struct GenericCommand {
     pub logging_params: LoggingParams,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+pub struct SetSleepTimerCommand {
+    pub timer_type: SleepTimer,
+    pub logging_params: LoggingParams,
+}
+
+/// The `timer_type` object of a `set_sleep_timer` command, e.g.
+/// `{ "type": "duration", "duration_s": 3600 }`.
+///
+/// The `type` discriminator is kept as a raw string (rather than a tagged
+/// enum) so that unsupported or future timer types are reported by name
+/// instead of being silently collapsed into a catch-all variant.
+#[derive(Clone, Debug, Deserialize)]
+pub struct SleepTimer {
+    #[serde(rename = "type")]
+    pub kind: String,
+    /// Countdown length in seconds, present for the `duration` type.
+    #[serde(default)]
+    pub duration_s: Option<u64>,
+    /// Absolute deadline as a Unix timestamp in milliseconds, present for the
+    /// `timestamp` type. The exact field shape is unconfirmed against a real
+    /// client, so it is optional to degrade gracefully.
+    #[serde(default)]
+    pub timestamp: Option<i64>,
 }
 
 #[derive(Clone, Debug, Default, Deserialize, Serialize)]

--- a/metadata/src/audio/item.rs
+++ b/metadata/src/audio/item.rs
@@ -194,7 +194,7 @@ impl AudioItem {
 fn get_covers(covers: Images, image_url: String) -> Vec<CoverImage> {
     let mut covers = covers;
 
-    covers.sort_by(|a, b| b.width.cmp(&a.width));
+    covers.sort_by_key(|b| std::cmp::Reverse(b.width));
 
     covers
         .iter()


### PR DESCRIPTION
Implements #1659.

The Spotify mobile app's *Sleep timer* (Now Playing → ⋯ → Sleep timer) sends a
`set_sleep_timer` command that librespot currently rejects with
"Not implemented { unknown endpoint: set_sleep_timer }". This PR handles it.

### Behaviour
- A `duration` timer arms a one-shot countdown; playback is paused when it
  expires, and the paused state is propagated back to the controlling client.
- A zero/missing duration disarms the timer; re-sending a timer re-arms it.
- A manual resume does not cancel the timer (it still fires at its deadline),
  matching the official client.

### Design
- A single absolute deadline (`Option<tokio::time::Instant>`) is stored on the
  task and awaited with `sleep_until` inside the existing `select!` loop, so
  recreating the future every iteration never drifts the deadline (same spirit
  as the keep-alive timer in #1359, without pinning a `Sleep`).
- The `timer_type` discriminator is kept as a raw string so unsupported or
  future types are logged by name.

### Scope / future work
- `duration` is fully implemented and tested end-to-end on an iPhone against a
  macOS build (timer armed, fired, paused, state propagated).
- `timestamp` is parsed defensively (no real-world sample captured yet).
- The *end of track* option sends `type: "end_of_track"`; it is a different,
  event-driven mechanism and is logged + ignored for now.

### Known limitation — open question for maintainers
With this change the device honours the command and pauses correctly, but the
mobile app still briefly shows a "you can't use the sleep timer on this device"
popup. This appears to be client-side capability gating for the (recently
added, Aug 2025) cross-device sleep timer: the device never advertises the
corresponding capability. The most likely place is the empty
`Capabilities.connect_capabilities` (tag 27) string field, but I couldn't find
the expected token/format in any public source. **Do you know how this
capability should be advertised?** Happy to add it if so.

### Breaking change
Adds a `SetSleepTimer` variant to the public, non-exhaustive
`core::dealer::protocol::Command` enum — downstream exhaustive matches must be
updated.