### PR TITLE
fix clippy 1.97 lints

### DIFF
--- a/core/src/dealer/mod.rs
+++ b/core/src/dealer/mod.rs
@@ -369,7 +369,7 @@ impl DealerShared {
         request: WebsocketRequest,
         send_tx: &mpsc::UnboundedSender<WsMessage>,
     ) {
-        trace!("dealer request {}", &request.message_ident);
+        trace!("dealer request {}", request.message_ident);
 
         let payload_request = match request.handle_payload() {
             Ok(payload) => payload,
@@ -387,7 +387,7 @@ impl DealerShared {
         } else {
             warn!(
                 "Dealer request with invalid message_ident: {}",
-                &request.message_ident
+                request.message_ident
             );
             return;
         };
@@ -402,7 +402,7 @@ impl DealerShared {
             return;
         }
 
-        warn!("No handler for message_ident: {}", &request.message_ident);
+        warn!("No handler for message_ident: {}", request.message_ident);
     }
 
     fn dispatch(&self, m: MessageOrRequest, send_tx: &mpsc::UnboundedSender<WsMessage>) {

--- a/core/src/mercury/mod.rs
+++ b/core/src/mercury/mod.rs
@@ -237,10 +237,10 @@ impl MercuryManager {
 
         let status_code = response.status_code;
         if status_code >= 500 {
-            error!("error {} for uri {}", status_code, &response.uri);
+            error!("error {} for uri {}", status_code, response.uri);
             Err(MercuryError::Response(response).into())
         } else if status_code >= 400 {
-            error!("error {} for uri {}", status_code, &response.uri);
+            error!("error {} for uri {}", status_code, response.uri);
             if let Some(cb) = pending.callback {
                 cb.send(Err(MercuryError::Response(response.clone()).into()))
                     .map_err(|_| MercuryError::Channel)?;
@@ -282,7 +282,7 @@ impl MercuryManager {
                 trace!("mercury response <{}> is handled by dealer", response.uri);
                 Ok(())
             } else {
-                debug!("unknown subscription uri={}", &response.uri);
+                debug!("unknown subscription uri={}", response.uri);
                 trace!("response pushed over Mercury: {response:?}");
                 Err(MercuryError::Response(response).into())
             }

--- a/metadata/src/audio/item.rs
+++ b/metadata/src/audio/item.rs
@@ -194,7 +194,7 @@ impl AudioItem {
 fn get_covers(covers: Images, image_url: String) -> Vec<CoverImage> {
     let mut covers = covers;
 
-    covers.sort_by(|a, b| b.width.cmp(&a.width));
+    covers.sort_by_key(|a| std::cmp::Reverse(a.width));
 
     covers
         .iter()


### PR DESCRIPTION
This is needed for clean CI.

Closes https://github.com/librespot-org/librespot/pull/1711

https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#unnecessary_sort_by
https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting