### PR TITLE
oauth: Add the device authorization flow

### DIFF
--- a/docs/device-authorization.md
+++ b/docs/device-authorization.md
@@ -1,0 +1,156 @@
+# Device Authorization
+
+Spotify implements the OAuth 2.0 Device Authorization Grant
+([RFC 8628](https://datatracker.ietf.org/doc/html/rfc8628)). Instead of redirecting a
+user agent back to the client, the authorization server issues a short user code which
+the user types in at <https://spotify.com/pair> from any other device. Nothing has to
+listen on a port and the device itself needs no browser.
+
+librespot exposes it as `--enable-device-auth`, implemented by `DeviceAuthClient` in the
+`librespot-oauth` crate.
+
+The device makes two calls, and waits in between:
+
+```
+POST /oauth2/device/authorize   -> device_code (secret) + user_code (shown to the user)
+POST /api/token                 -> repeat until it stops saying authorization_pending
+```
+
+Between those, the user opens <https://spotify.com/pair> on some other device and enters
+the `user_code`. The device plays no part in that and learns the outcome only by polling.
+
+Both device endpoints take `application/x-www-form-urlencoded` bodies and answer with
+JSON, including on error. Neither needs an `Authorization` header, a client secret, PKCE,
+or cookies.
+
+## 1. Device authorization request
+
+`POST https://accounts.spotify.com/oauth2/device/authorize`
+
+| Parameter | Required | Notes |
+| --- | --- | --- |
+| `client_id` | yes | Must be a client ID Spotify has enabled for this flow. |
+| `scope` | no | Separated by either commas or spaces. Omitting it is accepted. |
+| `creation_point` | no | A URL identifying where the flow began. The desktop client sends one; the server does not require it. |
+| `intent` | no | The desktop client sends `login`. Optional. |
+
+Response:
+
+```json
+{
+  "device_code": "QUJDREVGLDAwMDAwMDAwLTAwMDAtMDAwMC0wMDAwLTAwMDAwMDAwMDAwMA==",
+  "user_code": "ABCDEF",
+  "verification_uri": "https://spotify.com/pair",
+  "verification_uri_complete": "https://spotify.com/pair?code=ABCDEF",
+  "expires_in": 3599,
+  "interval": 5
+}
+```
+
+The field names are exactly RFC 8628's, so a standards-compliant OAuth client library can
+parse this response unmodified. `device_code` is base64 of `<user_code>,<uuid>`.
+
+Errors are RFC 6749 shaped, at HTTP 400:
+
+| `error` | Cause |
+| --- | --- |
+| `invalid_client` | `client_id` missing or not a real client. |
+| `unauthorized_client` | Real client ID, but not enabled for the device flow. |
+| `invalid_scope` | At least one requested scope is not recognised for this client. |
+
+Scopes are validated before the client's eligibility for the flow, so a request that
+is wrong in both ways reports `invalid_scope` and never mentions the client.
+
+## 2. User approval
+
+The user opens `verification_uri_complete` (or types `user_code` at `verification_uri`)
+on another device and approves. This half is between the browser and Spotify; the device
+takes no part in it and only observes the result by polling.
+
+For reference, the page resolves the code via
+`POST https://accounts.spotify.com/pair/api/code?flow_ctx=<uuid>:<timestamp>` with
+`{"code": "<user_code>"}`, which returns the client's display name and the scopes being
+requested, grouped for presentation.
+
+## 3. Token polling
+
+`POST https://accounts.spotify.com/api/token`
+
+| Parameter | Value |
+| --- | --- |
+| `client_id` | Same as step 1. |
+| `grant_type` | `urn:ietf:params:oauth:grant-type:device_code` |
+| `device_code` | From step 1. |
+
+Poll no faster than `interval` seconds. While the user has not yet acted, each poll
+returns HTTP 400:
+
+```json
+{"error": "authorization_pending"}
+```
+
+A malformed or unknown `device_code` gives `invalid_request`. The remaining outcomes are
+the ones RFC 8628 section 3.5 defines — `slow_down`, `access_denied` and `expired_token` —
+which have not been observed directly here; only `authorization_pending` and success have.
+
+On success, HTTP 200:
+
+```json
+{
+  "access_token": "BQ...",
+  "token_type": "Bearer",
+  "expires_in": 3600,
+  "refresh_token": "AQ...",
+  "scope": "streaming playlist-read user-read-email ..."
+}
+```
+
+The granted `scope` is **space**-separated regardless of which separator the request used.
+
+The `refresh_token` is exchanged at the same endpoint with `grant_type=refresh_token` and
+`refresh_token=<token>`; a bad token there gives `invalid_grant`.
+
+## Client IDs
+
+Spotify enables this flow per client. Of the IDs librespot ships in
+`core/src/config.rs`, only the desktop one is accepted:
+
+| Client ID | Constant | Device flow |
+| --- | --- | --- |
+| `65b708073fc0480ea92a077233ca87bd` | `KEYMASTER_CLIENT_ID` | Yes |
+| `9a8d2f0ce77a4e248bb71fefcb557637` | `ANDROID_CLIENT_ID` | No |
+| `58bd3c95768941ea9eb4350aaa033eb3` | `IOS_CLIENT_ID` | No |
+
+`--enable-device-auth` therefore only works with a client ID Spotify has enabled, which
+by default means running on a platform where `SessionConfig` picks the desktop ID.
+
+The mobile IDs are not OAuth clients at all; they exist only for Login5
+(`core/src/login5.rs`).
+
+The refusal is reported as `unauthorized_client`, but only for scopes the client is
+otherwise allowed. Each client has its own scope registry, and requesting anything
+outside it reports `invalid_scope` first. Of librespot's 26 `OAUTH_SCOPES` the Android
+client does not recognise nine — `app-remote-control`, `user-modify-playback-state`,
+`user-personalized`, `user-read-currently-playing`, `user-read-play-history`,
+`user-read-playback-position`, `user-read-playback-state`, `user-read-recently-played`
+and `user-top-read` — and the iOS client does not recognise `user-personalized`. So
+attempting this flow on those platforms surfaces as `invalid_scope`, which points at the
+scopes rather than at the real problem.
+
+## Scopes
+
+An unrecognised scope fails the whole request with `invalid_scope` rather than being
+dropped, so scopes cannot be probed by requesting extras and seeing what comes back.
+
+The desktop client requests 28 scopes. librespot requests 26 of them, leaving out
+`sts-content-management` and `transfer-auth-session`. All 26 are accepted.
+
+Note that `default` appears in the scope list Spotify's own pair page reports for the
+desktop client, but sending it is rejected with `invalid_scope`. It is not requestable.
+
+## Headers
+
+The desktop client sends `client-token` and `spotify-installation-id` on both requests.
+Neither is required: the flow completes with no headers beyond `Content-Type`. Responses
+set a `__Host-device_id` cookie which is likewise not needed, and the flow succeeds
+without ever sending it back.

--- a/docs/device-authorization.md
+++ b/docs/device-authorization.md
@@ -137,6 +137,33 @@ and `user-top-read` — and the iOS client does not recognise `user-personalized
 attempting this flow on those platforms surfaces as `invalid_scope`, which points at the
 scopes rather than at the real problem.
 
+### Other clients Spotify enables
+
+Spotify also enables the flow for clients librespot does not ship an ID for. These were
+probed against the live endpoints on 2026-08-18.
+
+Only the pairing exchange was tested for each: that a device code is issued and that
+approving it returns tokens. Whether a session built from those tokens can stream was
+not tested for any of them.
+
+| Client | Client ID | Rejects from `OAUTH_SCOPES` |
+| --- | --- | --- |
+| Spotify for Desktop (`KEYMASTER_CLIENT_ID`) | `65b708073fc0480ea92a077233ca87bd` | — |
+| Spotify PlayStation | `9b18101888dd42948afd0b8792122bec` | — |
+| PlayStation®Network | `cdee0485c0b143de91bb71a853594f9a` | — |
+| Spotify for Microsoft Xbox | `1fc2d01aa9074dde950e8d3dc0eb1729` | — |
+| Spotify for Samsung Tizen TV | `568a50c7e7f64fe3b44a3316ef5590fd` | — |
+| Spotify for Android TV | `756a522d9f1648b89e76e80be654456a` | `user-personalized` |
+| Samsung Wearable | `88197451c42e4c5d96b00be2e4e30713` | `user-personalized` |
+| Spotify for LG TV | `3e29cb18c4c34d60837ec94cf31e9f3e` | `user-personalized`, `user-read-birthdate` |
+| Spotify for Wear OS by Google | `407d482703b9480899f54656c3ed7728` | `user-personalized`, `user-read-birthdate` |
+
+Names are as the pairing API reports them.
+
+One unrecognised scope fails the whole request, so the four clients above cannot be asked
+for `OAUTH_SCOPES` as it stands. `user-personalized` is the only scope all four reject;
+without it and `user-read-birthdate` a single list would cover every client here.
+
 ## Scopes
 
 An unrecognised scope fails the whole request with `invalid_scope` rather than being

--- a/oauth/Cargo.toml
+++ b/oauth/Cargo.toml
@@ -39,6 +39,8 @@ reqwest = { version = "0.12", default-features = false, features = [
     "system-proxy",
 ] }
 thiserror = "2"
+# The device flow's async poll needs a timer to wait between polls.
+tokio = { version = "1", features = ["time"] }
 url = "2.5"
 
 [dev-dependencies]

--- a/oauth/examples/device_auth.rs
+++ b/oauth/examples/device_auth.rs
@@ -1,0 +1,47 @@
+use std::env;
+
+use librespot_oauth::DeviceAuthClientBuilder;
+
+const SPOTIFY_CLIENT_ID: &str = "65b708073fc0480ea92a077233ca87bd";
+
+fn main() {
+    let mut builder = env_logger::Builder::new();
+    builder.parse_filters("librespot=trace");
+    builder.init();
+
+    let args: Vec<_> = env::args().collect();
+    let (client_id, scopes) = if args.len() == 3 {
+        // Spotify only enables the device flow for some client IDs, and refuses
+        // the rest with `unauthorized_client`.
+        (args[1].as_str(), args[2].split(',').collect::<Vec<&str>>())
+    } else if args.len() == 1 {
+        (SPOTIFY_CLIENT_ID, vec!["streaming"])
+    } else {
+        eprintln!("Usage: {} [CLIENT_ID SCOPES]", args[0]);
+        return;
+    };
+
+    let client = match DeviceAuthClientBuilder::new(client_id, scopes).build() {
+        Ok(client) => client,
+        Err(err) => {
+            eprintln!("Unable to build a device auth client: {err}");
+            return;
+        }
+    };
+
+    let refresh_token = match client.get_access_token() {
+        Ok(token) => {
+            println!("OAuth Token: {token:#?}");
+            token.refresh_token
+        }
+        Err(err) => {
+            println!("Unable to get OAuth Token: {err}");
+            return;
+        }
+    };
+
+    match client.refresh_token(&refresh_token) {
+        Ok(token) => println!("New refreshed OAuth Token: {token:#?}"),
+        Err(err) => println!("Unable to get refreshed OAuth Token: {err}"),
+    }
+}

--- a/oauth/src/lib.rs
+++ b/oauth/src/lib.rs
@@ -1,15 +1,21 @@
 #![warn(missing_docs)]
-//! Provides a Spotify access token using the OAuth authorization code flow
-//! with PKCE.
+//! Provides a Spotify access token using either the OAuth authorization code
+//! flow with PKCE, or the device authorization flow.
 //!
 //! Assuming sufficient scopes, the returned access token may be used with Spotify's
 //! Web API, and/or to establish a new Session with [`librespot_core`].
 //!
-//! The authorization code flow is an interactive process which requires a web browser
-//! to complete. The resulting code must then be provided back from the browser to this
-//! library for exchange into an access token. Providing the code can be automatic via
-//! a spawned http server (mimicking Spotify's client), or manually via stdin. The latter
-//! is appropriate for headless systems.
+//! The authorization code flow ([`OAuthClient`]) is an interactive process which
+//! requires a web browser to complete. The resulting code must then be provided back
+//! from the browser to this library for exchange into an access token. Providing the
+//! code can be automatic via a spawned http server (mimicking Spotify's client), or
+//! manually via stdin. The latter is appropriate for headless systems.
+//!
+//! The device authorization flow ([`DeviceAuthClient`]) instead has Spotify issue a
+//! short code which the user types in at <https://spotify.com/pair> from any other
+//! device. Nothing has to listen on a port and no browser is needed on the machine
+//! running librespot. Spotify only enables this flow for some client IDs; see
+//! `docs/device-authorization.md`.
 
 use std::{
     io::{self, BufRead, BufReader, Write},
@@ -19,9 +25,10 @@ use std::{
 };
 
 use oauth2::{
-    AuthUrl, AuthorizationCode, ClientId, CsrfToken, EmptyExtraTokenFields, EndpointNotSet,
-    EndpointSet, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken, Scope,
-    StandardTokenResponse, TokenResponse, TokenUrl, basic::BasicClient, basic::BasicTokenType,
+    AuthUrl, AuthorizationCode, ClientId, CsrfToken, DeviceAuthorizationUrl, EmptyExtraTokenFields,
+    EndpointNotSet, EndpointSet, PkceCodeChallenge, PkceCodeVerifier, RedirectUrl, RefreshToken,
+    Scope, StandardDeviceAuthorizationResponse, StandardTokenResponse, TokenResponse, TokenUrl,
+    basic::BasicClient, basic::BasicTokenType,
 };
 
 use log::{error, info, trace};
@@ -48,6 +55,22 @@ compile_error!(
 compile_error!(
     "Either feature \"native-tls\" (default), \"rustls-tls-native-roots\" or \"rustls-tls-webpki-roots\" must be enabled for this crate."
 );
+
+/// Spotify's authorization endpoint, for the authorization code flow.
+const AUTH_URL: &str = "https://accounts.spotify.com/authorize";
+
+/// Spotify's token endpoint, shared by every grant type in this crate.
+const TOKEN_URL: &str = "https://accounts.spotify.com/api/token";
+
+/// Spotify's device authorization endpoint.
+const DEVICE_AUTHORIZATION_URL: &str = "https://accounts.spotify.com/oauth2/device/authorize";
+
+/// A [`BasicClient`] configured for the device authorization flow.
+///
+/// The authorization endpoint is deliberately left unset: this flow never
+/// redirects a user agent, so there is nothing to send them to.
+type DeviceBasicClient =
+    BasicClient<EndpointNotSet, EndpointSet, EndpointNotSet, EndpointNotSet, EndpointSet>;
 
 /// Possible errors encountered during the OAuth authentication flow.
 #[derive(Debug, Error)]
@@ -117,6 +140,20 @@ pub enum OAuthError {
     /// Token exchange failure with Spotify's authorization server.
     #[error("Failed to exchange code for access token ({e})")]
     ExchangeCode {
+        /// Inner error description
+        e: String,
+    },
+
+    /// Device code request failure with Spotify's authorization server.
+    #[error("Failed to obtain device code ({e})")]
+    DeviceCode {
+        /// Inner error description
+        e: String,
+    },
+
+    /// Token exchange failure, including the user declining or letting the code expire.
+    #[error("Failed to exchange device code for access token ({e})")]
+    ExchangeDeviceCode {
         /// Inner error description
         e: String,
     },
@@ -230,6 +267,36 @@ pub struct OAuthClient {
     client: BasicClient<EndpointSet, EndpointNotSet, EndpointNotSet, EndpointNotSet, EndpointSet>,
 }
 
+/// Convert a token endpoint response into an [`OAuthToken`].
+///
+/// `default_scopes` stands in for the granted scopes when Spotify omits them
+/// from the response.
+fn build_token(
+    resp: StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
+    default_scopes: &[String],
+) -> OAuthToken {
+    trace!("Obtained new access token: {resp:?}");
+
+    let token_scopes: Vec<String> = match resp.scopes() {
+        Some(s) => s.iter().map(|s| s.to_string()).collect(),
+        _ => default_scopes.to_vec(),
+    };
+    let refresh_token = match resp.refresh_token() {
+        Some(t) => t.secret().to_string(),
+        _ => "".to_string(), // Spotify always provides a refresh token.
+    };
+    OAuthToken {
+        access_token: resp.access_token().secret().to_string(),
+        refresh_token,
+        expires_at: Instant::now()
+            + resp
+                .expires_in()
+                .unwrap_or_else(|| Duration::from_secs(3600)),
+        token_type: format!("{:?}", resp.token_type()),
+        scopes: token_scopes,
+    }
+}
+
 impl OAuthClient {
     /// Generates and opens/shows the authorization URL to obtain an access token.
     ///
@@ -259,26 +326,7 @@ impl OAuthClient {
         &self,
         resp: StandardTokenResponse<EmptyExtraTokenFields, BasicTokenType>,
     ) -> Result<OAuthToken, OAuthError> {
-        trace!("Obtained new access token: {resp:?}");
-
-        let token_scopes: Vec<String> = match resp.scopes() {
-            Some(s) => s.iter().map(|s| s.to_string()).collect(),
-            _ => self.scopes.clone(),
-        };
-        let refresh_token = match resp.refresh_token() {
-            Some(t) => t.secret().to_string(),
-            _ => "".to_string(), // Spotify always provides a refresh token.
-        };
-        Ok(OAuthToken {
-            access_token: resp.access_token().secret().to_string(),
-            refresh_token,
-            expires_at: Instant::now()
-                + resp
-                    .expires_in()
-                    .unwrap_or_else(|| Duration::from_secs(3600)),
-            token_type: format!("{:?}", resp.token_type()),
-            scopes: token_scopes,
-        })
+        Ok(build_token(resp, &self.scopes))
     }
 
     /// Syncronously obtain a Spotify access token using the authorization code with PKCE OAuth flow.
@@ -399,10 +447,10 @@ impl OAuthClientBuilder {
 
     /// End of the building process pipeline. If Ok, a OAuthClient instance will be returned.
     pub fn build(self) -> Result<OAuthClient, OAuthError> {
-        let auth_url = AuthUrl::new("https://accounts.spotify.com/authorize".to_string())
-            .map_err(|_| OAuthError::InvalidSpotifyUri)?;
-        let token_url = TokenUrl::new("https://accounts.spotify.com/api/token".to_string())
-            .map_err(|_| OAuthError::InvalidSpotifyUri)?;
+        let auth_url =
+            AuthUrl::new(AUTH_URL.to_string()).map_err(|_| OAuthError::InvalidSpotifyUri)?;
+        let token_url =
+            TokenUrl::new(TOKEN_URL.to_string()).map_err(|_| OAuthError::InvalidSpotifyUri)?;
         let redirect_url = RedirectUrl::new(self.redirect_uri.clone()).map_err(|e| {
             OAuthError::InvalidRedirectUri {
                 uri: self.redirect_uri.clone(),
@@ -438,10 +486,9 @@ pub fn get_access_token(
     redirect_uri: &str,
     scopes: Vec<&str>,
 ) -> Result<OAuthToken, OAuthError> {
-    let auth_url = AuthUrl::new("https://accounts.spotify.com/authorize".to_string())
-        .map_err(|_| OAuthError::InvalidSpotifyUri)?;
-    let token_url = TokenUrl::new("https://accounts.spotify.com/api/token".to_string())
-        .map_err(|_| OAuthError::InvalidSpotifyUri)?;
+    let auth_url = AuthUrl::new(AUTH_URL.to_string()).map_err(|_| OAuthError::InvalidSpotifyUri)?;
+    let token_url =
+        TokenUrl::new(TOKEN_URL.to_string()).map_err(|_| OAuthError::InvalidSpotifyUri)?;
     let redirect_url =
         RedirectUrl::new(redirect_uri.to_string()).map_err(|e| OAuthError::InvalidRedirectUri {
             uri: redirect_uri.to_string(),
@@ -509,6 +556,231 @@ pub fn get_access_token(
         token_type: format!("{:?}", token.token_type()).to_string(), // Urgh!?
         scopes: token_scopes,
     })
+}
+
+/// A pending device authorization, waiting on the user's approval.
+///
+/// Show [`Self::url`] and [`Self::user_code`] to the user, then hand this to
+/// [`DeviceAuthClient::poll_for_token`].
+#[derive(Debug, Clone)]
+pub struct DeviceAuthorization {
+    inner: StandardDeviceAuthorizationResponse,
+}
+
+impl DeviceAuthorization {
+    /// The code the user types in at [`Self::verification_uri`].
+    pub fn user_code(&self) -> &str {
+        self.inner.user_code().secret()
+    }
+
+    /// The page the user visits to enter [`Self::user_code`].
+    pub fn verification_uri(&self) -> &str {
+        self.inner.verification_uri().as_str()
+    }
+
+    /// [`Self::verification_uri`] with the code already filled in, when Spotify
+    /// provides it.
+    pub fn verification_uri_complete(&self) -> Option<&str> {
+        self.inner
+            .verification_uri_complete()
+            .map(|uri| uri.secret().as_str())
+    }
+
+    /// The URL to send the user to, preferring the prefilled variant.
+    pub fn url(&self) -> &str {
+        self.verification_uri_complete()
+            .unwrap_or_else(|| self.verification_uri())
+    }
+}
+
+/// Struct that handles obtaining and refreshing access tokens by pairing a code.
+///
+/// Unlike [`OAuthClient`] this needs no redirect URI, nothing listening on a port,
+/// and no browser on the machine running it. Spotify only enables this flow for
+/// some client IDs; see `docs/device-authorization.md`.
+pub struct DeviceAuthClient {
+    scopes: Vec<String>,
+    should_open_url: bool,
+    client: DeviceBasicClient,
+}
+
+impl DeviceAuthClient {
+    fn request_scopes(&self) -> Vec<Scope> {
+        self.scopes.iter().map(|s| Scope::new(s.into())).collect()
+    }
+
+    /// Shows the user where to approve the authorization, opening it for them if
+    /// the client was built with [`DeviceAuthClientBuilder::open_in_browser`].
+    fn announce(&self, auth: &DeviceAuthorization) {
+        let url = auth.url();
+        if self.should_open_url {
+            open::that_in_background(url);
+        }
+        println!("Browse to: {url}");
+        println!("If prompted, enter code: {}", auth.user_code());
+    }
+
+    /// Synchronously request a device code for the user to approve
+    pub fn request_device_code(&self) -> Result<DeviceAuthorization, OAuthError> {
+        let http_client = reqwest::blocking::Client::new();
+        let inner = self
+            .client
+            .exchange_device_code()
+            .add_scopes(self.request_scopes())
+            .request(&http_client)
+            .map_err(|e| OAuthError::DeviceCode { e: e.to_string() })?;
+
+        trace!("Obtained device authorization: {inner:?}");
+        Ok(DeviceAuthorization { inner })
+    }
+
+    /// Synchronously poll Spotify until the user resolves `auth`
+    ///
+    /// Blocks until the user approves or declines, or the authorization expires.
+    /// Spotify's requested poll interval and any `slow_down` it sends back are
+    /// both respected.
+    pub fn poll_for_token(&self, auth: &DeviceAuthorization) -> Result<OAuthToken, OAuthError> {
+        let http_client = reqwest::blocking::Client::new();
+        let resp = self
+            .client
+            .exchange_device_access_token(&auth.inner)
+            .request(&http_client, std::thread::sleep, None)
+            .map_err(|e| OAuthError::ExchangeDeviceCode { e: e.to_string() })?;
+
+        Ok(build_token(resp, &self.scopes))
+    }
+
+    /// Synchronously obtain a Spotify access token using the device authorization flow.
+    ///
+    /// Requests a code, shows it to the user, then blocks until they approve it.
+    /// Drive [`Self::request_device_code`] and [`Self::poll_for_token`] directly
+    /// to present the code some other way.
+    pub fn get_access_token(&self) -> Result<OAuthToken, OAuthError> {
+        let auth = self.request_device_code()?;
+        self.announce(&auth);
+        self.poll_for_token(&auth)
+    }
+
+    /// Synchronously obtain a new valid OAuth token from `refresh_token`
+    pub fn refresh_token(&self, refresh_token: &str) -> Result<OAuthToken, OAuthError> {
+        let refresh_token = RefreshToken::new(refresh_token.to_string());
+        let http_client = reqwest::blocking::Client::new();
+        let resp = self
+            .client
+            .exchange_refresh_token(&refresh_token)
+            .request(&http_client)
+            .map_err(|e| OAuthError::ExchangeCode { e: e.to_string() })?;
+
+        Ok(build_token(resp, &self.scopes))
+    }
+
+    /// Asynchronously request a device code for the user to approve
+    pub async fn request_device_code_async(&self) -> Result<DeviceAuthorization, OAuthError> {
+        let http_client = reqwest::Client::new();
+        let inner = self
+            .client
+            .exchange_device_code()
+            .add_scopes(self.request_scopes())
+            .request_async(&http_client)
+            .await
+            .map_err(|e| OAuthError::DeviceCode { e: e.to_string() })?;
+
+        trace!("Obtained device authorization: {inner:?}");
+        Ok(DeviceAuthorization { inner })
+    }
+
+    /// Asynchronously poll Spotify until the user resolves `auth`
+    ///
+    /// See [`Self::poll_for_token`].
+    pub async fn poll_for_token_async(
+        &self,
+        auth: &DeviceAuthorization,
+    ) -> Result<OAuthToken, OAuthError> {
+        let http_client = reqwest::Client::new();
+        let resp = self
+            .client
+            .exchange_device_access_token(&auth.inner)
+            .request_async(&http_client, tokio::time::sleep, None)
+            .await
+            .map_err(|e| OAuthError::ExchangeDeviceCode { e: e.to_string() })?;
+
+        Ok(build_token(resp, &self.scopes))
+    }
+
+    /// Asynchronously obtain a Spotify access token using the device authorization flow.
+    ///
+    /// See [`Self::get_access_token`].
+    pub async fn get_access_token_async(&self) -> Result<OAuthToken, OAuthError> {
+        let auth = self.request_device_code_async().await?;
+        self.announce(&auth);
+        self.poll_for_token_async(&auth).await
+    }
+
+    /// Asynchronously obtain a new valid OAuth token from `refresh_token`
+    pub async fn refresh_token_async(&self, refresh_token: &str) -> Result<OAuthToken, OAuthError> {
+        let refresh_token = RefreshToken::new(refresh_token.to_string());
+        let http_client = reqwest::Client::new();
+        let resp = self
+            .client
+            .exchange_refresh_token(&refresh_token)
+            .request_async(&http_client)
+            .await
+            .map_err(|e| OAuthError::ExchangeCode { e: e.to_string() })?;
+
+        Ok(build_token(resp, &self.scopes))
+    }
+}
+
+/// Builder struct through which structures of type DeviceAuthClient are instantiated.
+pub struct DeviceAuthClientBuilder {
+    client_id: String,
+    scopes: Vec<String>,
+    should_open_url: bool,
+}
+
+impl DeviceAuthClientBuilder {
+    /// Create a new DeviceAuthClientBuilder with provided params and default config.
+    ///
+    /// Spotify fails the whole request with `invalid_scope` if it does not
+    /// recognise any one of `scopes`, so unsupported scopes cannot be discovered
+    /// by asking for extras and seeing what comes back.
+    pub fn new(client_id: &str, scopes: Vec<&str>) -> Self {
+        Self {
+            client_id: client_id.to_string(),
+            scopes: scopes.into_iter().map(Into::into).collect(),
+            should_open_url: false,
+        }
+    }
+
+    /// When this function is added to the building process pipeline, the verification
+    /// url will also be opened with the default web browser. Otherwise, it is only
+    /// printed to standard output.
+    ///
+    /// Off by default, since the point of this flow is that the device running
+    /// librespot need not have a browser at all.
+    pub fn open_in_browser(mut self) -> Self {
+        self.should_open_url = true;
+        self
+    }
+
+    /// End of the building process pipeline. If Ok, a DeviceAuthClient instance will be returned.
+    pub fn build(self) -> Result<DeviceAuthClient, OAuthError> {
+        let device_authorization_url =
+            DeviceAuthorizationUrl::new(DEVICE_AUTHORIZATION_URL.to_string())
+                .map_err(|_| OAuthError::InvalidSpotifyUri)?;
+        let token_url =
+            TokenUrl::new(TOKEN_URL.to_string()).map_err(|_| OAuthError::InvalidSpotifyUri)?;
+
+        let client = BasicClient::new(ClientId::new(self.client_id))
+            .set_token_uri(token_url)
+            .set_device_authorization_url(device_authorization_url);
+
+        Ok(DeviceAuthClient {
+            scopes: self.scopes,
+            should_open_url: self.should_open_url,
+            client,
+        })
+    }
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ use librespot::{
         player::{Player, coefficient_to_duration, duration_to_coefficient},
     },
 };
-use librespot_oauth::OAuthClientBuilder;
+use librespot_oauth::{DeviceAuthClientBuilder, OAuthClientBuilder};
 use log::{debug, error, info, trace, warn};
 use sha1::{Digest, Sha1};
 use std::{
@@ -215,6 +215,7 @@ struct Setup {
     mixer_config: MixerConfig,
     credentials: Option<Credentials>,
     enable_oauth: bool,
+    enable_device_auth: bool,
     oauth_port: Option<u16>,
     zeroconf_port: u16,
     player_event_program: Option<String>,
@@ -248,6 +249,7 @@ async fn get_setup() -> Setup {
     const DISABLE_GAPLESS: &str = "disable-gapless";
     const DITHER: &str = "dither";
     const EMIT_SINK_EVENTS: &str = "emit-sink-events";
+    const ENABLE_DEVICE_AUTH: &str = "enable-device-auth";
     const ENABLE_OAUTH: &str = "enable-oauth";
     const ENABLE_VOLUME_NORMALISATION: &str = "enable-volume-normalisation";
     const FORMAT: &str = "format";
@@ -305,6 +307,7 @@ async fn get_setup() -> Setup {
     const HELP_SHORT: &str = "h";
     const ZEROCONF_INTERFACE_SHORT: &str = "i";
     const ENABLE_OAUTH_SHORT: &str = "j";
+    const ENABLE_DEVICE_AUTH_SHORT: &str = ""; // no short flag
     const OAUTH_PORT_SHORT: &str = "K";
     const ACCESS_TOKEN_SHORT: &str = "k";
     const CACHE_SIZE_LIMIT_SHORT: &str = "M";
@@ -436,6 +439,11 @@ async fn get_setup() -> Setup {
         ENABLE_OAUTH_SHORT,
         ENABLE_OAUTH,
         "Perform interactive OAuth sign in.",
+    )
+    .optflag(
+        ENABLE_DEVICE_AUTH_SHORT,
+        ENABLE_DEVICE_AUTH,
+        "Perform OAuth sign in by pairing a code at spotify.com/pair. Needs no browser on this machine.",
     )
     .optopt(
         NAME_SHORT,
@@ -1134,6 +1142,14 @@ async fn get_setup() -> Setup {
     });
 
     let enable_oauth = opt_present(ENABLE_OAUTH);
+    let enable_device_auth = opt_present(ENABLE_DEVICE_AUTH);
+
+    if enable_oauth && enable_device_auth {
+        error!(
+            "`--{ENABLE_OAUTH}` / `-{ENABLE_OAUTH_SHORT}` and `--{ENABLE_DEVICE_AUTH}` are mutually exclusive."
+        );
+        exit(1);
+    }
 
     let cache = {
         let volume_dir = opt_str(SYSTEM_CACHE)
@@ -1189,7 +1205,7 @@ async fn get_setup() -> Setup {
             }
         };
 
-        if enable_oauth && (cache.is_none() || cred_dir.is_none()) {
+        if (enable_oauth || enable_device_auth) && (cache.is_none() || cred_dir.is_none()) {
             warn!("Credential caching is unavailable, but advisable when using OAuth login.");
         }
 
@@ -1246,12 +1262,21 @@ async fn get_setup() -> Setup {
         None
     };
 
-    if credentials.is_none() && no_discovery_reason.is_some() && !enable_oauth {
+    if credentials.is_none()
+        && no_discovery_reason.is_some()
+        && !enable_oauth
+        && !enable_device_auth
+    {
         error!("Credentials are required if discovery and oauth login are disabled.");
         exit(1);
     }
 
     let oauth_port = if opt_present(OAUTH_PORT) {
+        if enable_device_auth {
+            warn!(
+                "With the `--{ENABLE_DEVICE_AUTH}` flag set `--{OAUTH_PORT}` / `-{OAUTH_PORT_SHORT}` has no effect."
+            );
+        }
         if !enable_oauth {
             warn!(
                 "Without the `--{ENABLE_OAUTH}` / `-{ENABLE_OAUTH_SHORT}` flag set `--{OAUTH_PORT}` / `-{OAUTH_PORT_SHORT}` has no effect."
@@ -1853,6 +1878,7 @@ async fn get_setup() -> Setup {
         mixer_config,
         credentials,
         enable_oauth,
+        enable_device_auth,
         oauth_port,
         zeroconf_port,
         player_event_program,
@@ -1946,6 +1972,22 @@ async fn main() {
 
     if let Some(credentials) = setup.credentials {
         last_credentials = Some(credentials);
+        connecting = true;
+    } else if setup.enable_device_auth {
+        let client =
+            DeviceAuthClientBuilder::new(&setup.session_config.client_id, OAUTH_SCOPES.to_vec())
+                .build()
+                .unwrap_or_else(|e| {
+                    error!("Failed to create device auth client: {e}");
+                    exit(1);
+                });
+        // The async variant, because constructing a blocking reqwest client
+        // inside this tokio runtime would panic.
+        let oauth_token = client.get_access_token_async().await.unwrap_or_else(|e| {
+            error!("Failed to get Spotify access token: {e}");
+            exit(1);
+        });
+        last_credentials = Some(Credentials::with_access_token(oauth_token.access_token));
         connecting = true;
     } else if setup.enable_oauth {
         let port_str = match setup.oauth_port {


### PR DESCRIPTION
Adds DeviceAuthClient to librespot-oauth and exposes it as `--enable-device-auth`. This flow uses a code entered at https://spotify.com/pair which is normally used to sign into the desktop (via QR code), TV and wearable apps. It doesn't require a callback so it's a lot more convenient for headless use cases like a smart speaker. This flow is just the standard [OAuth 2.0 device authorization flow](https://oauth.net/2/device-flow/).

When running `librespot --enable-device-auth`, it will present the pairing URL and code like so:
```
[2026-08-18T20:21:32Z INFO  librespot] librespot 0.8.0 7770efd (Built on 2026-08-18, Build ID: T86baaI0, Profile: debug)
[2026-08-18T20:21:32Z WARN  librespot] Credential caching is unavailable, but advisable when using OAuth login.
Browse to: https://spotify.com/pair?code=XXXXXX
If prompted, enter code: XXXXXX
```
then in the background it'll keep polling Spotify for the pairing/login result. When the user finishes logging in and clicks pair, Spotify hands the oauth access and refresh tokens for the user's account to librespot on the next poll. If caching is enabled, the creds are stored for future relaunches.

One note about this flow, only client IDs that are whitelisted by Spotify are able to use it. So far I've found that the desktop, TV and wearable client IDs can use it but Android, iOS and web can't. Since librespot uses the desktop ID by default it should work as-is.