### PR TITLE
Add `clear_queue` to `Spirc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - [connect] Add method `add_to_queue` to `Spirc` to add tracks, episodes, albums and playlists to the queue
+- [connect] Add method `clear_queue` to `Spirc` to remove all manually queued tracks
 - [playback] Add `SetQueue` player event, emitting when the queue changes (context loaded, track added to queue, or queue set via Spotify Connect). Gated behind `ConnectConfig::emit_set_queue_events`
 - [examples] Obtain an access token via OAuth to establish a new session and retrieve the stored credentials
 

--- a/connect/src/spirc.rs
+++ b/connect/src/spirc.rs
@@ -136,6 +136,7 @@ enum SpircCommand {
     Transfer(Option<TransferRequest>),
     Load(LoadRequest),
     AddToQueue(SpotifyUri),
+    ClearQueue,
 }
 
 const CONTEXT_FETCH_THRESHOLD: usize = 2;
@@ -411,6 +412,17 @@ impl Spirc {
             return Err(Error::invalid_argument("uri"));
         }
         Ok(self.commands.send(SpircCommand::AddToQueue(uri))?)
+    }
+
+    /// Removes all queued tracks from the next tracks.
+    ///
+    /// Does nothing if we are not the active device.
+    ///
+    /// Only tracks added to the queue (via [Spirc::add_to_queue] or a connect client)
+    /// are removed. The current track, even if it was queued, and the tracks of the
+    /// context are kept; the next tracks are filled up from the context again.
+    pub fn clear_queue(&self) -> Result<(), Error> {
+        Ok(self.commands.send(SpircCommand::ClearQueue)?)
     }
 
     /// Disconnects the current device and pauses the playback according the value.
@@ -747,6 +759,10 @@ impl SpircTask {
             SpircCommand::SetVolume(volume) => self.set_volume(volume),
             SpircCommand::Load(command) => self.handle_load(command, None, None).await?,
             SpircCommand::AddToQueue(uri) => self.handle_add_to_queue(uri).await,
+            SpircCommand::ClearQueue => {
+                self.connect_state.clear_queue()?;
+                self.emit_set_queue_event();
+            }
         };
 
         self.notify().await

--- a/connect/src/state/tracks.rs
+++ b/connect/src/state/tracks.rs
@@ -266,6 +266,17 @@ impl<'ct> ConnectState {
         self.prev_tracks_mut().clear()
     }
 
+    /// Remove all queued tracks
+    ///
+    /// Keeps the tracks from the context in the next tracks and fills
+    /// them up from the current context afterwards
+    pub fn clear_queue(&mut self) -> Result<(), Error> {
+        self.next_tracks_mut().retain(|t| !t.is_queue());
+        self.fill_up_next_tracks()?;
+        self.update_queue_revision();
+        Ok(())
+    }
+
     pub fn clear_next_tracks(&mut self) {
         // respect queued track and don't throw them out of our next played tracks
         let first_non_queued_track = self


### PR DESCRIPTION
Add `clear_queue` to `Spirc`, the counterpart of `add_to_queue` (#1676).

`ConnectState::clear_queue` retains the non-queue next tracks, refills them from the context with `fill_up_next_tracks` and calls `update_queue_revision`, matching what `handle_set_queue` does when a client clears the queue. The `SpircCommand::ClearQueue` handler emits the `SetQueue` player event (still gated behind `emit_set_queue_events`) and the existing `notify()` pushes the new state to Spotify. The current track is not affected, even if it was queued.

Tested against the official Spotify client: after `clear_queue` the queued items disappear from its queue view while playback continues.

Fixes #1752
