### PR TITLE
audio: fall back to the next CDN URL when a fetch returns a non-206 status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [main] Fixed `--volume-ctrl fixed` not disabling volume control
 - [core] Fix default permissions on credentials file and warn user if file is world readable
 - [core] Try all resolved addresses for the dealer connection instead of failing after the first one.
+- [audio] Try the next CDN URL when a fetch returns a non-206 status instead of only retrying on transport errors, fixing playback failures when the first CDN URL is reachable but does not stream audio.
 
 ## [0.8.0] - 2025-11-10
 

--- a/audio/src/fetch/mod.rs
+++ b/audio/src/fetch/mod.rs
@@ -488,12 +488,6 @@ impl AudioFileStreaming {
 
         trace!("Streaming from {url}");
 
-        let code = response.status();
-        if code != StatusCode::PARTIAL_CONTENT {
-            debug!("Opening audio file expected partial content but got: {code}");
-            return Err(AudioFileError::StatusCode(code).into());
-        }
-
         let header_value = response
             .headers()
             .get(CONTENT_RANGE)

--- a/audio/src/fetch/mod.rs
+++ b/audio/src/fetch/mod.rs
@@ -467,10 +467,14 @@ impl AudioFileStreaming {
                 .and_then(|x| x.map_err(Error::from));
 
             match streamer_result {
-                Ok(r) => {
+                Ok(r) if r.status() == StatusCode::PARTIAL_CONTENT => {
                     response_streamer_url = Some((r, streamer, url));
                     break;
                 }
+                Ok(r) => warn!(
+                    "Fetching {url} returned {} (expected 206 Partial Content), trying next",
+                    r.status()
+                ),
                 Err(e) => warn!("Fetching {url} failed with error {e:?}, trying next"),
             }
         }


### PR DESCRIPTION
## Problem

Spotify hands librespot **several** CDN URLs for each track and expects the client to try the next one if a URL doesn't work. Right now, librespot only moves on to the next URL when a download fails at the *connection* level (timeout, DNS, TLS, etc.).

But a CDN edge can accept the connection and still answer with an HTTP error — e.g. a **500 Internal Server Error** from an edge node that's being drained. To librespot that counts as a "successful" response, so it stops on that first broken URL and never tries the others. The track fails to load, and playback never starts.

This currently breaks playback completely for some accounts: Spotify is handing out a bad edge as the *first* URL, so every track dies on the first try even though working URLs were right there in the list.

This fix builds on #1524, which added CDN-URL fallback but only for connection-level errors. This change extends that same fallback to cover HTTP error responses too.

## Evidence

For one track, `storage-resolve` returned 4 CDN URLs. Fetching each directly with a range request (curl):

 `audio-fa-del-874.spotifycdn.com` - **500** ← the only one librespot tried
 `audio-cf.spotifycdn.com` - 206  
 `audio-fa.scdn.co` - 206  
 `audio4-ak.spotifycdn.com` - 206 

librespot's log on the unpatched build:

```
DEBUG librespot_audio::fetch] Opening audio file expected partial content but got: 500 Internal Server Error
ERROR librespot_playback::player] Unable to load encrypted file: Error { kind: FailedPrecondition, error: StatusCode(500) }
```

It tried the broken URL, treated the 500 as a final answer, and gave up — never attempting the three working URLs.

## Fix

A successful fetch is now defined as one that actually returns **206 Partial Content** (what a range request should return). Anything else — a 500, or any other status — is logged and treated like the other failures, so the loop continues to the next CDN URL instead of stopping.

The change is in the existing URL-retry loop in `audio/src/fetch/mod.rs` (`AudioFileStreaming::open`): the "is this 206?" check, which previously ran *after* the loop had already committed to one URL, now runs *inside* the loop so a non-206 response falls through to the next candidate.

## Testing

Built from this branch and played tracks against the same account that was failing:

- **Before:** 0 tracks loaded (every one hit the 500 and gave up).
- **After:** 31/31 tracks loaded and played — librespot skipped the 500 edge and streamed from the next 206 URL automatically.

Also verified end-to-end through the `spotty` helper / Lyrion Music Server, where this bug was originally observed: full tracks decode and play.
