### PR TITLE
playback: fall back to raw-range mapping for Alsa mixers without dB info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [playback] Alsa mixer: fall back to a linear mapping on the raw volume range for controls without dB information (e.g. the Alsa pulse plugin's `Master`) instead of failing to open the mixer
 - [audio] Fixed integer overflow in throughput calculation
 - [main] Fixed `--volume-ctrl fixed` not disabling volume control
 - [core] Fix default permissions on credentials file and warn user if file is world readable

--- a/playback/src/mixer/alsamixer.rs
+++ b/playback/src/mixer/alsamixer.rs
@@ -25,6 +25,7 @@ pub struct AlsaMixer {
     has_switch: bool,
     is_softvol: bool,
     use_linear_in_db: bool,
+    has_db: bool,
 }
 
 // min_db cannot be depended on to be mute. Also note that contrary to
@@ -42,8 +43,6 @@ enum AlsaMixerError {
     CouldNotOpenWithDevice(AlsaError),
     #[error("Could not open Alsa softvol with that name. {0}")]
     CouldNotOpenWithName(NulError),
-    #[error("Could not get Alsa softvol dB range. {0}")]
-    NoDbRange(AlsaError),
     #[error("Could not convert Alsa raw volume to dB volume. {0}")]
     CouldNotConvertRaw(AlsaError),
 }
@@ -81,6 +80,7 @@ impl Mixer for AlsaMixer {
 
         // Query dB volume range -- note that Alsa exposes a different
         // API for hardware and software mixers
+        let mut has_db = true;
         let (min_millibel, max_millibel) = if is_softvol {
             let control =
                 Ctl::new(&config.device, false).map_err(AlsaMixerError::CouldNotOpenWithDevice)?;
@@ -90,9 +90,23 @@ impl Mixer for AlsaMixer {
                     .map_err(AlsaMixerError::CouldNotOpenWithName)?,
             );
             element_id.set_index(config.index);
-            let (min_millibel, mut max_millibel) = control
-                .get_db_range(&element_id)
-                .map_err(AlsaMixerError::NoDbRange)?;
+            let (min_millibel, mut max_millibel) = match control.get_db_range(&element_id) {
+                Ok(range) => range,
+                Err(e) => {
+                    // Some controls (e.g. the Alsa pulse plugin's `Master`,
+                    // which maps onto the PulseAudio sink volume) expose no
+                    // dB information at all. Fall back to mapping the volume
+                    // linearly onto the raw range; for PulseAudio this is
+                    // the right thing since its raw scale is already
+                    // perceptually (cubically) tapered.
+                    info!(
+                        "Alsa mixer control has no dB information ({e}), \
+                         falling back to linear mapping on the raw volume range"
+                    );
+                    has_db = false;
+                    (ZERO_DB, ZERO_DB)
+                }
+            };
 
             // Alsa can report incorrect maximum volumes due to rounding
             // errors. e.g. Alsa rounds [-60.0..0.0] in range [0..255] to
@@ -170,6 +184,12 @@ impl Mixer for AlsaMixer {
             config.volume_ctrl = VolumeCtrl::Linear;
         }
 
+        // Without dB information the volume can only be mapped onto the raw
+        // range, so other taper curves cannot be applied faithfully.
+        if !has_db {
+            config.volume_ctrl = VolumeCtrl::Linear;
+        }
+
         debug!("Alsa mixer control is softvol: {}", is_softvol);
         debug!("Alsa support for playback (mute) switch: {}", has_switch);
         debug!("Alsa raw volume range: [{}..{}] ({})", min, max, range);
@@ -190,6 +210,7 @@ impl Mixer for AlsaMixer {
             has_switch,
             is_softvol,
             use_linear_in_db,
+            has_db,
         })
     }
 
@@ -312,6 +333,10 @@ impl AlsaMixer {
     }
 
     fn is_some_linear(&self) -> bool {
-        self.is_softvol || self.use_linear_in_db
+        // The antilog compensation assumes Alsa maps the raw range onto a
+        // dB scale internally (as the softvol plugin does). Controls without
+        // dB information (e.g. the pulse plugin) apply the raw volume
+        // directly, so no compensation must be applied there.
+        (self.is_softvol && self.has_db) || self.use_linear_in_db
     }
 }


### PR DESCRIPTION
Some Alsa mixer controls expose no dB information at all — most notably the Alsa pulse plugin's `Master`, which maps onto the PulseAudio sink volume. `AlsaMixer::open()` currently fails hard for such controls:

```
Invalid state { Could not get Alsa softvol dB range. ALSA function 'snd_ctl_get_dB_range' failed with error 'No such file or directory (2)' }
```

making them unusable as `--mixer alsa` targets.

### What this PR does

When `snd_ctl_get_dB_range` reports that no dB information is available, fall back to mapping the volume linearly onto the control's raw volume range instead of erroring out:

- `VolumeCtrl` is forced to `Linear`, since without dB information other taper curves cannot be applied faithfully.
- The softvol antilog compensation is skipped for these controls. It exists to counteract Alsa's internal linear-to-dB conversion in the softvol plugin, which does not happen when the raw volume is applied directly.

For PulseAudio specifically, a linear raw mapping is the desired behavior: PA's raw volume scale is already perceptually (cubically) tapered (e.g. raw 50% = −18.06 dB), so the Connect volume slider tracks the sink volume 1:1.

### Motivation / use case

Running librespot with `--backend pulseaudio` on a headless device (raspotify on a Pi 4 with an IQaudIO DAC), where the DAC's hardware `Digital` control spans −103.5..0 dB — too wide a range for a usable taper, and separate from the PulseAudio sink volume that other audio sources go through. With this change,

```
--mixer alsa --alsa-mixer-device pulse --alsa-mixer-control Master
```

lets Spotify Connect control the PulseAudio sink (master) volume directly, affecting all streams on the sink with a sensible taper.

### Testing

- Verified on a Raspberry Pi 4 (aarch64, Debian bookworm, PulseAudio 16.1) with the setup above: the mixer now opens (log: `Alsa mixer control has no dB information ..., falling back to linear mapping on the raw volume range`), the Connect volume slider tracks the PulseAudio sink volume (`pactl` / `alsamixer -D pulse` Master) ~1:1 in both directions, and playback through the pulseaudio backend is unaffected.
- Regular hardware mixer controls (with dB info) are unaffected; the fallback only engages on the previous hard-error path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

