### PR TITLE
Add External Mixer Support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [connect] Add method `add_to_queue` to `Spirc` to add tracks, episodes, albums and playlists to the queue
 - [playback] Add `SetQueue` player event, emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect). Gated behind `ConnectConfig::emit_set_queue_events`
 - [playback] Add `external` mixer for externally controlled volume: Spotify volume events stay enabled while playback output remains unattenuated
+- [playback] Add `--external-volume-query` / `LIBRESPOT_EXTERNAL_VOLUME_QUERY` to refresh the `external` mixer volume from an external controller
 
 ### Changed
 
 - [core] Made `SpotifyId::to_base62`, `SpotifyId::to_base16`, `FileId::to_base16`, `SpotifyUri::to_id`, `SpotifyUri::to_uri` infallible (breaking)
+- [playback] Add `external_volume_query` to `MixerConfig` (breaking)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - [core] Made `SpotifyId::to_base62`, `SpotifyId::to_base16`, `FileId::to_base16`, `SpotifyUri::to_id`, `SpotifyUri::to_uri` infallible (breaking)
-- [playback] Add `external_volume_query` to `MixerConfig` (breaking)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - [connect] Add method `add_to_queue` to `Spirc` to add tracks, episodes, albums and playlists to the queue
 - [playback] Add `SetQueue` player event, emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect). Gated behind `ConnectConfig::emit_set_queue_events`
+- [playback] Add `external` mixer for externally controlled volume: Spotify volume events stay enabled while playback output remains unattenuated
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ target/release/librespot -n "Librespot" -b 320 -c ./cache --enable-volume-normal
 ```
 The above command will create a receiver named ```Librespot```, with bitrate set to 320 kbps, initial volume at 75%, with volume normalisation enabled, and the device displayed in the app as an Audio/Video Receiver. A folder named ```cache``` will be created/used in the current directory, and be used to cache audio data and credentials.
 
+For setups where volume is controlled outside librespot, such as a Raspberry Pi connected to a receiver over Toslink, use the external mixer:
+```shell
+target/release/librespot --mixer external --initial-volume 100 --onevent ./event-handler
+```
+This keeps Spotify Connect volume events enabled for the event handler while leaving playback audio unattenuated.
+
 A full list of runtime options is available [here](https://github.com/librespot-org/librespot/wiki/Options).
 
 _Please Note: When using the cache feature, an authentication blob is stored for your account in the cache directory. For security purposes, we recommend that you set directory permissions on the cache directory to `700`._

--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ For setups where volume is controlled outside librespot, such as a Raspberry Pi 
 target/release/librespot --mixer external --initial-volume 100 --onevent ./event-handler
 ```
 This keeps Spotify Connect volume events enabled for the event handler while leaving playback audio unattenuated.
