### PR TITLE
Fix Windows ARM64 platform signature for Spotify Access Point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [audio] Fixed integer overflow in throughput calculation
 - [main] Fixed `--volume-ctrl fixed` not disabling volume control
 - [core] Fix default permissions on credentials file and warn user if file is world readable
+- [core] Report Windows ARM/ARM64 as Win32 x86_64 to avoid Access Point authentication rejection
 - [core] Try all resolved addresses for the dealer connection instead of failing after the first one.
 - [audio] Try the next CDN URL when a fetch returns a non-206 status instead of only retrying on transport errors, fixing playback failures when the first CDN URL is reachable but does not stream audio.
 

--- a/core/src/connection/handshake.rs
+++ b/core/src/connection/handshake.rs
@@ -138,8 +138,7 @@ where
             _ => Platform::PLATFORM_OSX_X86,
         },
         "windows" => match ARCH {
-            "arm" | "aarch64" => Platform::PLATFORM_WINDOWS_CE_ARM,
-            "x86_64" => Platform::PLATFORM_WIN32_X86_64,
+            "arm" | "aarch64" | "x86_64" => Platform::PLATFORM_WIN32_X86_64,
             _ => Platform::PLATFORM_WIN32_X86,
         },
         _ => Platform::PLATFORM_LINUX_X86,

--- a/core/src/connection/mod.rs
+++ b/core/src/connection/mod.rs
@@ -104,7 +104,6 @@ pub async fn authenticate(
 
     let cpu_family = match std::env::consts::ARCH {
         "blackfin" => CpuFamily::CPU_BLACKFIN,
-        "arm" | "aarch64" => CpuFamily::CPU_ARM,
         "ia64" => CpuFamily::CPU_IA64,
         "mips" => CpuFamily::CPU_MIPS,
         "ppc" => CpuFamily::CPU_PPC,
@@ -112,6 +111,8 @@ pub async fn authenticate(
         "sh" => CpuFamily::CPU_SH,
         "x86" => CpuFamily::CPU_X86,
         "x86_64" => CpuFamily::CPU_X86_64,
+        "arm" | "aarch64" if crate::config::OS == "windows" => CpuFamily::CPU_X86_64,
+        "arm" | "aarch64" => CpuFamily::CPU_ARM,
         _ => CpuFamily::CPU_UNKNOWN,
     };
 


### PR DESCRIPTION
### Summary

On Windows ARM/ARM64, librespot currently reports `PLATFORM_WINDOWS_CE_ARM` in `ClientHello` and `CPU_ARM` during Access Point authentication. The protocol schema defines Windows CE ARM (`0x7`) and Win32 x86_64 (`0x27`) as distinct platform identifiers, so a modern Windows on ARM client is effectively identified as Windows CE.

This change reports Windows ARM/ARM64 as `PLATFORM_WIN32_X86_64` and `CPU_X86_64`, while preserving the existing mappings for non-Windows ARM and unknown Windows architectures.

### Protocol context

`BuildInfo.platform` is a required field in `ClientHello`. The relevant identifiers are defined in:

* `protocol/proto/keyexchange.proto`

The Windows platform is selected in `client_hello()` and sent in the handshake via `set_platform(platform)`:

* `core/src/connection/handshake.rs`

Spotify's public developer documentation does not document these low-level Access Point platform identifiers. Its Commercial Hardware documentation states that the eSDK binary handles negotiation with Spotify backend services internally, and Spotify's eSDK changelog refers to the Access Point as proprietary.

Therefore this PR does not rely on an official Spotify deprecation claim for `PLATFORM_WINDOWS_CE_ARM`; it fixes the mismatch in librespot's current Windows ARM mapping.

### Rationale

Windows on ARM should not identify itself as Windows CE. Reporting the desktop Win32 x86_64 platform and CPU identifiers avoids the Access Point authentication rejection observed on Windows ARM/ARM64 while leaving other platform mappings unchanged.

References crmne/fastpotify#123 and librespot-org/librespot#1737.
