### PR TITLE
fix(connect): fall back to index when context unavailable resolving track

### DIFF
--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -1384,12 +1384,22 @@ impl SpircTask {
             Some(ref playing_track) => Some(match playing_track {
                 PlayingTrack::Index(i) => Ok(*i as usize),
                 PlayingTrack::Uri(uri) => {
-                    let ctx = self.connect_state.get_context(ContextType::Default)?;
-                    ConnectState::find_index_in_context(ctx, |t| &t.uri == uri)
+                    match self.connect_state.get_context(ContextType::Default) {
+                        Ok(ctx) => ConnectState::find_index_in_context(ctx, |t| &t.uri == uri),
+                        Err(why) => {
+                            warn!("context unavailable when resolving track by URI, using fallback index {fallback_index:?}: {why}");
+                            Ok(fallback_index.unwrap_or_default())
+                        }
+                    }
                 }
                 PlayingTrack::Uid(uid) => {
-                    let ctx = self.connect_state.get_context(ContextType::Default)?;
-                    ConnectState::find_index_in_context(ctx, |t| &t.uid == uid)
+                    match self.connect_state.get_context(ContextType::Default) {
+                        Ok(ctx) => ConnectState::find_index_in_context(ctx, |t| &t.uid == uid),
+                        Err(why) => {
+                            warn!("context unavailable when resolving track by UID, using fallback index {fallback_index:?}: {why}");
+                            Ok(fallback_index.unwrap_or_default())
+                        }
+                    }
                 }
             }),
         }


### PR DESCRIPTION
When resolving the current track by URI or UID, `SpircTask` calls
`get_context(ContextType::Default)?`. If the Default context is not
available, the `?` propagates the error out of the whole track-resolution
path and the request is abandoned.

On a long-running Connect device this happens regularly, and shows up as:

```
WARN  librespot_connect::state::context] couldnt load context info because: context is not available. type: Default
WARN  librespot_connect::spirc] failed filling up next_track during stopping: Invalid state { context is not available. type: Default }
ERROR librespot_connect::spirc] failed to handle request: Invalid state { could not find track None in context of 200 }
```

Since a `fallback_index` is already available at that point, this handles
the error instead of propagating it: fall back to that index (or 0) and
log a warning, so playback continues rather than the request failing.

Observed on a Raspberry Pi 3B+ running as a persistent Connect endpoint,
where the Default context is frequently unavailable after idle periods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)