### PR TITLE
audio: use versioned Spotify storage resolution

### DIFF
--- a/audio/src/fetch/mod.rs
+++ b/audio/src/fetch/mod.rs
@@ -380,6 +380,7 @@ impl AudioFile {
     pub async fn open(
         session: &Session,
         file_id: FileId,
+        audio_format: i32,
         bytes_per_second: usize,
     ) -> Result<AudioFile, Error> {
         if let Some(file) = session.cache().and_then(|cache| cache.file(file_id)) {
@@ -391,8 +392,13 @@ impl AudioFile {
 
         let (complete_tx, complete_rx) = oneshot::channel();
 
-        let streaming =
-            AudioFileStreaming::open(session.clone(), file_id, complete_tx, bytes_per_second);
+        let streaming = AudioFileStreaming::open(
+            session.clone(),
+            file_id,
+            audio_format,
+            complete_tx,
+            bytes_per_second,
+        );
 
         let session_ = session.clone();
         session.spawn(complete_rx.map_ok(move |mut file| {
@@ -438,10 +444,13 @@ impl AudioFileStreaming {
     pub async fn open(
         session: Session,
         file_id: FileId,
+        audio_format: i32,
         complete_tx: oneshot::Sender<NamedTempFile>,
         bytes_per_second: usize,
     ) -> Result<AudioFileStreaming, Error> {
-        let cdn_url = CdnUrl::new(file_id).resolve_audio(&session).await?;
+        let cdn_url = CdnUrl::new(file_id, audio_format)
+            .resolve_audio(&session)
+            .await?;
 
         let minimum_download_size = AudioFetchParams::get().minimum_download_size;
 

--- a/core/src/cdn_url.rs
+++ b/core/src/cdn_url.rs
@@ -54,24 +54,33 @@ impl From<CdnUrlError> for Error {
 #[derive(Debug, Clone)]
 pub struct CdnUrl {
     pub file_id: FileId,
+    audio_format: i32,
     urls: MaybeExpiringUrls,
 }
 
 impl CdnUrl {
-    pub fn new(file_id: FileId) -> Self {
+    pub fn new(file_id: FileId, audio_format: i32) -> Self {
         Self {
             file_id,
+            audio_format,
             urls: MaybeExpiringUrls(Vec::new()),
         }
     }
 
     pub async fn resolve_audio(&self, session: &Session) -> Result<Self, Error> {
         let file_id = self.file_id;
-        let response = session.spclient().get_audio_storage(&file_id).await?;
+        let response = session
+            .spclient()
+            .get_audio_storage(&file_id, self.audio_format)
+            .await?;
         let msg = CdnUrlMessage::parse_from_bytes(&response)?;
         let urls = MaybeExpiringUrls::try_from(msg)?;
 
-        let cdn_url = Self { file_id, urls };
+        let cdn_url = Self {
+            file_id,
+            audio_format: self.audio_format,
+            urls,
+        };
 
         trace!("Resolved CDN storage: {cdn_url:#?}");
 

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -51,9 +51,9 @@ component! {
 
 pub type SpClientResult = Result<Bytes, Error>;
 
-fn audio_storage_endpoints(file_id: &str) -> [String; 2] {
+fn audio_storage_endpoints(file_id: &str, audio_format: i32) -> [String; 2] {
     [
-        format!("/storage-resolve/v2/files/audio/{file_id}"),
+        format!("/storage-resolve/v2/files/audio/interactive/{audio_format}/{file_id}"),
         format!("/storage-resolve/files/audio/interactive/{file_id}"),
     ]
 }
@@ -777,8 +777,8 @@ impl SpClient {
     // TODO: Seen-in-the-wild but unimplemented endpoints
     // - /presence-view/v1/buddylist
 
-    pub async fn get_audio_storage(&self, file_id: &FileId) -> SpClientResult {
-        let endpoints = audio_storage_endpoints(&file_id.to_base16());
+    pub async fn get_audio_storage(&self, file_id: &FileId, audio_format: i32) -> SpClientResult {
+        let endpoints = audio_storage_endpoints(&file_id.to_base16(), audio_format);
 
         match self.request(&Method::GET, &endpoints[0], None, None).await {
             Ok(response) => Ok(response),
@@ -786,9 +786,7 @@ impl SpClient {
                 // Spotify 1.2.96 uses the versioned route. Keep the legacy
                 // interactive route as a compatibility fallback for older
                 // spclient clusters and Connect-era accounts.
-                warn!(
-                    "Storage resolve v2 failed ({v2_error}); trying legacy interactive endpoint"
-                );
+                warn!("Storage resolve v2 failed ({v2_error}); trying legacy interactive endpoint");
                 self.request(&Method::GET, &endpoints[1], None, None).await
             }
         }
@@ -981,9 +979,12 @@ mod test {
 
     #[test]
     fn audio_storage_uses_current_route_before_legacy_fallback() {
-        let endpoints = audio_storage_endpoints("ABC123");
+        let endpoints = audio_storage_endpoints("ABC123", 2);
 
-        assert_eq!(endpoints[0], "/storage-resolve/v2/files/audio/ABC123");
+        assert_eq!(
+            endpoints[0],
+            "/storage-resolve/v2/files/audio/interactive/2/ABC123"
+        );
         assert_eq!(
             endpoints[1],
             "/storage-resolve/files/audio/interactive/ABC123"

--- a/core/src/spclient.rs
+++ b/core/src/spclient.rs
@@ -51,6 +51,13 @@ component! {
 
 pub type SpClientResult = Result<Bytes, Error>;
 
+fn audio_storage_endpoints(file_id: &str) -> [String; 2] {
+    [
+        format!("/storage-resolve/v2/files/audio/{file_id}"),
+        format!("/storage-resolve/files/audio/interactive/{file_id}"),
+    ]
+}
+
 #[allow(clippy::declare_interior_mutable_const)]
 pub const CLIENT_TOKEN: HeaderName = HeaderName::from_static("client-token");
 #[allow(clippy::declare_interior_mutable_const)]
@@ -771,11 +778,20 @@ impl SpClient {
     // - /presence-view/v1/buddylist
 
     pub async fn get_audio_storage(&self, file_id: &FileId) -> SpClientResult {
-        let endpoint = format!(
-            "/storage-resolve/files/audio/interactive/{}",
-            file_id.to_base16()
-        );
-        self.request(&Method::GET, &endpoint, None, None).await
+        let endpoints = audio_storage_endpoints(&file_id.to_base16());
+
+        match self.request(&Method::GET, &endpoints[0], None, None).await {
+            Ok(response) => Ok(response),
+            Err(v2_error) => {
+                // Spotify 1.2.96 uses the versioned route. Keep the legacy
+                // interactive route as a compatibility fallback for older
+                // spclient clusters and Connect-era accounts.
+                warn!(
+                    "Storage resolve v2 failed ({v2_error}); trying legacy interactive endpoint"
+                );
+                self.request(&Method::GET, &endpoints[1], None, None).await
+            }
+        }
     }
 
     pub fn stream_from_cdn<U>(
@@ -956,5 +972,21 @@ impl SpClient {
             &NO_METRICS_AND_SALT,
         )
         .await
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::audio_storage_endpoints;
+
+    #[test]
+    fn audio_storage_uses_current_route_before_legacy_fallback() {
+        let endpoints = audio_storage_endpoints("ABC123");
+
+        assert_eq!(endpoints[0], "/storage-resolve/v2/files/audio/ABC123");
+        assert_eq!(
+            endpoints[1],
+            "/storage-resolve/files/audio/interactive/ABC123"
+        );
     }
 }

--- a/metadata/src/audio/file.rs
+++ b/metadata/src/audio/file.rs
@@ -52,6 +52,32 @@ impl TryFrom<i32> for AudioFileFormat {
     }
 }
 
+impl From<AudioFileFormat> for i32 {
+    fn from(value: AudioFileFormat) -> Self {
+        match value {
+            AudioFileFormat::OGG_VORBIS_96 => 0,
+            AudioFileFormat::OGG_VORBIS_160 => 1,
+            AudioFileFormat::OGG_VORBIS_320 => 2,
+            AudioFileFormat::MP3_256 => 3,
+            AudioFileFormat::MP3_320 => 4,
+            AudioFileFormat::MP3_160 => 5,
+            AudioFileFormat::MP3_96 => 6,
+            AudioFileFormat::MP3_160_ENC => 7,
+            AudioFileFormat::AAC_24 => 8,
+            AudioFileFormat::AAC_48 => 9,
+            AudioFileFormat::AAC_160 => 10,
+            AudioFileFormat::AAC_320 => 11,
+            AudioFileFormat::MP4_128 => 12,
+            AudioFileFormat::OTHER5 => 13,
+            AudioFileFormat::FLAC_FLAC => 16,
+            AudioFileFormat::XHE_AAC_24 => 18,
+            AudioFileFormat::XHE_AAC_16 => 19,
+            AudioFileFormat::XHE_AAC_12 => 20,
+            AudioFileFormat::FLAC_FLAC_24BIT => 22,
+        }
+    }
+}
+
 impl From<Format> for AudioFileFormat {
     fn from(value: Format) -> Self {
         match value {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -1091,7 +1091,8 @@ impl PlayerTrackLoader {
         // This is only a loop to be able to reload the file if an error occurred
         // while opening a cached file.
         loop {
-            let encrypted_file = AudioFile::open(&self.session, file_id, bytes_per_second);
+            let encrypted_file =
+                AudioFile::open(&self.session, file_id, format.into(), bytes_per_second);
 
             let encrypted_file = match encrypted_file.await {
                 Ok(encrypted_file) => encrypted_file,


### PR DESCRIPTION
## What changed

- Thread the selected audio format from the player through `AudioFile` and `CdnUrl` into `SpClient`.
- Resolve audio through Spotify's versioned `storage-resolve/v2/files/audio/interactive/{format}/{file_id}` route first.
- Retain the legacy interactive route as an automatic fallback for older clusters and accounts.
- Add a unit test that locks the route order and format component.

## Why

The current signed Spotify desktop client uses the versioned storage route and includes the selected audio-format identifier. Librespot still called the older unversioned route without a format. That route remains available in some environments, so removing it would create avoidable compatibility risk; this change prefers the current contract while preserving the known fallback.

## Impact

Successful legacy behavior is unchanged when the v2 route is unavailable. The requested format now stays attached to storage resolution instead of being known only by the decoder/player layer.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p librespot-core -p librespot-metadata -p librespot-audio -p librespot-playback`
- `cargo clippy -p librespot-core -p librespot-metadata -p librespot-audio -p librespot-playback --all-targets -- -D warnings`
- Production fork PCM canary and attended jukebox soak: fresh Spotify PCM, six of six handoffs completed, and zero measured dead air.
