### PR TITLE
Fall back to IPv4 when IPv6 dual-stack bind fails in discovery

### DIFF
--- a/discovery/src/server.rs
+++ b/discovery/src/server.rs
@@ -292,6 +292,17 @@ impl DiscoveryServer {
 
         let listener = match TcpListener::bind(address) {
             Ok(listener) => listener,
+            Err(_e) if !cfg!(windows) => {
+                warn!("IPv6 dual-stack bind failed ({_e}), falling back to IPv4");
+                let v4_address = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), *port);
+                match TcpListener::bind(v4_address) {
+                    Ok(listener) => listener,
+                    Err(e) => {
+                        warn!("Discovery server failed to start: {e}");
+                        return Err(e.into());
+                    }
+                }
+            }
             Err(e) => {
                 warn!("Discovery server failed to start: {e}");
                 return Err(e.into());


### PR DESCRIPTION
## Summary

- Fall back to `0.0.0.0:port` (IPv4-only) when the `[::]:port` (IPv6 dual-stack) bind fails on non-Windows systems

On systems where IPv6 is completely disabled at the kernel level (e.g. `ipv6.disable=1` on Raspberry Pi / piCorePlayer), `TcpListener::bind("[::]:port")` fails with `EAFNOSUPPORT` (os error 97), preventing the discovery server from starting entirely. This makes librespot invisible to the Spotify app on those hosts.

The fix tries the dual-stack bind first (preserving existing behavior on normal systems), and only falls back to IPv4 if it fails. The Windows path is unaffected (it already binds to `0.0.0.0`).

## Tested

Running this patch in production via [SpotOn](https://github.com/stiefenm/spoton) (an LMS Spotify plugin using librespot) on both dual-stack and IPv4-only systems. Multiple users on piCorePlayer / Raspberry Pi have confirmed discovery works with `ipv6.disable=1` after this change.

Fixes #1694