+If the external controller can report its current volume, use `--external-volume-query` to initialize and resync Spotify's volume slider from that state:
+```shell
+target/release/librespot --mixer external --external-volume-query "/usr/local/bin/current-volume" --onevent ./event-handler
+```
+The query command must print one raw volume value from `0` to `65535`.
 
 A full list of runtime options is available [here](https://github.com/librespot-org/librespot/wiki/Options).
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -39,7 +39,7 @@ use std::{
     future::Future,
     sync::Arc,
     sync::atomic::{AtomicUsize, Ordering},
-    time::{Duration, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use thiserror::Error;
 use tokio::{sync::mpsc, time::sleep};
@@ -107,6 +107,8 @@ struct SpircTask {
     /// when no other future resolves, otherwise resets the delay
     update_volume: bool,
 
+    last_spotify_volume_update: Option<Instant>,
+
     /// when set to true, it will update the volume after [UPDATE_STATE_DELAY],
     /// when no other future resolves, otherwise resets the delay
     update_state: bool,
@@ -144,6 +146,9 @@ const CONTEXT_FETCH_THRESHOLD: usize = 2;
 const VOLUME_UPDATE_DELAY: Duration = Duration::from_millis(500);
 // to reduce updates to remote, we group some request by waiting for a set amount of time
 const UPDATE_STATE_DELAY: Duration = Duration::from_millis(200);
+// Avoid snapping the Spotify slider back to a stale external-controller value
+// while a user-initiated volume change is still propagating outside librespot.
+const EXTERNAL_VOLUME_REFRESH_SUPPRESSION: Duration = Duration::from_secs(2);
 
 /// The spotify connect handle
 pub struct Spirc {
@@ -259,6 +264,7 @@ impl Spirc {
 
             transfer_state: None,
             update_volume: false,
+            last_spotify_volume_update: None,
             update_state: false,
 
             spirc_id,
@@ -266,12 +272,15 @@ impl Spirc {
 
         let spirc = Spirc { commands: cmd_tx };
 
-        let initial_volume = task.connect_state.device_info().volume;
+        let initial_volume = task
+            .refresh_volume_from_mixer()
+            .map(u32::from)
+            .unwrap_or_else(|| task.connect_state.device_info().volume);
         task.connect_state.set_volume(0);
 
         match initial_volume.try_into() {
             Ok(volume) => {
-                task.set_volume(volume);
+                task.apply_volume(volume);
                 // we don't want to update the volume initially,
                 // we just want to set the mixer to the correct volume
                 task.update_volume = false;
@@ -1313,6 +1322,8 @@ impl SpircTask {
     }
 
     fn handle_activate(&mut self) {
+        self.sync_refreshed_volume_from_mixer();
+
         self.connect_state.set_active(true);
         self.player
             .emit_session_connected_event(self.session.connection_id(), self.session.username());
@@ -1535,8 +1546,7 @@ impl SpircTask {
 
         // Synchronize the volume from the mixer. This is useful on
         // systems that can switch sources from and back to librespot.
-        let current_volume = self.mixer.volume();
-        self.set_volume(current_volume);
+        self.sync_volume_from_mixer();
     }
 
     fn handle_play_pause(&mut self) {
@@ -1909,9 +1919,41 @@ impl SpircTask {
             .map(|_| ())
     }
 
+    fn should_skip_external_volume_refresh(&self) -> bool {
+        self.last_spotify_volume_update
+            .is_some_and(|updated_at| updated_at.elapsed() < EXTERNAL_VOLUME_REFRESH_SUPPRESSION)
+    }
+
+    fn refresh_volume_from_mixer(&mut self) -> Option<u16> {
+        if self.should_skip_external_volume_refresh() {
+            debug!("skipping external volume refresh after recent Spotify volume update");
+            return None;
+        }
+
+        self.mixer.refresh_volume()
+    }
+
+    fn sync_refreshed_volume_from_mixer(&mut self) {
+        if let Some(volume) = self.refresh_volume_from_mixer() {
+            self.apply_volume(volume);
+        }
+    }
+
+    fn sync_volume_from_mixer(&mut self) {
+        let volume = self
+            .refresh_volume_from_mixer()
+            .unwrap_or_else(|| self.mixer.volume());
+
+        self.apply_volume(volume);
+    }
+
     fn set_volume(&mut self, volume: u16) {
         debug!("SpircTask::set_volume({volume})");
+        self.last_spotify_volume_update = Some(Instant::now());
+        self.apply_volume(volume);
+    }
 
+    fn apply_volume(&mut self, volume: u16) {
         let old_volume = self.connect_state.device_info().volume;
         let new_volume = volume as u32;
         if old_volume != new_volume || self.mixer.volume() != volume {

--- a/playback/src/mixer/external.rs
+++ b/playback/src/mixer/external.rs
@@ -51,22 +51,7 @@ enum ExternalVolumeQueryError {
 
 impl Mixer for ExternalMixer {
     fn open(config: MixerConfig) -> Result<Self, Error> {
-        let volume_query = config
-            .external_volume_query
-            .map(ExternalVolumeQuery::new)
-            .transpose()
-            .map_err(Error::invalid_argument)?;
-
-        if volume_query.is_some() {
-            info!("Mixing with external volume control and volume query");
-        } else {
-            info!("Mixing with external volume control");
-        }
-
-        Ok(Self {
-            volume: AtomicU16::new(u16::MAX / 2),
-            volume_query,
-        })
+        Ok(Self::open_with_config(config, None))
     }
 
     fn volume(&self) -> u16 {
@@ -95,6 +80,29 @@ impl Mixer for ExternalMixer {
 
 impl ExternalMixer {
     pub const NAME: &'static str = "external";
+
+    pub fn open_with_volume_query(
+        config: MixerConfig,
+        volume_query: String,
+    ) -> Result<Self, Error> {
+        let volume_query =
+            ExternalVolumeQuery::new(volume_query).map_err(Error::invalid_argument)?;
+
+        Ok(Self::open_with_config(config, Some(volume_query)))
+    }
+
+    fn open_with_config(_config: MixerConfig, volume_query: Option<ExternalVolumeQuery>) -> Self {
+        if volume_query.is_some() {
+            info!("Mixing with external volume control and volume query");
+        } else {
+            info!("Mixing with external volume control");
+        }
+
+        Self {
+            volume: AtomicU16::new(u16::MAX / 2),
+            volume_query,
+        }
+    }
 }
 
 impl ExternalVolumeQuery {
@@ -237,10 +245,10 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn external_mixer_query_success_updates_cached_volume() {
-        let mixer = ExternalMixer::open(MixerConfig {
-            external_volume_query: Some("/bin/sh -c 'printf 4242'".to_owned()),
-            ..MixerConfig::default()
-        })
+        let mixer = ExternalMixer::open_with_volume_query(
+            MixerConfig::default(),
+            "/bin/sh -c 'printf 4242'".to_owned(),
+        )
         .unwrap();
 
         assert_eq!(mixer.refresh_volume(), Some(4242));
@@ -251,10 +259,10 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn external_mixer_query_failure_preserves_cached_volume() {
-        let mixer = ExternalMixer::open(MixerConfig {
-            external_volume_query: Some("/bin/sh -c 'exit 1'".to_owned()),
-            ..MixerConfig::default()
-        })
+        let mixer = ExternalMixer::open_with_volume_query(
+            MixerConfig::default(),
+            "/bin/sh -c 'exit 1'".to_owned(),
+        )
         .unwrap();
 
         mixer.set_volume(1234);

--- a/playback/src/mixer/external.rs
+++ b/playback/src/mixer/external.rs
@@ -1,18 +1,71 @@
 use super::{Mixer, MixerConfig};
 use librespot_core::Error;
 use portable_atomic::AtomicU16;
+use shell_words::split;
+use std::process::{Command, ExitStatus, Stdio};
 use std::sync::atomic::Ordering;
+use std::time::{Duration, Instant};
+use thiserror::Error;
+
+const EXTERNAL_VOLUME_QUERY_TIMEOUT: Duration = Duration::from_secs(1);
 
 pub struct ExternalMixer {
     volume: AtomicU16,
+    volume_query: Option<ExternalVolumeQuery>,
+}
+
+struct ExternalVolumeQuery {
+    command: String,
+    args: Vec<String>,
+    display: String,
+}
+
+#[derive(Debug, Error)]
+enum ExternalVolumeQueryError {
+    #[error("missing command")]
+    MissingCommand,
+    #[error("failed to parse command args for {command}: {e}")]
+    InvalidArgs {
+        command: String,
+        e: shell_words::ParseError,
+    },
+    #[error("failed to spawn command {command}: {e}")]
+    SpawnFailure { command: String, e: std::io::Error },
+    #[error("command exited unsuccessfully: {0}")]
+    NonZeroExit(ExitStatus),
+    #[error("command timed out after {0:?}")]
+    TimedOut(Duration),
+    #[error("failed to wait for command: {0}")]
+    WaitFailure(std::io::Error),
+    #[error("failed to kill timed-out command: {0}")]
+    KillFailure(std::io::Error),
+    #[error("command output was not UTF-8: {0}")]
+    InvalidUtf8(#[from] std::str::Utf8Error),
+    #[error("command output was empty")]
+    EmptyOutput,
+    #[error("command output must contain one integer, got {0:?}")]
+    InvalidOutput(String),
+    #[error("command volume {0} is outside the valid 0..=65535 range")]
+    VolumeOutOfRange(u32),
 }
 
 impl Mixer for ExternalMixer {
-    fn open(_config: MixerConfig) -> Result<Self, Error> {
-        info!("Mixing with external volume control");
+    fn open(config: MixerConfig) -> Result<Self, Error> {
+        let volume_query = config
+            .external_volume_query
+            .map(ExternalVolumeQuery::new)
+            .transpose()
+            .map_err(Error::invalid_argument)?;
+
+        if volume_query.is_some() {
+            info!("Mixing with external volume control and volume query");
+        } else {
+            info!("Mixing with external volume control");
+        }
 
         Ok(Self {
             volume: AtomicU16::new(u16::MAX / 2),
+            volume_query,
         })
     }
 
@@ -23,15 +76,119 @@ impl Mixer for ExternalMixer {
     fn set_volume(&self, volume: u16) {
         self.volume.store(volume, Ordering::Relaxed);
     }
+
+    fn refresh_volume(&self) -> Option<u16> {
+        let query = self.volume_query.as_ref()?;
+
+        match query.volume() {
+            Ok(volume) => {
+                self.volume.store(volume, Ordering::Relaxed);
+                Some(volume)
+            }
+            Err(why) => {
+                warn!("External volume query failed: {why}");
+                None
+            }
+        }
+    }
 }
 
 impl ExternalMixer {
     pub const NAME: &'static str = "external";
 }
 
+impl ExternalVolumeQuery {
+    fn new(command: String) -> Result<Self, ExternalVolumeQueryError> {
+        let mut command_parts =
+            split(&command).map_err(|e| ExternalVolumeQueryError::InvalidArgs {
+                command: command.clone(),
+                e,
+            })?;
+
+        if command_parts.is_empty() {
+            return Err(ExternalVolumeQueryError::MissingCommand);
+        }
+
+        Ok(Self {
+            command: command_parts.remove(0),
+            args: command_parts,
+            display: command,
+        })
+    }
+
+    fn volume(&self) -> Result<u16, ExternalVolumeQueryError> {
+        let mut child = Command::new(&self.command)
+            .args(&self.args)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .spawn()
+            .map_err(|e| ExternalVolumeQueryError::SpawnFailure {
+                command: self.display.clone(),
+                e,
+            })?;
+
+        let deadline = Instant::now() + EXTERNAL_VOLUME_QUERY_TIMEOUT;
+        loop {
+            match child
+                .try_wait()
+                .map_err(ExternalVolumeQueryError::WaitFailure)?
+            {
+                Some(_) => {
+                    let output = child
+                        .wait_with_output()
+                        .map_err(ExternalVolumeQueryError::WaitFailure)?;
+
+                    if !output.status.success() {
+                        return Err(ExternalVolumeQueryError::NonZeroExit(output.status));
+                    }
+
+                    return parse_external_volume(&output.stdout);
+                }
+                None => {
+                    let now = Instant::now();
+                    if now >= deadline {
+                        child
+                            .kill()
+                            .map_err(ExternalVolumeQueryError::KillFailure)?;
+                        let _ = child.wait();
+                        return Err(ExternalVolumeQueryError::TimedOut(
+                            EXTERNAL_VOLUME_QUERY_TIMEOUT,
+                        ));
+                    }
+
+                    std::thread::sleep(
+                        deadline
+                            .saturating_duration_since(now)
+                            .min(Duration::from_millis(10)),
+                    );
+                }
+            }
+        }
+    }
+}
+
+fn parse_external_volume(output: &[u8]) -> Result<u16, ExternalVolumeQueryError> {
+    let output = std::str::from_utf8(output)?;
+    let trimmed = output.trim();
+
+    if trimmed.is_empty() {
+        return Err(ExternalVolumeQueryError::EmptyOutput);
+    }
+
+    if trimmed.split_whitespace().count() != 1 {
+        return Err(ExternalVolumeQueryError::InvalidOutput(output.to_owned()));
+    }
+
+    let volume = trimmed
+        .parse::<u32>()
+        .map_err(|_| ExternalVolumeQueryError::InvalidOutput(output.to_owned()))?;
+
+    u16::try_from(volume).map_err(|_| ExternalVolumeQueryError::VolumeOutOfRange(volume))
+}
+
 #[cfg(test)]
 mod tests {
-    use super::ExternalMixer;
+    use super::{ExternalMixer, ExternalVolumeQueryError, parse_external_volume};
     use crate::mixer::{Mixer, MixerConfig};
 
     #[test]
@@ -52,5 +209,58 @@ mod tests {
             mixer.set_volume(volume);
             assert_eq!(mixer.get_soft_volume().attenuation_factor(), 1.0);
         }
+    }
+
+    #[test]
+    fn external_query_parses_valid_volume() {
+        assert_eq!(parse_external_volume(b"0").unwrap(), 0);
+        assert_eq!(parse_external_volume(b"32768\n").unwrap(), 32768);
+        assert_eq!(parse_external_volume(b" 65535 \n").unwrap(), u16::MAX);
+    }
+
+    #[test]
+    fn external_query_rejects_invalid_volume() {
+        assert!(matches!(
+            parse_external_volume(b"not a volume"),
+            Err(ExternalVolumeQueryError::InvalidOutput(_))
+        ));
+        assert!(matches!(
+            parse_external_volume(b"1 2"),
+            Err(ExternalVolumeQueryError::InvalidOutput(_))
+        ));
+        assert!(matches!(
+            parse_external_volume(b"65536"),
+            Err(ExternalVolumeQueryError::VolumeOutOfRange(65536))
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_mixer_query_success_updates_cached_volume() {
+        let mixer = ExternalMixer::open(MixerConfig {
+            external_volume_query: Some("/bin/sh -c 'printf 4242'".to_owned()),
+            ..MixerConfig::default()
+        })
+        .unwrap();
+
+        assert_eq!(mixer.refresh_volume(), Some(4242));
+        assert_eq!(mixer.volume(), 4242);
+        assert_eq!(mixer.get_soft_volume().attenuation_factor(), 1.0);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn external_mixer_query_failure_preserves_cached_volume() {
+        let mixer = ExternalMixer::open(MixerConfig {
+            external_volume_query: Some("/bin/sh -c 'exit 1'".to_owned()),
+            ..MixerConfig::default()
+        })
+        .unwrap();
+
+        mixer.set_volume(1234);
+
+        assert_eq!(mixer.refresh_volume(), None);
+        assert_eq!(mixer.volume(), 1234);
+        assert_eq!(mixer.get_soft_volume().attenuation_factor(), 1.0);
     }
 }

--- a/playback/src/mixer/external.rs
+++ b/playback/src/mixer/external.rs
@@ -1,0 +1,56 @@
+use super::{Mixer, MixerConfig};
+use librespot_core::Error;
+use portable_atomic::AtomicU16;
+use std::sync::atomic::Ordering;
+
+pub struct ExternalMixer {
+    volume: AtomicU16,
+}
+
+impl Mixer for ExternalMixer {
+    fn open(_config: MixerConfig) -> Result<Self, Error> {
+        info!("Mixing with external volume control");
+
+        Ok(Self {
+            volume: AtomicU16::new(u16::MAX / 2),
+        })
+    }
+
+    fn volume(&self) -> u16 {
+        self.volume.load(Ordering::Relaxed)
+    }
+
+    fn set_volume(&self, volume: u16) {
+        self.volume.store(volume, Ordering::Relaxed);
+    }
+}
+
+impl ExternalMixer {
+    pub const NAME: &'static str = "external";
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ExternalMixer;
+    use crate::mixer::{Mixer, MixerConfig};
+
+    #[test]
+    fn external_mixer_tracks_requested_volume() {
+        let mixer = ExternalMixer::open(MixerConfig::default()).unwrap();
+
+        for volume in [0, u16::MAX / 2, u16::MAX] {
+            mixer.set_volume(volume);
+            assert_eq!(mixer.volume(), volume);
+        }
+    }
+
+    #[test]
+    fn external_mixer_never_attenuates_audio() {
+        let mixer = ExternalMixer::open(MixerConfig::default()).unwrap();
+
+        for volume in [0, u16::MAX / 2, u16::MAX] {
+            mixer.set_volume(volume);
+            assert_eq!(mixer.get_soft_volume().attenuation_factor(), 1.0);
+        }
+    }
+}

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -15,6 +15,10 @@ pub trait Mixer: Send + Sync {
     fn volume(&self) -> u16;
     fn set_volume(&self, volume: u16);
 
+    fn refresh_volume(&self) -> Option<u16> {
+        None
+    }
+
     fn get_soft_volume(&self) -> Box<dyn VolumeGetter + Send> {
         Box::new(NoOpVolume)
     }
@@ -48,6 +52,7 @@ pub struct MixerConfig {
     pub control: String,
     pub index: u32,
     pub volume_ctrl: VolumeCtrl,
+    pub external_volume_query: Option<String>,
 }
 
 impl Default for MixerConfig {
@@ -57,6 +62,7 @@ impl Default for MixerConfig {
             control: String::from("PCM"),
             index: 0,
             volume_ctrl: VolumeCtrl::default(),
+            external_volume_query: None,
         }
     }
 }

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -52,7 +52,6 @@ pub struct MixerConfig {
     pub control: String,
     pub index: u32,
     pub volume_ctrl: VolumeCtrl,
-    pub external_volume_query: Option<String>,
 }
 
 impl Default for MixerConfig {
@@ -62,7 +61,6 @@ impl Default for MixerConfig {
             control: String::from("PCM"),
             index: 0,
             volume_ctrl: VolumeCtrl::default(),
-            external_volume_query: None,
         }
     }
 }

--- a/playback/src/mixer/mod.rs
+++ b/playback/src/mixer/mod.rs
@@ -34,6 +34,9 @@ impl VolumeGetter for NoOpVolume {
 pub mod softmixer;
 use self::softmixer::SoftMixer;
 
+pub mod external;
+use self::external::ExternalMixer;
+
 #[cfg(feature = "alsa-backend")]
 pub mod alsamixer;
 #[cfg(feature = "alsa-backend")]
@@ -66,6 +69,7 @@ fn mk_sink<M: Mixer + 'static>(config: MixerConfig) -> Result<Arc<dyn Mixer>, Er
 
 pub const MIXERS: &[(&str, MixerFn)] = &[
     (SoftMixer::NAME, mk_sink::<SoftMixer>), // default goes first
+    (ExternalMixer::NAME, mk_sink::<ExternalMixer>),
     #[cfg(feature = "alsa-backend")]
     (AlsaMixer::NAME, mk_sink::<AlsaMixer>),
 ];
@@ -78,5 +82,15 @@ pub fn find(name: Option<&str>) -> Option<MixerFn> {
             .map(|mixer| mixer.1)
     } else {
         MIXERS.first().map(|mixer| mixer.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{external::ExternalMixer, find};
+
+    #[test]
+    fn finds_external_mixer() {
+        assert!(find(Some(ExternalMixer::NAME)).is_some());
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -951,12 +951,10 @@ async fn get_setup() -> Setup {
     }
 
     let external_volume_query = if is_external_mixer {
-        opt_str(EXTERNAL_VOLUME_QUERY).map(|query| {
+        opt_str(EXTERNAL_VOLUME_QUERY).inspect(|query| {
             if query.is_empty() {
                 empty_string_error_msg(EXTERNAL_VOLUME_QUERY, EXTERNAL_VOLUME_QUERY_SHORT);
             }
-
-            query
         })
     } else {
         if opt_present(EXTERNAL_VOLUME_QUERY) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,7 @@ async fn get_setup() -> Setup {
     const EMIT_SINK_EVENTS: &str = "emit-sink-events";
     const ENABLE_OAUTH: &str = "enable-oauth";
     const ENABLE_VOLUME_NORMALISATION: &str = "enable-volume-normalisation";
+    const EXTERNAL_VOLUME_QUERY: &str = "external-volume-query";
     const FORMAT: &str = "format";
     const HELP: &str = "help";
     const INITIAL_VOLUME: &str = "initial-volume";
@@ -318,6 +319,7 @@ async fn get_setup() -> Setup {
     const PASSTHROUGH_SHORT: &str = "P";
     const PASSWORD_SHORT: &str = "p";
     const EMIT_SINK_EVENTS_SHORT: &str = "Q";
+    const EXTERNAL_VOLUME_QUERY_SHORT: &str = ""; // no short flag
     const QUIET_SHORT: &str = "q";
     const INITIAL_VOLUME_SHORT: &str = "R";
     const ALSA_MIXER_DEVICE_SHORT: &str = "S";
@@ -559,6 +561,12 @@ async fn get_setup() -> Setup {
         MIXER_TYPE,
         MIXER_TYPE_DESC,
         "MIXER",
+    )
+    .optopt(
+        EXTERNAL_VOLUME_QUERY_SHORT,
+        EXTERNAL_VOLUME_QUERY,
+        "Command to query current external volume when using `--mixer external`. Must print one raw volume integer from 0 to 65535 within 1 second.",
+        "COMMAND",
     )
     .optopt(
         DEVICE_SHORT,
@@ -863,7 +871,8 @@ async fn get_setup() -> Setup {
         };
 
     let empty_string_error_msg = |long: &str, short: &str| {
-        error!("`--{long}` / `-{short}` can not be an empty string");
+        let flag = format_flag(long, short);
+        error!("{flag} can not be an empty string");
         exit(1);
     };
 
@@ -939,6 +948,22 @@ async fn get_setup() -> Setup {
             }
         }
     }
+
+    let external_volume_query = if is_external_mixer {
+        opt_str(EXTERNAL_VOLUME_QUERY).map(|query| {
+            if query.is_empty() {
+                empty_string_error_msg(EXTERNAL_VOLUME_QUERY, EXTERNAL_VOLUME_QUERY_SHORT);
+            }
+
+            query
+        })
+    } else {
+        if opt_present(EXTERNAL_VOLUME_QUERY) {
+            warn!("External volume query has no effect if not using the external mixer.");
+        }
+
+        None
+    };
 
     let mixer_config = {
         let mixer_default_config = MixerConfig::default();
@@ -1125,6 +1150,7 @@ async fn get_setup() -> Setup {
             control,
             index,
             volume_ctrl,
+            external_volume_query,
         }
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ use librespot::{
             AudioFormat, Bitrate, NormalisationMethod, NormalisationType, PlayerConfig, VolumeCtrl,
         },
         dither,
-        mixer::{self, MixerConfig, MixerFn},
+        mixer::{self, Mixer, MixerConfig, MixerFn},
         player::{Player, coefficient_to_duration, duration_to_coefficient},
     },
 };
@@ -214,6 +214,7 @@ struct Setup {
     session_config: SessionConfig,
     connect_config: ConnectConfig,
     mixer_config: MixerConfig,
+    external_volume_query: Option<String>,
     credentials: Option<Credentials>,
     enable_oauth: bool,
     oauth_port: Option<u16>,
@@ -1150,7 +1151,6 @@ async fn get_setup() -> Setup {
             control,
             index,
             volume_ctrl,
-            external_volume_query,
         }
     };
 
@@ -1882,6 +1882,7 @@ async fn get_setup() -> Setup {
         session_config,
         connect_config,
         mixer_config,
+        external_volume_query,
         credentials,
         enable_oauth,
         oauth_port,
@@ -2008,11 +2009,21 @@ async fn main() {
     }
 
     let mixer_config = setup.mixer_config.clone();
-    let mixer = match (setup.mixer)(mixer_config) {
-        Ok(mixer) => mixer,
-        Err(why) => {
-            error!("{why}");
-            exit(1)
+    let mixer = if let Some(volume_query) = setup.external_volume_query.clone() {
+        match ExternalMixer::open_with_volume_query(mixer_config, volume_query) {
+            Ok(mixer) => std::sync::Arc::new(mixer) as std::sync::Arc<dyn Mixer>,
+            Err(why) => {
+                error!("{why}");
+                exit(1)
+            }
+        }
+    } else {
+        match (setup.mixer)(mixer_config) {
+            Ok(mixer) => mixer,
+            Err(why) => {
+                error!("{why}");
+                exit(1)
+            }
         }
     };
     let player_config = setup.player_config.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ use data_encoding::HEXLOWER;
 use futures_util::StreamExt;
 #[cfg(feature = "alsa-backend")]
 use librespot::playback::mixer::alsamixer::AlsaMixer;
+use librespot::playback::mixer::external::ExternalMixer;
 use librespot::{
     connect::{ConnectConfig, Spirc},
     core::{
@@ -341,9 +342,13 @@ async fn get_setup() -> Setup {
     // Options that have different descriptions
     // depending on what backends were enabled at build time.
     #[cfg(feature = "alsa-backend")]
-    const MIXER_TYPE_DESC: &str = "Mixer to use {alsa|softvol}. Defaults to softvol.";
+    const MIXER_TYPE_DESC: &str = "Mixer to use {alsa|external|softvol}. Defaults to softvol.";
     #[cfg(not(feature = "alsa-backend"))]
-    const MIXER_TYPE_DESC: &str = "Not supported by the included audio backend(s).";
+    const MIXER_TYPE_DESC: &str = "Mixer to use {external|softvol}. Defaults to softvol.";
+    #[cfg(feature = "alsa-backend")]
+    const MIXER_TYPE_VALUES: &str = "alsa, external, softvol";
+    #[cfg(not(feature = "alsa-backend"))]
+    const MIXER_TYPE_VALUES: &str = "external, softvol";
     #[cfg(any(
         feature = "alsa-backend",
         feature = "rodio-backend",
@@ -903,22 +908,21 @@ async fn get_setup() -> Setup {
         }
     }
 
-    #[cfg(feature = "alsa-backend")]
     let mixer_type = opt_str(MIXER_TYPE);
-    #[cfg(not(feature = "alsa-backend"))]
-    let mixer_type: Option<String> = None;
 
     let mixer = mixer::find(mixer_type.as_deref()).unwrap_or_else(|| {
         invalid_error_msg(
             MIXER_TYPE,
             MIXER_TYPE_SHORT,
             &opt_str(MIXER_TYPE).unwrap_or_default(),
-            "alsa, softvol",
+            MIXER_TYPE_VALUES,
             "softvol",
         );
 
         exit(1);
     });
+
+    let is_external_mixer = matches!(mixer_type.as_deref(), Some(ExternalMixer::NAME));
 
     let is_alsa_mixer = match mixer_type.as_deref() {
         #[cfg(feature = "alsa-backend")]
@@ -1524,7 +1528,8 @@ async fn get_setup() -> Setup {
         let name = name.unwrap_or(connect_default_config.name);
         let device_type = device_type.unwrap_or(connect_default_config.device_type);
         let initial_volume = initial_volume.unwrap_or(connect_default_config.initial_volume);
-        let disable_volume = matches!(mixer_config.volume_ctrl, VolumeCtrl::Fixed);
+        let disable_volume =
+            matches!(mixer_config.volume_ctrl, VolumeCtrl::Fixed) && !is_external_mixer;
         let volume_steps = volume_steps.unwrap_or(connect_default_config.volume_steps);
 
         ConnectConfig {


### PR DESCRIPTION
## Summary

Adds support for externally controlled volume in librespot.

This introduces an `external` mixer for setups where librespot should keep Spotify Connect volume control active, but must not attenuate playback audio in software. This is useful for Raspberry Pi / Raspotify devices connected to an AVR or receiver over Toslink, where volume is controlled by the receiver.

Closes #1162.

## Changes

- Add `--mixer external`.
  - Stores the latest Spotify-requested volume.
  - Emits normal `volume_changed` events.
  - Keeps playback gain at unity by using `NoOpVolume`, so audio is not attenuated by librespot.

- Add `--external-volume-query "COMMAND [ARGS...]"`.
  - Also available as `LIBRESPOT_EXTERNAL_VOLUME_QUERY`.
  - Valid with `--mixer external`.
  - Command must exit `0` and print one raw volume integer from `0` to `65535`.
  - Failures, invalid output, spawn errors, and timeouts preserve the previous librespot volume.
  - Timeout is fixed at 1 second.

- Add safe external volume refresh points.
  - Startup can initialize Spotify’s volume slider from the external controller.
  - Activation/play sync can refresh from the external controller.
  - Spotify-originated volume changes still update immediately and do not trigger a query.
  - A short suppression window avoids stale external readings snapping the Spotify slider back after a recent Spotify volume change.

- Keep the API mostly additive.
  - `Mixer::refresh_volume()` has a default no-op implementation.
  - `ExternalMixer::open_with_volume_query(...)` supports query-enabled construction.
  - `MixerConfig` is unchanged to avoid a breaking public struct change.

## Usage

```shell
librespot --mixer external --onevent ./event-handler