### PR TITLE
fix(audio_key): retry on timeout and fail track cleanly on key error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [core] Audio key requests now retry up to 2 times on timeout before giving up, improving resilience after access-point reconnects
+- [playback] Audio key transport failures (timeout, channel error) now fail the track cleanly instead of continuing without decryption, which always failed downstream and dropped the session
 - [audio] Fixed integer overflow in throughput calculation
 - [main] Fixed `--volume-ctrl fixed` not disabling volume control
 - [core] Fix default permissions on credentials file and warn user if file is world readable

--- a/core/src/audio_key.rs
+++ b/core/src/audio_key.rs
@@ -79,23 +79,46 @@ impl AudioKeyManager {
     }
 
     pub async fn request(&self, track: SpotifyId, file: FileId) -> Result<AudioKey, Error> {
-        let (tx, rx) = oneshot::channel();
-
-        let seq = self.lock(move |inner| {
-            let seq = inner.sequence.get();
-            inner.pending.insert(seq, tx);
-            seq
-        });
-
-        self.send_key_request(seq, track, file)?;
         const KEY_RESPONSE_TIMEOUT: Duration = Duration::from_millis(1500);
-        match tokio::time::timeout(KEY_RESPONSE_TIMEOUT, rx).await {
-            Err(_) => {
-                error!("Audio key response timeout");
-                Err(AudioKeyError::Timeout.into())
+        const MAX_RETRIES: u32 = 2;
+
+        for attempt in 0..=MAX_RETRIES {
+            if attempt > 0 {
+                warn!(
+                    "Retrying audio key request (attempt {}/{})",
+                    attempt + 1,
+                    MAX_RETRIES + 1
+                );
             }
-            Ok(k) => k?,
+
+            let (tx, rx) = oneshot::channel();
+
+            let seq = self.lock(move |inner| {
+                let seq = inner.sequence.get();
+                inner.pending.insert(seq, tx);
+                seq
+            });
+
+            self.send_key_request(seq, track, file)?;
+
+            match tokio::time::timeout(KEY_RESPONSE_TIMEOUT, rx).await {
+                Ok(result) => return result?,
+                Err(_) => {
+                    self.lock(|inner| inner.pending.remove(&seq));
+                    warn!(
+                        "Audio key response timeout (attempt {}/{})",
+                        attempt + 1,
+                        MAX_RETRIES + 1
+                    );
+                }
+            }
         }
+
+        error!(
+            "Audio key request failed after {} attempts",
+            MAX_RETRIES + 1
+        );
+        Err(AudioKeyError::Timeout.into())
     }
 
     fn send_key_request(&self, seq: u32, track: SpotifyId, file: FileId) -> Result<(), Error> {

--- a/playback/src/player.rs
+++ b/playback/src/player.rs
@@ -24,7 +24,7 @@ use crate::{
     audio_backend::Sink,
     config::{Bitrate, NormalisationMethod, NormalisationType, PlayerConfig},
     convert::Converter,
-    core::{Error, Session, SpotifyId, SpotifyUri, util::SeqGenerator},
+    core::{Error, Session, SpotifyId, SpotifyUri, error::ErrorKind, util::SeqGenerator},
     decoder::{AudioDecoder, AudioPacket, AudioPacketPosition, SymphoniaDecoder},
     local_file::{LocalFileLookup, create_local_file_lookup},
     metadata::audio::{AudioFileFormat, AudioFiles, AudioItem},
@@ -1105,14 +1105,15 @@ impl PlayerTrackLoader {
 
             let stream_loader_controller = encrypted_file.get_stream_loader_controller().ok()?;
 
-            // Not all audio files are encrypted. If we can't get a key, try loading the track
-            // without decryption. If the file was encrypted after all, the decoder will fail
-            // parsing and bail out, so we should be safe from outputting ear-piercing noise.
             let key = match self.session.audio_key().request(track_id, file_id).await {
                 Ok(key) => Some(key),
-                Err(e) => {
+                Err(e) if e.kind == ErrorKind::Unavailable => {
                     warn!("Unable to load key, continuing without decryption: {e}");
                     None
+                }
+                Err(e) => {
+                    error!("Unable to load key, cannot play track: {e}");
+                    return None;
                 }
             };
 


### PR DESCRIPTION
## Summary

Rebased version of #1743 (source branch was accidentally deleted).

- **Audio key retry:** Requests now retry up to 2 times on timeout before giving up, improving resilience after access-point reconnects
- **Clean track failure:** Audio key transport failures (timeout, channel error) now fail the track cleanly instead of continuing without decryption, which always failed downstream and dropped the session

## Context

After an access-point reconnect, the first audio key request often times out (1.5s default). Without retry, this fails the track. With the AP connection already restored, a retry succeeds immediately.

The second change stops the player from attempting to play encrypted audio without a decryption key — the old "try without decryption" fallback was never useful for encrypted files and produced broken audio or a dropped session.

## Changes

- `core/src/audio_key.rs`: Wrap `request()` in retry loop (up to 2 retries on timeout), clean up pending entry on timeout
- `playback/src/player.rs`: Distinguish `ErrorKind::Unavailable` (unencrypted file, continue) from other errors (fail track)
- `CHANGELOG.md`: Document both fixes