### PR TITLE
fix(audio_key): retry on timeout and fail track cleanly on key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [core] Audio key requests now retry up to 2 times on timeout before giving up, improving resilience after access-point reconnects
+- [playback] Audio key transport failures (timeout, channel error) now fail the track cleanly instead of continuing without decryption, which always failed downstream and dropped the session
 - [audio] Fixed integer overflow in throughput calculation
 - [main] Fixed `--volume-ctrl fixed` not disabling volume control
 - [core] Fix default permissions on credentials file and warn user if file is world readable

--- a/core/src/audio_key.rs
+++ b/core/src/audio_key.rs
@@ -79,23 +79,46 @@ impl AudioKeyManager {
     }
 
     pub async fn request(&self, track: SpotifyId, file: FileId) -> Result<AudioKey, Error> {
-        let (tx, rx) = oneshot::channel();
-
-        let seq = self.lock(move |inner| {
-            let seq = inner.sequence.get();
-            inner.pending.insert(seq, tx);
-            seq
-        });
-
-        self.send_key_request(seq, track, file)?;
         const KEY_RESPONSE_TIMEOUT: Duration = Duration::from_millis(1500);
-        match tokio::time::timeout(KEY_RESPONSE_TIMEOUT, rx).await {
-            Err(_) => {
-                error!("Audio key response timeout");
-                Err(AudioKeyError::Timeout.into())
+        const MAX_RETRIES: u32 = 2;
+
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                warn!(
+                    "Retrying audio key request (attempt {}/{})",
+                    attempt + 1,
+                    MAX_RETRIES + 1
+                );
             }
-            Ok(k) => k?,
+
+            let (tx, rx) = oneshot::channel();
+
+            let seq = self.lock(move |inner| {
+                let seq = inner.sequence.get();
+                inner.pending.insert(seq, tx);
+                seq
+            });
+
+            self.send_key_request(seq, track, file)?;
+
+            match tokio::time::timeout(KEY_RESPONSE_TIMEOUT, rx).await {
+                Ok(result) => return result?,
+                Err(_) => {
+                    self.lock(|inner| inner.pending.remove(&seq));
+                    warn!(
+                        "Audio key response timeout (attempt {}/{})",
+                        attempt + 1,
+                        MAX_RETRIES + 1
+                    );
+                }
+            }
         }
+
+        error!(
+            "Audio key request failed after {} attempts",
+            MAX_RETRIES + 1
+        );
+        Err(AudioKeyError::Timeout.into())
     }
 
     fn send_key_request(&self, seq: u32, track: SpotifyId, file: FileId) -> Result<(), Error> {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -24,7 +24,7 @@ use crate::{
     audio_backend::Sink,
     config::{Bitrate, NormalisationMethod, NormalisationType, PlayerConfig},
     convert::Converter,
-    core::{Error, Session, SpotifyId, SpotifyUri, util::SeqGenerator},
+    core::{Error, Session, SpotifyId, SpotifyUri, error::ErrorKind, util::SeqGenerator},
     decoder::{AudioDecoder, AudioPacket, AudioPacketPosition, SymphoniaDecoder},
     local_file::{LocalFileLookup, create_local_file_lookup},
     metadata::audio::{AudioFileFormat, AudioFiles, AudioItem},
@@ -1105,14 +1105,15 @@ impl PlayerTrackLoader {
 
             let stream_loader_controller = encrypted_file.get_stream_loader_controller().ok()?;
 
-            // Not all audio files are encrypted. If we can't get a key, try loading the track
-            // without decryption. If the file was encrypted after all, the decoder will fail
-            // parsing and bail out, so we should be safe from outputting ear-piercing noise.
             let key = match self.session.audio_key().request(track_id, file_id).await {
                 Ok(key) => Some(key),
-                Err(e) => {
+                Err(e) if e.kind == ErrorKind::Unavailable => {
                     warn!("Unable to load key, continuing without decryption: {e}");
                     None
+                }
+                Err(e) => {
+                    error!("Unable to load key, cannot play track: {e}");
+                    return None;
                 }
             };
 


### PR DESCRIPTION
## Summary

Two changes to improve playback resilience after access-point reconnects:

1. **Retry on timeout** (`core/src/audio_key.rs`): `request()` now retries up to 2 times on timeout before giving up. The 1500ms timeout is tight immediately after an AP reconnect when the new connection is still settling. Timed-out pending entries are cleaned up to prevent map leaks.

2. **Fail track cleanly on transport errors** (`playback/src/player.rs`): `load_track()` now distinguishes key errors by `ErrorKind`:
   - `Unavailable` (server says no key exists): continues without decryption as before
   - `Aborted` (timeout, channel error): fails the track cleanly (`return None` → `PlayerEvent::Unavailable` → Spirc skips) instead of feeding encrypted bytes to the decoder

## Problem

When the AP connection drops and librespot reconnects mid-playback, the audio key request for the in-flight track can time out. The current code then continues "without decryption":

```
ERROR librespot_core::audio_key] Audio key response timeout
WARN  librespot_playback::player] Unable to load key, continuing without decryption
ERROR librespot_playback::player] Unable to read audio file: Passthrough Decoder Error: No Ogg capture pattern found
DEBUG librespot_core::session] drop Session
```

The decoder receives encrypted bytes, fails to parse them, and the session is dropped. This happens on both OGG passthrough and PCM paths.

## Evidence

Over 4.5 hours of Connect playback on a production system:
- 12 audio key timeouts, 7 decoder failures
- All following routine AP reconnects (`early eof`, `os error 10054`)
- Zero occurrences on idle daemons (which never request audio keys)

## Throttle amplification note

Spotify's audio-key throttling (rapid-skip scenario) can manifest as timeouts; the retry adds up to ~3s of additional per-track wait. This is acceptable since the alternative — immediate session drop — is worse, and the rapid-skip throttle is transient (~2 minutes).

Replaces #1742 (rebased to avoid API incompatibility with downstream builds).