### PR TITLE
connect: preserve continuation on same-context refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- [connect] Preserve live queue continuation when refreshing the same context, preventing already-traversed tracks from being replayed.
 - [audio] Fixed integer overflow in throughput calculation
 - [main] Fixed `--volume-ctrl fixed` not disabling volume control
 - [core] Fix default permissions on credentials file and warn user if file is world readable

--- a/connect/src/state/context.rs
+++ b/connect/src/state/context.rs
@@ -235,19 +235,36 @@ impl ConnectState {
                     && matches!(context.uri, Some(ref uri) if uri == self.context_uri())
                 {
                     if let Some(new_index) = self.find_last_index_in_new_context(&new_context) {
-                        new_context.index.track = match new_index {
-                            Ok(i) => i,
-                            Err(i) => {
-                                self.player_mut().index = MessageField::none();
-                                i
-                            }
-                        };
+                        match new_index {
+                            Ok(i) => {
+                                /*
+                                 * A same-context UpdateContext is a refresh of the context,
+                                 * not a new playback command.
+                                 *
+                                 * Keep the live next_tracks queue and the existing context fill
+                                 * position. Rebuilding them from the refreshed context can replace
+                                 * Spotify's established playback order.
+                                 */
+                                let previous_fill_index = self
+                                    .context
+                                    .as_ref()
+                                    .map(|ctx| ctx.index.track)
+                                    .unwrap_or(i);
 
-                        // enforce reloading the context
-                        if let Ok(autoplay_ctx) = self.get_context_mut(ContextType::Autoplay) {
-                            autoplay_ctx.index.track = 0
+                                debug!(
+                                    "same-context refresh mapped playback to index {}; preserving live continuation with fill index {}",
+                                    i, previous_fill_index
+                                );
+
+                                new_context.index.track = previous_fill_index;
+                            }
+                            Err(fallback_index) => {
+                                warn!(
+                                    "ignoring ambiguous same-context refresh instead of replacing playback continuation with fallback index {fallback_index}"
+                                );
+                                return Ok(None);
+                            }
                         }
-                        self.clear_next_tracks();
                     }
                 }
 


### PR DESCRIPTION
## Summary

Preserve the existing live `next_tracks` continuation when Spotify sends an `UpdateContext` for the same context and the current playback position can still be mapped successfully.

Previously, the current position was mapped correctly but `next_tracks` was then cleared and rebuilt. This could replace the established continuation with earlier tracks from the same playlist and replay tracks that had already been traversed.

## Reproduction

Tested against `dev` at:

`1599145bf2c98660d35b17817b3386767a7e4b42`

With shuffle and repeat disabled:

- `next_tracks` decreased normally to 61.

- Spotify sent `UpdateContext` for the same 97-track playlist.

- `next_tracks` jumped from 61 to 79.

- The following skip decreased it to 78 and replayed a track already traversed earlier in the session.

## Fix

For a same-context refresh where the current playback position maps successfully, retain the established live continuation instead of clearing and rebuilding `next_tracks`.

Genuine context changes continue to use the existing reset/rebuild path.

## Validation

With the patch, same-context refreshes preserved the existing continuation:

- `77 -> 77`

- `75 -> 75`

- `74 -> 74`

A subsequent manual skip test continued monotonically from 73 down through 45 with no upward queue reset and no unexpected replay.

The final qualification was also performed with the external replay-protection workaround disabled (`SPOTIFY_REPLAY_GUARD=no`), confirming that the corrected behaviour came from librespot itself.

## Checks

- `cargo fmt --all -- --check`

- `git diff --check`

- live A/B reproduction against unmodified and patched `dev`
